### PR TITLE
fix: write conflict_status.txt for AI resolution script

### DIFF
--- a/.github/workflows/sync_branches_with_ai.yaml
+++ b/.github/workflows/sync_branches_with_ai.yaml
@@ -96,8 +96,9 @@ jobs:
           else
             echo "status=conflict" >> $GITHUB_OUTPUT
             git diff --name-only --diff-filter=U > /tmp/unmerged_files.txt
+            git status --porcelain | grep -E '^(DU|UD|UU|AA|DD) ' > /tmp/conflict_status.txt 2>/dev/null || true
             echo "Conflicted files:"
-            cat /tmp/unmerged_files.txt
+            cat /tmp/conflict_status.txt
           fi
 
       - name: Resolve conflicts with AI


### PR DESCRIPTION
## Summary
- The AI conflict resolution script (`resolve-conflicts-with-claude.sh`) reads `/tmp/conflict_status.txt` with porcelain status codes (`UU`, `DU`, `UD`, etc.)
- The workflow only wrote `/tmp/unmerged_files.txt` with bare filenames via `git diff --name-only`
- This caused the script to process **zero conflicts** every time and always create "manual resolution needed" PRs

## Fix
Add `git status --porcelain | grep -E '^(DU|UD|UU|AA|DD) ' > /tmp/conflict_status.txt` after the failed merge to bridge the gap.

## Test plan
- [ ] Trigger a sync on a repo with known conflicts between main and staging
- [ ] Verify `/tmp/conflict_status.txt` is populated with correct format
- [ ] Verify AI resolution script processes the conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)