### PR TITLE
fix(cobertura): add write permissions and token for coverage-action

### DIFF
--- a/.github/workflows/cobertura_report.yaml
+++ b/.github/workflows/cobertura_report.yaml
@@ -29,6 +29,11 @@ on:
         type: string
         default: "scala-coverage-report"
 
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
 jobs:
   coverage:
     name: Coverage Report
@@ -52,3 +57,4 @@ jobs:
           publish: true
           diff-storage: _xml_coverage_reports
           togglable-report: true
+          token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Add `contents: write`, `checks: write`, `pull-requests: write` permissions to cobertura_report reusable workflow
- Pass explicit `token` to `coverage-action` so it can push diff storage to `_xml_coverage_reports` branch

## Context
The coverage-action was failing with 403 when trying to push because the reusable workflow had no write permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)