### PR TITLE
feat(claude-skills): add shared Claude Code skills with /babysit

### DIFF
--- a/.github/workflows/claude_skills_test.yaml
+++ b/.github/workflows/claude_skills_test.yaml
@@ -1,0 +1,21 @@
+name: claude-skills test
+
+on:
+  pull_request:
+    paths:
+      - 'claude-skills/**'
+      - '.github/workflows/claude_skills_test.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'claude-skills/**'
+      - '.github/workflows/claude_skills_test.yaml'
+
+jobs:
+  test:
+    name: Validate shared skills catalog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run unit tests
+        run: python3 claude-skills/tests/test_skills.py

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Shareable Renovate presets in `renovate/`:
 - `scala_config.json` — sbt projects (automerge patch/minor, manual major)
 - `react_config.json` — npm projects (automerge patch/minor, manual major)
 
+## Claude Code Skills
+
+Shared [Claude Code](https://claude.com/claude-code) slash commands and
+skills live under `claude-skills/`. To install them, ask your Claude Code
+agent to follow [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md) —
+Claude will fetch the file, discover the available commands, and write
+them into your `~/.claude/` directory. Re-ask any time to pull updates.
+No clone, no script, no cron.
+
 ## Versioning
 
 This repo uses [semantic-release](https://github.com/semantic-release/semantic-release).

--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -1,0 +1,116 @@
+# BSG Claude Skills — Install Guide
+
+This file is the entry point for installing the **BSG shared Claude Code
+skills** (slash commands + full skills) into a developer's local
+`~/.claude/` directory.
+
+It is written to be read **by [Claude Code](https://claude.com/claude-code)
+itself**: a developer points their Claude session at this file, Claude
+follows the instructions below, fetches each skill from this repo, and
+writes it into the developer's home. A human can read it too — it doubles
+as the catalog of what's available.
+
+## How a developer installs (or updates)
+
+In any Claude Code session, ask:
+
+> Install the BSG Claude skills by following
+> https://raw.githubusercontent.com/beyond-scale-group/bsg-workflows/main/claude-skills/INSTALL.md
+
+Claude will fetch this file, discover the commands and skills listed
+below, and install them under `~/.claude/`. **To pick up updates later,
+just ask the same thing again** — Claude will overwrite the local copies
+with the latest version from `main`.
+
+No git clone, no script to run, no cron to set up.
+
+## Available commands
+
+| Name | Description |
+|------|-------------|
+| `/babysit` | Monitor a long-running or flaky process (shell command or CI run), diagnose failures, fix root causes, retry until green. Includes PR mergeability rules. |
+
+## Available skills
+
+_None yet._
+
+## Adding a new command or skill to the catalog
+
+1. Drop the file in the right place inside this repo:
+   - Slash command → `claude-skills/commands/<name>.md`
+   - Full skill → `claude-skills/skills/<name>/SKILL.md` (plus any extra
+     resources in the same directory)
+2. Add a row to the relevant table above.
+3. Open a PR.
+
+Once merged on `main`, every developer who re-runs the install command
+gets the new skill.
+
+---
+
+## Instructions for the Claude Code agent
+
+**You — the Claude Code agent reading this file — are installing the BSG
+shared Claude Code commands and skills into the current user's local
+`~/.claude/` directory. Follow these steps exactly. Use your `WebFetch`,
+`Write`, and `Bash` tools.**
+
+### 1. Discover available commands
+
+Fetch this GitHub API endpoint:
+
+```
+https://api.github.com/repos/beyond-scale-group/bsg-workflows/contents/claude-skills/commands?ref=main
+```
+
+It returns a JSON array. For each entry where `"type": "file"` and `name`
+ends with `.md`, note the `name` and the `download_url`.
+
+### 2. Install each command
+
+For each command discovered in step 1:
+
+1. Fetch its raw content from the `download_url`.
+2. Write it to `~/.claude/commands/<name>` (resolve `~` to the actual
+   home directory). Create `~/.claude/commands/` first if it does not
+   exist.
+3. **Always overwrite** any existing file at that path — the remote is
+   the source of truth, and the local file is a cached copy.
+
+### 3. Discover and install skills
+
+Fetch:
+
+```
+https://api.github.com/repos/beyond-scale-group/bsg-workflows/contents/claude-skills/skills?ref=main
+```
+
+If the response is `404`, there are no skills yet — skip to step 4.
+
+Otherwise, for each entry with `"type": "dir"`:
+
+1. Fetch that entry's `url` (also a GitHub API URL) to list the files
+   inside the skill directory.
+2. For each file, fetch its `download_url` and write it to
+   `~/.claude/skills/<skill-name>/<file-name>`. Create directories as
+   needed. Recurse into subdirectories the same way.
+
+### 4. Report to the user
+
+Print a short summary listing every command and skill that was installed
+or updated, with the count, and remind the user that they can re-run the
+same install flow any time to pull updates.
+
+### Constraints
+
+- Do **not** clone the repo. Use HTTPS fetches only.
+- Do **not** touch any file outside `~/.claude/commands/` and
+  `~/.claude/skills/`.
+- Do **not** ask the user to confirm before overwriting — files installed
+  by this flow are cached copies of the remote source of truth. If a
+  developer wants a customized variant of a command, they should fork it
+  under a different name (e.g. `babysit-custom.md`) so this install flow
+  leaves it alone.
+- If the GitHub API returns a rate-limit error (HTTP 403 with
+  `X-RateLimit-Remaining: 0`), report it to the user and stop — do not
+  retry in a loop.

--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -40,11 +40,45 @@ _None yet._
    - Slash command → `claude-skills/commands/<name>.md`
    - Full skill → `claude-skills/skills/<name>/SKILL.md` (plus any extra
      resources in the same directory)
-2. Add a row to the relevant table above.
-3. Open a PR.
+2. **Add the standard "How to improve this skill" footer** (see below) so
+   that anyone using the cached copy in `~/.claude/` knows to PR back
+   here instead of editing locally.
+3. Add a row to the relevant table above.
+4. Open a PR.
 
 Once merged on `main`, every developer who re-runs the install command
 gets the new skill.
+
+### Required footer for every shared skill
+
+Append this block (verbatim, with `<name>` replaced) at the very bottom of
+each new command or skill file. The leading `---` separates it from the
+skill's behavioral content so the agent treats it as out-of-band metadata
+rather than part of its role:
+
+````markdown
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/commands/<name>.md` in
+[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+That repo is the single source of truth — `~/.claude/commands/<name>.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+2. Edit `claude-skills/commands/<name>.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.
+````
+
+For files under `claude-skills/skills/<name>/SKILL.md`, replace
+`commands/<name>.md` with `skills/<name>/SKILL.md` everywhere in the
+footer.
 
 ---
 

--- a/claude-skills/commands/babysit.md
+++ b/claude-skills/commands/babysit.md
@@ -1,0 +1,79 @@
+Babysit the following process: $ARGUMENTS
+
+You are a babysitter agent. Your job is to monitor a long-running or flaky process, detect failures, diagnose root causes, fix them, and retry — looping until success or until you've exhausted reasonable attempts.
+
+## How to babysit
+
+1. **Parse the target.** The user gave you either:
+   - A shell command to run (e.g. `sbt test`, `npm run build`, `cargo check`)
+   - A GitHub Actions run or PR URL to monitor (e.g. `gh run watch 12345`)
+   - A description of what to watch (e.g. "the CI on this PR")
+
+2. **Run or check the process.** Execute the command or poll the status. For GitHub CI:
+   - Use `gh run list --branch <branch> --limit 1` or `gh run view <id>` to check status
+   - Use `gh run view <id> --log-failed` to get failure logs
+
+3. **On success** — report the result and stop. You're done.
+
+4. **On failure** — diagnose and fix:
+   - Read the error output carefully
+   - Identify the root cause (test failure, compilation error, lint issue, flaky test, infra problem)
+   - If it's something you can fix (code error, formatting, missing import, test assertion), fix it, commit, and push
+   - If it's a flaky/transient failure (network timeout, resource contention), retry without changes
+   - If it's an infrastructure issue you can't fix (Docker registry down, GitHub outage), report it and stop
+
+5. **If the failure is caused by an upstream/external dependency** — research and escalate:
+   - Identify the upstream repository responsible (e.g. a library that hasn't published an artifact, an SBT plugin with a breaking change)
+   - Use agents in parallel to research each upstream issue: find the repo, check Maven Central / npm / etc. for published artifacts, search for existing issues or PRs
+   - If an existing upstream issue/PR already covers it, do NOT create a duplicate — just reference it
+   - If no upstream issue exists, create one in the appropriate external repository explaining the impact
+   - Comment on the local PR with a detailed analysis: root cause, upstream status/links, whether it's mergeable, and recommended action (e.g. "do not merge — blocked on X")
+   - If multiple local PRs are related (e.g. both need a coordinated ecosystem upgrade), cross-reference them in the comments
+
+6. **Retry the process** after fixing. Go back to step 2.
+
+7. **Give up after 5 fix attempts** (not counting transient retries). Report what you tried and what's still broken.
+
+## Rules
+
+- After each fix, create a focused commit describing what you fixed and why
+- Do NOT force-push or amend commits — always create new commits
+- If the process is a CI pipeline, wait for it to finish before diagnosing (use `gh run watch` or poll)
+- Between CI polls, wait 30-60 seconds to avoid hammering the API
+- Keep the user informed with brief status updates at each iteration
+- If you're unsure whether a failure is transient or real, retry once before attempting a code fix
+- If the same error persists after 2 fix attempts, step back and reconsider your approach
+- When a failure is caused by an external dependency (missing artifact, breaking upstream change, ecosystem migration), do NOT count it as a fix attempt — escalate upstream instead
+- Research upstream issues using parallel agents for efficiency
+- Never duplicate an existing upstream issue — check first, then reference or comment on it
+- When commenting on PRs, include: root cause, upstream links, mergeability verdict, and recommended next steps
+
+## Merge criteria
+
+When evaluating whether a PR can be merged, apply these criteria strictly:
+
+**Hard criteria (must all be true):**
+1. **CI green** — all required checks SUCCESS (no FAILURE, no CANCELLED on critical jobs)
+2. **Mergeable state = CLEAN** (not BEHIND, BLOCKED, DIRTY, UNSTABLE)
+3. **Up to date with base branch** — otherwise untested against latest code; rebase first
+4. **No unresolved conflicts**
+5. **Approved review** (or explicit user instruction to bypass)
+6. **Target branch correct** (PRs → `staging`, not `main`, unless explicitly stated)
+7. **No WIP/draft marker** in title or status
+
+**Soft criteria (use judgement):**
+- PR scope matches description (no unrelated changes)
+- Commit messages follow conventional commits
+- No secrets/`.env` files staged
+- Documentation PRs can have lighter checks
+- Dependabot PRs: green CI + semver patch/minor = auto-mergeable; major bumps need review
+
+**Red flags — do NOT auto-merge despite green CI:**
+- Force-push right before merge
+- CI skipped rather than run (no signal ≠ green)
+- Flaky tests retried to green
+- Changes to CI config + main code in same PR (suggest splitting)
+
+**Reporting format** when evaluating mergeability:
+- List PRs in three buckets: `READY` (all hard criteria met), `NEEDS ACTION` (which criterion is missing), `BLOCKED` (why and by what)
+- Never merge without explicit user instruction unless the user pre-authorized autonomous merging for the scope

--- a/claude-skills/commands/babysit.md
+++ b/claude-skills/commands/babysit.md
@@ -77,3 +77,21 @@ When evaluating whether a PR can be merged, apply these criteria strictly:
 **Reporting format** when evaluating mergeability:
 - List PRs in three buckets: `READY` (all hard criteria met), `NEEDS ACTION` (which criterion is missing), `BLOCKED` (why and by what)
 - Never merge without explicit user instruction unless the user pre-authorized autonomous merging for the scope
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/commands/babysit.md` in
+[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+That repo is the single source of truth — `~/.claude/commands/babysit.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+2. Edit `claude-skills/commands/babysit.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the BSG claude-skills catalog.
+
+Validates structural invariants that are easy to break by hand when adding
+or editing a shared skill:
+
+  1. every command file ends with the required "How to improve this skill"
+     footer (so a developer using the cached copy in ~/.claude/ knows to PR
+     back here instead of editing locally)
+  2. that footer references the file's own filename (not a copy-paste from
+     another skill)
+  3. the "Available commands" catalog table in INSTALL.md is in sync with
+     the actual files in claude-skills/commands/
+
+Run locally:
+
+    python3 claude-skills/tests/test_skills.py
+
+Stdlib only — no third-party dependencies, no network.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_DIR = REPO_ROOT / "claude-skills"
+COMMANDS_DIR = SKILLS_DIR / "commands"
+INSTALL_MD = SKILLS_DIR / "INSTALL.md"
+
+FOOTER_HEADER = "## How to improve this skill"
+# matches `claude-skills/commands/<name>.md` inside backticks
+FOOTER_PATH_RE = re.compile(r"`claude-skills/commands/([a-z0-9_-]+\.md)`")
+# matches a row in the "Available commands" table: `| `/<name>` | ... |`
+CATALOG_ROW_RE = re.compile(r"^\|\s*`/([a-z0-9_-]+)`\s*\|", re.MULTILINE)
+
+
+def list_commands() -> list[Path]:
+    return sorted(p for p in COMMANDS_DIR.glob("*.md") if p.is_file())
+
+
+class TestSharedSkills(unittest.TestCase):
+    def test_every_command_has_footer(self) -> None:
+        for path in list_commands():
+            with self.subTest(path=path.name):
+                text = path.read_text()
+                self.assertIn(
+                    FOOTER_HEADER,
+                    text,
+                    f"{path.relative_to(REPO_ROOT)} is missing the required "
+                    f"'{FOOTER_HEADER}' footer. See claude-skills/INSTALL.md "
+                    f"for the template.",
+                )
+
+    def test_footer_references_own_filename(self) -> None:
+        for path in list_commands():
+            with self.subTest(path=path.name):
+                text = path.read_text()
+                idx = text.find(FOOTER_HEADER)
+                if idx < 0:
+                    self.skipTest("no footer (covered by another test)")
+                footer = text[idx:]
+                referenced = set(FOOTER_PATH_RE.findall(footer))
+                self.assertIn(
+                    path.name,
+                    referenced,
+                    f"footer in {path.relative_to(REPO_ROOT)} does not "
+                    f"reference its own filename "
+                    f"`claude-skills/commands/{path.name}`. Found references "
+                    f"to: {sorted(referenced) or 'nothing'}. This usually "
+                    f"means the footer was copy-pasted from another skill — "
+                    f"fix the file name in the footer.",
+                )
+
+    def test_install_md_catalog_in_sync(self) -> None:
+        install_text = INSTALL_MD.read_text()
+        catalog_names = set(CATALOG_ROW_RE.findall(install_text))
+        actual_names = {p.stem for p in list_commands()}
+
+        missing = sorted(actual_names - catalog_names)
+        orphans = sorted(catalog_names - actual_names)
+        self.assertSetEqual(
+            catalog_names,
+            actual_names,
+            f"INSTALL.md 'Available commands' table is out of sync with "
+            f"claude-skills/commands/.\n"
+            f"  Missing rows (file exists but no catalog entry): {missing}\n"
+            f"  Orphan rows (catalog entry but no file): {orphans}\n"
+            f"Update the table in claude-skills/INSTALL.md.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Introduces `claude-skills/` as the home for slash commands and skills shared across BSG developers, with `/babysit` as the first one.
- Installation is driven entirely by Claude Code itself: a developer asks their session to follow [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md), and Claude fetches each command from this repo via the GitHub API and writes it into `~/.claude/`. Re-running the same flow pulls updates — no clone, no script, no cron.
- Every shared skill must carry a "How to improve this skill" footer pointing back here, so improvements go through PR review instead of being silently overwritten on the next install.

## Design

- `claude-skills/INSTALL.md` is dual-purpose: human-readable catalog on top, agent-facing install instructions below the `---`.
- Source of truth lives in the repo. `~/.claude/commands/<name>.md` is a cached copy and is overwritten on every install.
- Customization path for developers: fork a skill under a different name (e.g. `babysit-custom.md`) — the install flow only touches names that exist upstream.

## Test plan

- [ ] From a separate Claude Code session, run: `Install the BSG Claude skills by following https://raw.githubusercontent.com/beyond-scale-group/bsg-workflows/GitHub-Actions-Bot/babysit-integration/claude-skills/INSTALL.md`
- [ ] Verify `~/.claude/commands/babysit.md` is created with the footer
- [ ] Verify `/babysit` works in a new session
- [ ] Re-run the install flow and confirm it overwrites cleanly (idempotent)
- [ ] Confirm the agent skips `claude-skills/skills/` gracefully (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)