### PR TITLE
fix: review app cleanup state path for Terraform workspaces

### DIFF
--- a/.github/workflows/review_app_deploy.yaml
+++ b/.github/workflows/review_app_deploy.yaml
@@ -154,7 +154,10 @@ jobs:
         if: inputs.action == 'cleanup'
         id: check_state
         run: |
-          STATE_KEY="review-apps/${{ inputs.state_prefix }}/pr-${{ inputs.pr_number }}/terraform.tfstate"
+          # Terraform workspaces store state under env:/{workspace}/key
+          WORKSPACE="${{ inputs.state_prefix }}-pr-${{ inputs.pr_number }}"
+          STATE_KEY="env:/${WORKSPACE}/review-apps/${{ inputs.state_prefix }}/pr-${{ inputs.pr_number }}/terraform.tfstate"
+          echo "Checking for state at: s3://terraform/${STATE_KEY}"
           if aws s3 ls "s3://terraform/${STATE_KEY}" \
             --endpoint-url "https://cellar-c2.services.clever-cloud.com" > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix state file lookup path for review app cleanup
- Terraform workspaces store state under `env:/{workspace}/key`, not just `key`
- Without this fix, cleanup never finds the state file and skips `terraform destroy`

## Context
The review app cleanup was always reporting "No state file found" because it checked `s3://terraform/review-apps/{prefix}/pr-{N}/terraform.tfstate` but the actual path is `s3://terraform/env:/{prefix}-pr-{N}/review-apps/{prefix}/pr-{N}/terraform.tfstate`.