### PR TITLE
fix: expose GITHUB_TOKEN to sbt for GitHub Packages resolution

### DIFF
--- a/.github/workflows/scala_test.yaml
+++ b/.github/workflows/scala_test.yaml
@@ -85,11 +85,15 @@ jobs:
       - name: Run tests
         if: ${{ !inputs.coverage }}
         run: sbt "${{ inputs.sbt_cmd }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run tests with coverage
         if: ${{ inputs.coverage }}
         run: |
           sbt "coverage; ${{ inputs.sbt_cmd }}; coverageAggregate"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload coverage report
         if: ${{ inputs.coverage && always() }}


### PR DESCRIPTION
## Summary

- Add `env: GITHUB_TOKEN: ${{ github.token }}` to both sbt run steps in `scala_test.yaml`
- Required for projects that depend on GitHub Packages (e.g., `dev.bsg:edomata` in expert-flow.ai)
- The default `GITHUB_TOKEN` in Actions has `packages:read` but sbt needs it as an env var

## Test plan

- [ ] Merge and re-run expert-flow.ai PR #1214 CI