### PR TITLE
fix(review-app): use string type for wait_for_checks

### DIFF
--- a/.github/workflows/review_app_deploy.yaml
+++ b/.github/workflows/review_app_deploy.yaml
@@ -82,10 +82,10 @@ on:
         type: string
         default: ""
       wait_for_checks:
-        description: "Wait for PR checks to pass before deploying"
+        description: "Wait for PR checks to pass before deploying (true/false)"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
       checks_timeout:
         description: "Max minutes to wait for checks"
         required: false
@@ -122,7 +122,7 @@ on:
 
 jobs:
   wait-for-checks:
-    if: inputs.action == 'deploy' && inputs.wait_for_checks
+    if: inputs.action == 'deploy' && inputs.wait_for_checks == 'true'
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.checks_timeout }}
     steps:


### PR DESCRIPTION
## Summary
- Change `wait_for_checks` from `boolean` to `string` type
- Compare with `== 'true'` instead of truthy evaluation
- Workaround for GitHub Actions bug where boolean inputs in reusable workflows are incorrectly evaluated when the calling job has an `if` condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)