### PR TITLE
feat: add docker_build_and_push, create_release_branch, and github_pull_request workflows

### DIFF
--- a/.github/workflows/create_release_branch.yaml
+++ b/.github/workflows/create_release_branch.yaml
@@ -1,0 +1,80 @@
+name: Create Release Branch
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to create the release branch from (e.g. v1.2.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "If true, only print what would happen"
+        required: false
+        type: boolean
+        default: false
+      cleanup_rc:
+        description: "Delete older release candidate branches"
+        required: false
+        type: boolean
+        default: true
+      runs_on:
+        description: "Runner to use"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+
+jobs:
+  release:
+    name: Create release branch
+    runs-on: ${{ inputs.runs_on }}
+    env:
+      DRY_RUN: ${{ inputs.dry_run }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Cleanup old RC branches
+        if: inputs.cleanup_rc
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release="${{ inputs.tag }}"
+          release_no_v="${release#[vV]}"
+
+          if [[ ! "$release_no_v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skip cleanup: tag looks like a pre-release ($release)"
+            exit 0
+          fi
+
+          while IFS= read -r ref; do
+            branch="${ref#refs/heads/}"
+            if [[ "$branch" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+)-rc\.[0-9]+$ ]]; then
+              branch_ver="${BASH_REMATCH[1]}"
+              if [[ "$(printf '%s\n%s\n' "$branch_ver" "$release_no_v" | sort -V | head -n1)" == "$branch_ver" ]]; then
+                if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+                  echo "[DRY RUN] Would delete origin/$branch"
+                else
+                  echo "Deleting origin/$branch"
+                  git push origin --delete "$branch"
+                fi
+              else
+                echo "Keeping origin/$branch (newer than $release_no_v)"
+              fi
+            fi
+          done < <(git ls-remote --heads origin "release/*-rc.*" | awk '{print $2}')
+
+      - name: Create and push release branch
+        run: |
+          BRANCH="release/${{ inputs.tag }}"
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "[DRY RUN] Would create and push branch $BRANCH"
+          else
+            git switch -c "$BRANCH"
+            git push origin "$BRANCH" --set-upstream
+            echo "Created branch $BRANCH"
+          fi
+        shell: bash

--- a/.github/workflows/docker_build_and_push.yaml
+++ b/.github/workflows/docker_build_and_push.yaml
@@ -1,0 +1,96 @@
+name: Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: "Runner to use"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      working_directory:
+        description: "Working directory"
+        required: false
+        type: string
+        default: "."
+      registry:
+        description: "Container registry (e.g. ghcr.io)"
+        required: false
+        type: string
+        default: "ghcr.io"
+      image_name:
+        description: "Docker image name (e.g. my-app). Defaults to repository name."
+        required: false
+        type: string
+        default: ""
+      image_tag:
+        description: "Docker image tag (defaults to git ref name)"
+        required: false
+        type: string
+        default: ""
+      platforms:
+        description: "Docker build platforms"
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+      build_args:
+        description: "Docker build arguments (newline-separated KEY=VALUE)"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      registry_username:
+        description: "Registry username (defaults to github.actor for GHCR)"
+        required: false
+      registry_password:
+        description: "Registry password / token (defaults to GITHUB_TOKEN for GHCR)"
+        required: false
+
+jobs:
+  build:
+    name: Docker build and push
+    runs-on: ${{ inputs.runs_on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.registry_username || github.actor }}
+          password: ${{ secrets.registry_password || secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        run: |
+          IMAGE_NAME="${{ inputs.image_name }}"
+          if [ -z "$IMAGE_NAME" ]; then
+            IMAGE_NAME="${{ github.event.repository.name }}"
+          fi
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          if [ -z "$IMAGE_TAG" ]; then
+            IMAGE_TAG="${{ github.ref_name }}"
+          fi
+          FULL_IMAGE="${{ inputs.registry }}/${{ github.repository_owner }}/${IMAGE_NAME}:${IMAGE_TAG}"
+          echo "full_image=${FULL_IMAGE}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.working_directory }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.full_image }}
+          build-args: ${{ inputs.build_args }}

--- a/.github/workflows/github_pull_request.yaml
+++ b/.github/workflows/github_pull_request.yaml
@@ -1,0 +1,97 @@
+name: Create Pull Request
+
+on:
+  workflow_call:
+    inputs:
+      from:
+        description: "Source branch"
+        required: true
+        type: string
+      base:
+        description: "Target branch"
+        required: true
+        type: string
+      branch:
+        description: "Intermediate branch name for the PR"
+        required: true
+        type: string
+      title:
+        description: "Pull request title"
+        required: true
+        type: string
+      labels:
+        description: "Comma-separated labels to add"
+        required: false
+        type: string
+        default: ""
+      auto_merge:
+        description: "Enable auto-merge on creation"
+        required: false
+        type: string
+        default: "true"
+      approve:
+        description: "Auto-approve the PR"
+        required: false
+        type: string
+        default: "true"
+      bot_app_id:
+        description: "GitHub App ID for authentication"
+        required: true
+        type: string
+      runs_on:
+        description: "Runner to use"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+    secrets:
+      bot_private_key:
+        description: "GitHub App private key"
+        required: true
+
+jobs:
+  create-pr:
+    name: Create PR ${{ inputs.from }} → ${{ inputs.base }}
+    runs-on: ${{ inputs.runs_on }}
+
+    steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ inputs.bot_app_id }}
+          private-key: ${{ secrets.bot_private_key }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base }}
+          fetch-depth: 0
+
+      - name: Reset branch to source
+        run: |
+          git fetch origin ${{ inputs.from }}:${{ inputs.from }}
+          git reset --hard ${{ inputs.from }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ inputs.branch }}
+          title: ${{ inputs.title }}
+          delete-branch: true
+          labels: ${{ inputs.labels }}
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created' && inputs.auto_merge == 'true'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+
+      - name: Auto-approve
+        if: steps.cpr.outputs.pull-request-operation == 'created' && inputs.approve == 'true'
+        uses: juliangruber/approve-pull-request-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary
- **docker_build_and_push**: Build et push d'images Docker vers GHCR (ou registry custom), multi-plateforme, build-args configurable
- **create_release_branch**: Crée `release/vX.Y.Z` depuis un tag, cleanup automatique des branches RC obsolètes, mode dry_run
- **github_pull_request**: Création automatique de PR pour sync de branches via GitHub App, auto-merge et auto-approve configurables

## Contexte
Ces workflows sont nécessaires pour la migration des projets ExpertFlow AI et Jarvis vers bsg-workflows (voir [expert-flow.ai#877](https://github.com/beyond-scale-group/expert-flow.ai/pull/877)).

## Test plan
- [ ] Vérifier la syntaxe YAML des 3 fichiers
- [ ] Tester `create_release_branch` via un tag dans un projet consommateur
- [ ] Tester `github_pull_request` avec un bot GitHub App
- [ ] Tester `docker_build_and_push` avec GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)