### PR TITLE
fix: remove GITHUB_TOKEN from scala test workflow

### DIFF
--- a/.github/workflows/scala_test.yaml
+++ b/.github/workflows/scala_test.yaml
@@ -85,15 +85,11 @@ jobs:
       - name: Run tests
         if: ${{ !inputs.coverage }}
         run: sbt "${{ inputs.sbt_cmd }}"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run tests with coverage
         if: ${{ inputs.coverage }}
         run: |
           sbt "coverage; ${{ inputs.sbt_cmd }}; coverageAggregate"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload coverage report
         if: ${{ inputs.coverage && always() }}


### PR DESCRIPTION
## Summary

- Remove `GITHUB_TOKEN` env var injection from sbt steps in `scala_test.yaml`

## Why

The edomata BSG fork now ships a public read-only token (`read:packages` scope) documented in its [README](https://github.com/beyond-scale-group/edomata#github-packages-resolver). Projects hardcode this token in `build.sbt`, making the `GITHUB_TOKEN` env var unnecessary for dependency resolution.

The injected `GITHUB_TOKEN` was problematic because **Coursier auto-detects it** for GitHub Packages auth. This forced all callers to add `packages: read` permission, even though the token was no longer needed.

## Test plan

- [ ] expert-flow.ai CI passes after this change (PR beyond-scale-group/expert-flow.ai#1240)