### PR TITLE
fix(ci): use conventional commit titles for sync PRs

### DIFF
--- a/.github/workflows/sync_branches_with_ai.yaml
+++ b/.github/workflows/sync_branches_with_ai.yaml
@@ -131,7 +131,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base ${{ inputs.to }} \
             --head "$BRANCH" \
-            --title "Sync ${{ inputs.from }} to ${{ inputs.to }}" \
+            --title "chore(ci): sync ${{ inputs.from }} to ${{ inputs.to }}" \
             --body "Auto-sync: ${{ steps.check.outputs.behind_count }} commits from \`${{ inputs.from }}\` to \`${{ inputs.to }}\`. Clean merge, no conflicts." \
             --label "sync")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
@@ -155,7 +155,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base ${{ inputs.to }} \
             --head "$BRANCH" \
-            --title "Sync ${{ inputs.from }} to ${{ inputs.to }} (AI-resolved)" \
+            --title "chore(ci): sync ${{ inputs.from }} to ${{ inputs.to }} (AI-resolved)" \
             --body-file "$BODY_FILE" \
             --label "sync")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
@@ -181,7 +181,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base ${{ inputs.to }} \
             --head "$BRANCH" \
-            --title "Sync ${{ inputs.from }} to ${{ inputs.to }} (manual resolution needed)" \
+            --title "chore(ci): sync ${{ inputs.from }} to ${{ inputs.to }} (manual resolution needed)" \
             --body-file "$BODY_FILE" \
             --label "sync")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Sync PR titles like "Sync main to staging" fail `semantic-pull-request` validation in consumer repos
- Prefix all 3 PR title variants with `chore(ci):` to comply with conventional commits

## Changes
- `sync_branches_with_ai.yaml`: 3 title strings updated
  - `"Sync X to Y"` → `"chore(ci): sync X to Y"`
  - `"Sync X to Y (AI-resolved)"` → `"chore(ci): sync X to Y (AI-resolved)"`
  - `"Sync X to Y (manual resolution needed)"` → `"chore(ci): sync X to Y (manual resolution needed)"`