### PR TITLE
feat: add backend env vars to review app deploy

### DIFF
--- a/.github/workflows/review_app_deploy.yaml
+++ b/.github/workflows/review_app_deploy.yaml
@@ -81,6 +81,11 @@ on:
         required: false
         type: string
         default: ""
+      tf_var_backend_url_internal:
+        description: "Scala backend URL for server-side calls"
+        required: false
+        type: string
+        default: ""
       runs_on:
         description: "Runner to use"
         required: false
@@ -103,6 +108,8 @@ on:
       anthropic_api_key:
         required: false
       mistral_api_key:
+        required: false
+      backend_api_key:
         required: false
 
 jobs:
@@ -127,6 +134,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.s3_secret_key }}
       TF_VAR_anthropic_api_key: ${{ secrets.anthropic_api_key }}
       TF_VAR_mistral_api_key: ${{ secrets.mistral_api_key }}
+      TF_VAR_backend_url_internal: ${{ inputs.tf_var_backend_url_internal }}
+      TF_VAR_backend_api_key: ${{ secrets.backend_api_key }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add `tf_var_backend_url_internal` input for Scala backend URL
- Add `backend_api_key` secret for backend authentication
- Passes them as `TF_VAR_backend_url_internal` and `TF_VAR_backend_api_key` to Terraform

## Context
Review apps for expert-flow.ai need BACKEND_URL and BACKEND_API_KEY to connect to the Scala backend.