### PR TITLE
fix(sync): use conventional commits format for PR titles

### DIFF
--- a/.github/workflows/sync_branches_with_ai.yaml
+++ b/.github/workflows/sync_branches_with_ai.yaml
@@ -131,7 +131,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base ${{ inputs.to }} \
             --head "$BRANCH" \
-            --title "Sync ${{ inputs.from }} to ${{ inputs.to }}" \
+            --title "chore(sync): merge ${{ inputs.from }} into ${{ inputs.to }}" \
             --body "Auto-sync: ${{ steps.check.outputs.behind_count }} commits from \`${{ inputs.from }}\` to \`${{ inputs.to }}\`. Clean merge, no conflicts." \
             --label "sync")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
@@ -155,7 +155,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base ${{ inputs.to }} \
             --head "$BRANCH" \
-            --title "Sync ${{ inputs.from }} to ${{ inputs.to }} (AI-resolved)" \
+            --title "chore(sync): merge ${{ inputs.from }} into ${{ inputs.to }} (AI-resolved)" \
             --body-file "$BODY_FILE" \
             --label "sync")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
@@ -181,7 +181,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base ${{ inputs.to }} \
             --head "$BRANCH" \
-            --title "Sync ${{ inputs.from }} to ${{ inputs.to }} (manual resolution needed)" \
+            --title "chore(sync): merge ${{ inputs.from }} into ${{ inputs.to }} (manual resolution needed)" \
             --body-file "$BODY_FILE" \
             --label "sync")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- PR titles created by `sync_branches_with_ai.yaml` didn't follow Conventional Commits format
- Titles like `"Sync main to staging"` cause semantic-release to misparse merge commits
- Changed all 3 PR title templates to `chore(sync): merge {from} into {to}` format

## Changes

| Before | After |
|--------|-------|
| `Sync main to staging` | `chore(sync): merge main into staging` |
| `Sync main to staging (AI-resolved)` | `chore(sync): merge main into staging (AI-resolved)` |
| `Sync main to staging (manual resolution needed)` | `chore(sync): merge main into staging (manual resolution needed)` |

## Test plan

- [ ] Trigger a sync workflow and verify the PR title follows conventional commits format