### PR TITLE
fix(review-app): remove job-level permissions from wait-for-checks

### DIFF
--- a/.github/workflows/review_app_deploy.yaml
+++ b/.github/workflows/review_app_deploy.yaml
@@ -125,9 +125,6 @@ jobs:
     if: inputs.action == 'deploy' && inputs.wait_for_checks
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.checks_timeout }}
-    permissions:
-      checks: read
-      pull-requests: read
     steps:
       - name: Wait for PR checks to pass
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Remove `permissions` block from `wait-for-checks` job in reusable workflow
- Reusable workflow jobs inherit permissions from the caller — setting them at job level causes validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)