### PR TITLE
feat(claude-skills): add po-manager subagent and po-report skill

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -1,8 +1,8 @@
 # BSG Claude Skills — Install Guide
 
 This file is the entry point for installing the **BSG shared Claude Code
-skills** (slash commands + full skills) into a developer's local
-`~/.claude/` directory.
+skills** (slash commands, full skills, and subagents) into a developer's
+local `~/.claude/` directory.
 
 It is written to be read **by [Claude Code](https://claude.com/claude-code)
 itself**: a developer points their Claude session at this file, Claude
@@ -17,10 +17,10 @@ In any Claude Code session, ask:
 > Install the BSG Claude skills by following
 > https://raw.githubusercontent.com/beyond-scale-group/bsg-workflows/main/claude-skills/INSTALL.md
 
-Claude will fetch this file, discover the commands and skills listed
-below, and install them under `~/.claude/`. **To pick up updates later,
-just ask the same thing again** — Claude will overwrite the local copies
-with the latest version from `main`.
+Claude will fetch this file, discover the commands, skills, and agents
+listed below, and install them under `~/.claude/`. **To pick up updates
+later, just ask the same thing again** — Claude will overwrite the local
+copies with the latest version from `main`.
 
 No git clone, no script to run, no cron to set up.
 
@@ -32,14 +32,23 @@ No git clone, no script to run, no cron to set up.
 
 ## Available skills
 
-_None yet._
+| Name | Description |
+|------|-------------|
+| `po-report` | Product owner reporting for the current GitHub repo. Aggregates issues, milestones, stale tickets, PRs into a dated markdown report under `.claude/reports/`. Heavy lifting in bash scripts (zero LLM cost), narration in the skill. |
 
-## Adding a new command or skill to the catalog
+## Available agents
+
+| Name | Description |
+|------|-------------|
+| `po-manager` | Product owner / project manager orchestrator subagent. Delegated to for status reports, milestone progress, sprint health, stale ticket detection, standup summaries. Uses the `po-report` skill for reporting and `daily-standup` for meeting parsing. Reporting only — does not implement features. |
+
+## Adding a new command, skill, or agent to the catalog
 
 1. Drop the file in the right place inside this repo:
    - Slash command → `claude-skills/commands/<name>.md`
    - Full skill → `claude-skills/skills/<name>/SKILL.md` (plus any extra
      resources in the same directory)
+   - Subagent → `claude-skills/agents/<name>.md`
 2. **Add the standard "How to improve this skill" footer** (see below) so
    that anyone using the cached copy in `~/.claude/` knows to PR back
    here instead of editing locally.
@@ -78,16 +87,21 @@ Bug reports and ideas without a fix → open an issue on the same repo.
 
 For files under `claude-skills/skills/<name>/SKILL.md`, replace
 `commands/<name>.md` with `skills/<name>/SKILL.md` everywhere in the
-footer.
+footer. **Only `SKILL.md` needs the footer** — supporting files like
+`references/*.md` and `scripts/*.sh` inside a skill directory do not.
+
+For files under `claude-skills/agents/<name>.md`, replace
+`commands/<name>.md` with `agents/<name>.md` everywhere in the footer,
+and replace `~/.claude/commands/<name>.md` with `~/.claude/agents/<name>.md`.
 
 ---
 
 ## Instructions for the Claude Code agent
 
 **You — the Claude Code agent reading this file — are installing the BSG
-shared Claude Code commands and skills into the current user's local
-`~/.claude/` directory. Follow these steps exactly. Use your `WebFetch`,
-`Write`, and `Bash` tools.**
+shared Claude Code commands, skills, and subagents into the current
+user's local `~/.claude/` directory. Follow these steps exactly. Use
+your `WebFetch`, `Write`, and `Bash` tools.**
 
 ### 1. Discover available commands
 
@@ -128,18 +142,45 @@ Otherwise, for each entry with `"type": "dir"`:
 2. For each file, fetch its `download_url` and write it to
    `~/.claude/skills/<skill-name>/<file-name>`. Create directories as
    needed. Recurse into subdirectories the same way.
+3. After writing, `chmod +x` any file under `scripts/` so the skill can
+   execute its own helpers without the user fixing permissions.
 
-### 4. Report to the user
+### 4. Discover and install subagents
 
-Print a short summary listing every command and skill that was installed
-or updated, with the count, and remind the user that they can re-run the
-same install flow any time to pull updates.
+Fetch:
+
+```
+https://api.github.com/repos/beyond-scale-group/bsg-workflows/contents/claude-skills/agents?ref=main
+```
+
+If the response is `404`, there are no agents yet — skip to step 5.
+
+Otherwise, for each entry where `"type": "file"` and `name` ends with
+`.md`:
+
+1. Fetch its raw content from the `download_url`.
+2. Write it to `~/.claude/agents/<name>` (resolve `~` to the actual home
+   directory). Create `~/.claude/agents/` first if it does not exist.
+3. **Always overwrite** any existing file at that path — same rule as
+   commands.
+
+Subagents installed this way are user-scope and become available across
+all the developer's projects. They are loaded at session start, so the
+developer must restart Claude Code to pick up newly-installed agents.
+
+### 5. Report to the user
+
+Print a short summary listing every command, skill, and subagent that
+was installed or updated, with the count, and remind the user that they
+can re-run the same install flow any time to pull updates. If any
+subagents were installed or changed, also remind the user to restart
+Claude Code so the new definitions are loaded.
 
 ### Constraints
 
 - Do **not** clone the repo. Use HTTPS fetches only.
-- Do **not** touch any file outside `~/.claude/commands/` and
-  `~/.claude/skills/`.
+- Do **not** touch any file outside `~/.claude/commands/`,
+  `~/.claude/skills/`, and `~/.claude/agents/`.
 - Do **not** ask the user to confirm before overwriting — files installed
   by this flow are cached copies of the remote source of truth. If a
   developer wants a customized variant of a command, they should fork it

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -1,0 +1,90 @@
+---
+name: po-manager
+description: >
+  Product owner / project manager orchestrator for the current GitHub repository.
+  Use proactively when the user asks for project status, milestone progress,
+  sprint health, ticket triage, stale issue detection, standup summaries, or any
+  PO/PM-flavored question like "où en est le projet", "rapport produit",
+  "what's blocking us", "give me a status report", "résume le sprint",
+  "list stale tickets", or "prepare a milestone update".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [po-report, daily-standup]
+color: purple
+---
+
+You are the **PO Manager** for this repository. Your job: give the user a
+clear, accurate, actionable view of project state — and only that. You do not
+implement features, you do not fix bugs, you do not open PRs. If the user asks
+for implementation work, hand it back to the main agent.
+
+## Operating principles
+
+1. **Facts over narrative.** Every number you report must come from a script
+   in the `po-report` skill or from a direct `gh` call you can cite. Never
+   invent counts or dates.
+2. **Scripts before LLM reasoning.** If the `po-report` skill has a script for
+   what you need, run it instead of querying `gh` ad-hoc. Scripts are faster,
+   deterministic, and free of token cost.
+3. **Files persist, chat is ephemeral.** Always write reports to
+   `.claude/reports/YYYY-MM-DD-{slug}.md`. In the chat, return the path plus a
+   3-bullet executive summary — never paste the full report.
+4. **One question, one report.** Don't pile multiple report types into one
+   file unless the user asked for "everything".
+5. **Confirm before any externally-visible action.** Posting a comment to a
+   GitHub issue, closing a ticket, editing labels — always confirm first.
+
+## Routing
+
+| User intent                                            | What to do                                |
+| ------------------------------------------------------ | ----------------------------------------- |
+| "status", "où en est", "health check"                  | `po-report` → `references/status.md`      |
+| "milestone", "sprint", "burndown"                      | `po-report` → `references/milestones.md`  |
+| "stale", "abandoned", "no activity"                    | `po-report` → `references/stale.md`       |
+| "standup", "daily", meeting transcript                 | `daily-standup` skill                     |
+| "implement X", "fix bug Y", "open PR"                  | Decline politely; this is out of scope.   |
+
+## Report file naming
+
+```
+.claude/reports/2026-04-10-status.md
+.claude/reports/2026-04-10-milestone-v1.md
+.claude/reports/2026-04-10-stale.md
+.claude/reports/2026-04-10-standup.md
+```
+
+Always use `date +%F` for the prefix.
+
+## Default response format
+
+After running the right script(s) and writing the report:
+
+```
+**Report:** `.claude/reports/2026-04-10-status.md`
+
+- ✅ Healthy: <one fact, e.g. "Milestone v2 at 78%, on track">
+- ⚠️ At risk: <one fact, e.g. "3 stale issues > 30 days, all unassigned">
+- 🤔 Needs decision: <one fact, e.g. "PR #42 open 18 days, no reviewers">
+
+Want me to drill into any of these?
+```
+
+Keep it tight. The user can open the file for the details.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/agents/po-manager.md` in
+[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+That repo is the single source of truth — `~/.claude/agents/po-manager.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+2. Edit `claude-skills/agents/po-manager.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/po-report/SKILL.md
+++ b/claude-skills/skills/po-report/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: po-report
+description: >
+  Product owner reporting and project status for the current GitHub repository.
+  Use when the user asks to "generate a PO report", "où en est le projet",
+  "project status", "milestone progress", "rapport produit", "list stale issues",
+  "burndown", "what's blocking us", "sprint health", or any request for an
+  aggregated view of GitHub issues, milestones, labels, or assignees.
+  Produces a dated markdown report in .claude/reports/ and prints a summary.
+version: 0.1.0
+---
+
+# Product Owner Report
+
+Aggregates GitHub state for the **current repository** and produces an
+actionable progress report. All heavy lifting is done by bash scripts in
+`scripts/` — use them instead of re-deriving data through ad-hoc `gh` calls.
+
+## Intent routing
+
+Read the user's request and pick the matching reference document:
+
+| If the user asks about...                          | Read this reference        |
+| -------------------------------------------------- | -------------------------- |
+| Overall status / health / "où en est le projet"    | `references/status.md`     |
+| Milestone progress, sprint health, burndown        | `references/milestones.md` |
+| Stale issues, no recent activity, abandoned work   | `references/stale.md`      |
+
+For multi-topic requests (e.g. "give me a full report"), follow `references/status.md`
+which itself orchestrates the others.
+
+## Hard rules
+
+1. **Never invent numbers.** Always read them from the scripts' JSON output.
+2. **Always write the final report to `.claude/reports/YYYY-MM-DD-{slug}.md`** so
+   it is dated and version-controllable.
+3. **Run scripts from the repo root.** They use `gh` which auto-detects the repo.
+4. **Do not call `gh issue list` or `gh api` yourself** for aggregation — use
+   the scripts. Direct `gh` calls are reserved for follow-up actions on a
+   specific ticket the user named.
+5. **Confirm before posting** anywhere external (GitHub comments, etc.). Default
+   is local-only.
+
+## Available scripts
+
+All scripts live in `scripts/` and emit JSON on stdout (except `generate-report.sh`
+which emits markdown). Run them with `bash scripts/<name>.sh [args]`.
+
+| Script                    | Purpose                                                    |
+| ------------------------- | ---------------------------------------------------------- |
+| `status.sh`               | Repo-wide counts: open/closed issues, PRs, by label, etc.  |
+| `milestone-progress.sh`   | For each open milestone: total/closed/open + % complete   |
+| `stale-issues.sh [DAYS]`  | Open issues with no activity for N days (default: 14)     |
+| `generate-report.sh`      | Composes a full markdown report from the above scripts    |
+
+## Output convention
+
+Reports go to `.claude/reports/`. Filename pattern:
+
+```
+.claude/reports/2026-04-10-status.md
+.claude/reports/2026-04-10-milestone-v1.md
+.claude/reports/2026-04-10-stale.md
+```
+
+Use today's date. After writing, print the file path and a 3-bullet executive
+summary in the chat — do **not** dump the full report inline.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/po-report/SKILL.md` in
+[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+That repo is the single source of truth — `~/.claude/skills/po-report/SKILL.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+2. Edit `claude-skills/skills/po-report/SKILL.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/po-report/references/milestones.md
+++ b/claude-skills/skills/po-report/references/milestones.md
@@ -1,0 +1,46 @@
+# Milestone progress workflow
+
+Use this when the user asks about milestone progress, sprint health, or
+burndown for a specific milestone.
+
+## Steps
+
+1. **List milestones with progress**:
+
+   ```bash
+   bash .claude/skills/po-report/scripts/milestone-progress.sh
+   ```
+
+   This outputs JSON with: `title`, `state`, `due_on`, `open_issues`,
+   `closed_issues`, `percent_complete`, `url`.
+
+2. **If the user named a specific milestone**, filter the JSON to that one
+   and fetch its issues for detail:
+
+   ```bash
+   gh issue list --milestone "<TITLE>" --state all \
+     --json number,title,state,assignees,labels,updatedAt --limit 200
+   ```
+
+3. **Build a milestone report** at `.claude/reports/$(date +%F)-milestone-<slug>.md`
+   containing:
+   - Header: title, due date, % complete, days remaining
+   - Burndown table: open vs closed by label
+   - Open issues grouped by assignee (unassigned first)
+   - Risk flags: stale > 14d, no assignee, blocked label
+
+4. **Reply to the user** with the file path + a 3-line summary.
+
+## Risk flags to compute
+
+| Flag           | Condition                                                  |
+| -------------- | ---------------------------------------------------------- |
+| At risk        | `percent_complete < 50` AND `due_on` within 7 days         |
+| Overdue        | `due_on < today` AND `state == open`                       |
+| Understaffed   | `open_issues > 5` AND > 50% unassigned                     |
+| Stalled        | No issue closed in the last 7 days                         |
+
+## Note on dates
+
+Always parse dates with `date -d` or `gdate -d` (BSD date on macOS does not
+support `-d`). Prefer `python3 -c 'from datetime import...'` for portability.

--- a/claude-skills/skills/po-report/references/stale.md
+++ b/claude-skills/skills/po-report/references/stale.md
@@ -1,0 +1,34 @@
+# Stale issues workflow
+
+Use this when the user asks about stale issues, abandoned work, or issues
+without recent activity.
+
+## Steps
+
+1. **Run the stale detector** with the desired threshold (default 14 days):
+
+   ```bash
+   bash .claude/skills/po-report/scripts/stale-issues.sh 14
+   # or for a stricter threshold
+   bash .claude/skills/po-report/scripts/stale-issues.sh 30
+   ```
+
+   Output is JSON: `[{number, title, assignees, labels, updatedAt, daysStale, url}, ...]`.
+
+2. **Bucket the results**:
+   - **Critical**: `priority:high` or `bug` label, stale > 14d
+   - **Assigned but stale**: has assignee, stale > N days
+   - **Orphaned**: no assignee, any age beyond threshold
+
+3. **Write the report** to `.claude/reports/$(date +%F)-stale.md`.
+
+4. **In chat**, surface:
+   - Total count per bucket
+   - Top 3 critical (by `daysStale` descending)
+   - Suggest next actions: ping assignees, close as `not planned`, re-triage
+
+## Do NOT
+
+- Do NOT close or comment on stale issues automatically. The user decides.
+- Do NOT consider an issue stale just by `createdAt` — use `updatedAt` which
+  reflects the last comment, label change, or assignment.

--- a/claude-skills/skills/po-report/references/status.md
+++ b/claude-skills/skills/po-report/references/status.md
@@ -1,0 +1,43 @@
+# Status report workflow
+
+Use this when the user asks for an overall project status, health check, or
+"où en est le projet".
+
+## Steps
+
+1. **Run all aggregation scripts** in parallel (single message, multiple Bash
+   tool calls):
+
+   ```bash
+   bash .claude/skills/po-report/scripts/status.sh
+   bash .claude/skills/po-report/scripts/milestone-progress.sh
+   bash .claude/skills/po-report/scripts/stale-issues.sh 14
+   ```
+
+2. **Compose the report** by piping the three JSON blobs into
+   `generate-report.sh`, which produces a single markdown document:
+
+   ```bash
+   bash .claude/skills/po-report/scripts/generate-report.sh > .claude/reports/$(date +%F)-status.md
+   ```
+
+3. **Read back the file** with the Read tool and extract the executive summary
+   for the chat response. Do not paste the whole report.
+
+4. **Reply to the user** with:
+   - Path to the file (`.claude/reports/YYYY-MM-DD-status.md`)
+   - 3 bullet points: what's healthy, what's at risk, what needs a decision
+   - Offer next actions (drill into a milestone, work a specific ticket, etc.)
+
+## What to highlight in the executive summary
+
+- Milestones < 50% complete with imminent dates
+- Issues stale > 30 days (especially if assigned)
+- PR queue depth and oldest open PR
+- Unassigned high-priority labels (`bug`, `priority:high`, etc.)
+
+## What NOT to do
+
+- Do NOT post the report as a GitHub comment unless the user explicitly asks
+- Do NOT delete or modify older reports in `.claude/reports/` — they're history
+- Do NOT speculate about reasons for delays; report facts, the user provides context

--- a/claude-skills/skills/po-report/scripts/generate-report.sh
+++ b/claude-skills/skills/po-report/scripts/generate-report.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# generate-report.sh — compose a full PO markdown report.
+# Calls the other scripts and emits markdown on stdout.
+# Usage:
+#   bash scripts/generate-report.sh > .claude/reports/$(date +%F)-status.md
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+status_json=$(bash "${HERE}/status.sh")
+milestones_json=$(bash "${HERE}/milestone-progress.sh")
+stale_json=$(bash "${HERE}/stale-issues.sh" 14)
+
+repo=$(printf '%s' "$status_json" | jq -r '.repo')
+generated_at=$(printf '%s' "$status_json" | jq -r '.generatedAt')
+open_issues=$(printf '%s' "$status_json" | jq -r '.issues.open')
+closed_issues=$(printf '%s' "$status_json" | jq -r '.issues.closed')
+open_prs=$(printf '%s' "$status_json" | jq -r '.pullRequests.open')
+draft_prs=$(printf '%s' "$status_json" | jq -r '.pullRequests.draft')
+
+cat <<MD
+# PO Report — ${repo}
+
+_Generated: ${generated_at}_
+
+## At a glance
+
+| Metric            | Value |
+| ----------------- | ----- |
+| Open issues       | ${open_issues} |
+| Closed issues     | ${closed_issues} |
+| Open PRs          | ${open_prs} |
+| Draft PRs         | ${draft_prs} |
+
+## Top labels (open issues)
+
+$(printf '%s' "$status_json" | jq -r '
+  if (.topLabels | length) == 0 then "_No labels._"
+  else (["| Label | Count |", "| --- | --- |"] + (.topLabels | map("| \(.name) | \(.count) |"))) | join("\n")
+  end
+')
+
+## Open issues by assignee
+
+$(printf '%s' "$status_json" | jq -r '
+  if (.byAssignee | length) == 0 then "_No open issues._"
+  else (["| Assignee | Open |", "| --- | --- |"] + (.byAssignee | map("| \(.login) | \(.count) |"))) | join("\n")
+  end
+')
+
+## Milestone progress
+
+$(printf '%s' "$milestones_json" | jq -r '
+  if length == 0 then "_No open milestones._"
+  else (["| Milestone | Due | Closed/Total | % | URL |", "| --- | --- | --- | --- | --- |"]
+        + (map("| \(.title) | \(.due_on // "—") | \(.closed_issues)/\(.total) | \(.percent_complete | floor)% | \(.url) |"))) | join("\n")
+  end
+')
+
+## Stale open issues (no activity > 14 days)
+
+$(printf '%s' "$stale_json" | jq -r '
+  if length == 0 then "_None._"
+  else (["| # | Title | Days stale | Assignees | Labels |", "| --- | --- | --- | --- | --- |"]
+        + (.[0:25] | map("| [#\(.number)](\(.url)) | \(.title | gsub("\\|"; "\\\\|")) | \(.daysStale) | \((.assignees // []) | join(", ")) | \((.labels // []) | join(", ")) |"))) | join("\n")
+  end
+')
+
+$(printf '%s' "$stale_json" | jq -r 'if length > 25 then "_Showing top 25 of \(length) stale issues._" else "" end')
+
+## Oldest open PR
+
+$(printf '%s' "$status_json" | jq -r '
+  if .oldestOpenPr == null then "_No open PRs._"
+  else "- [#\(.oldestOpenPr.number)](\(.oldestOpenPr.url)) — \(.oldestOpenPr.title) _(opened \(.oldestOpenPr.createdAt))_"
+  end
+')
+MD

--- a/claude-skills/skills/po-report/scripts/milestone-progress.sh
+++ b/claude-skills/skills/po-report/scripts/milestone-progress.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# milestone-progress.sh — list open milestones with progress as JSON.
+# No arguments. Run from repo root.
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo '{"error":"gh CLI not found"}' >&2
+  exit 1
+fi
+
+# Resolve owner/repo from gh
+slug=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+owner="${slug%%/*}"
+name="${slug##*/}"
+
+# Use REST API for milestones (gh CLI has no top-level milestone command).
+# state=open keeps the noise down; switch to all if you need closed too.
+gh api "repos/${owner}/${name}/milestones?state=open&per_page=100" \
+  --jq '[ .[] | {
+      number: .number,
+      title: .title,
+      state: .state,
+      due_on: .due_on,
+      open_issues: .open_issues,
+      closed_issues: .closed_issues,
+      total: (.open_issues + .closed_issues),
+      percent_complete: (
+        if (.open_issues + .closed_issues) == 0 then 0
+        else ((.closed_issues * 100) / (.open_issues + .closed_issues))
+        end
+      ),
+      url: .html_url
+    } ]'

--- a/claude-skills/skills/po-report/scripts/stale-issues.sh
+++ b/claude-skills/skills/po-report/scripts/stale-issues.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# stale-issues.sh [DAYS] — list open issues with no activity for N days.
+# Default: 14 days. Run from repo root.
+set -euo pipefail
+
+DAYS="${1:-14}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo '{"error":"gh CLI not found"}' >&2
+  exit 1
+fi
+
+# Compute the cutoff in UTC. Use python for portability (BSD vs GNU date).
+cutoff=$(python3 -c "
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(days=${DAYS})).strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+
+gh issue list --state open --limit 1000 \
+  --json number,title,assignees,labels,updatedAt,url \
+  --jq "
+    [ .[]
+      | select(.updatedAt < \"${cutoff}\")
+      | {
+          number,
+          title,
+          assignees: [.assignees[].login],
+          labels: [.labels[].name],
+          updatedAt,
+          daysStale: (((now - (.updatedAt | fromdateiso8601)) / 86400) | floor),
+          url
+        }
+    ]
+    | sort_by(-.daysStale)
+  "

--- a/claude-skills/skills/po-report/scripts/status.sh
+++ b/claude-skills/skills/po-report/scripts/status.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# status.sh — emit repo-wide PO metrics as JSON.
+# No arguments. Run from repo root. Requires `gh` authenticated.
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo '{"error":"gh CLI not found"}' >&2
+  exit 1
+fi
+
+# Pull each metric independently so a partial failure doesn't tank the whole thing.
+open_issues=$(gh issue list --state open    --limit 1000 --json number --jq 'length' 2>/dev/null || echo 0)
+closed_issues=$(gh issue list --state closed --limit 1000 --json number --jq 'length' 2>/dev/null || echo 0)
+open_prs=$(gh pr list      --state open    --limit 1000 --json number --jq 'length' 2>/dev/null || echo 0)
+draft_prs=$(gh pr list     --state open    --limit 1000 --json number,isDraft --jq '[.[] | select(.isDraft)] | length' 2>/dev/null || echo 0)
+
+# Top labels on open issues
+top_labels=$(gh issue list --state open --limit 1000 \
+  --json labels \
+  --jq '[.[].labels[].name] | group_by(.) | map({name: .[0], count: length}) | sort_by(-.count) | .[0:10]' \
+  2>/dev/null || echo '[]')
+
+# Open issues by assignee (unassigned first)
+by_assignee=$(gh issue list --state open --limit 1000 \
+  --json assignees \
+  --jq '[.[] | (if (.assignees|length)==0 then "unassigned" else .assignees[0].login end)] | group_by(.) | map({login: .[0], count: length}) | sort_by(-.count)' \
+  2>/dev/null || echo '[]')
+
+# Oldest open PR (for "review queue depth" signal)
+oldest_open_pr=$(gh pr list --state open --limit 1000 \
+  --json number,title,createdAt,url \
+  --jq 'sort_by(.createdAt) | .[0] // null' \
+  2>/dev/null || echo 'null')
+
+repo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo 'unknown')
+generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+cat <<JSON
+{
+  "repo": "${repo}",
+  "generatedAt": "${generated_at}",
+  "issues": {
+    "open": ${open_issues},
+    "closed": ${closed_issues}
+  },
+  "pullRequests": {
+    "open": ${open_prs},
+    "draft": ${draft_prs}
+  },
+  "topLabels": ${top_labels},
+  "byAssignee": ${by_assignee},
+  "oldestOpenPr": ${oldest_open_pr}
+}
+JSON

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -3,15 +3,17 @@
 Unit tests for the BSG claude-skills catalog.
 
 Validates structural invariants that are easy to break by hand when adding
-or editing a shared skill:
+or editing a shared command, skill, or subagent:
 
-  1. every command file ends with the required "How to improve this skill"
-     footer (so a developer using the cached copy in ~/.claude/ knows to PR
-     back here instead of editing locally)
-  2. that footer references the file's own filename (not a copy-paste from
-     another skill)
-  3. the "Available commands" catalog table in INSTALL.md is in sync with
-     the actual files in claude-skills/commands/
+  1. every command file, skill SKILL.md, and agent file ends with the
+     required "How to improve this skill" footer (so a developer using the
+     cached copy in ~/.claude/ knows to PR back here instead of editing
+     locally)
+  2. that footer references the file's own canonical path (not a
+     copy-paste from another asset)
+  3. the "Available commands", "Available skills", and "Available agents"
+     catalog tables in INSTALL.md are in sync with the actual files in
+     claude-skills/{commands,skills,agents}/
 
 Run locally:
 
@@ -29,23 +31,73 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_DIR = REPO_ROOT / "claude-skills"
 COMMANDS_DIR = SKILLS_DIR / "commands"
+SKILLS_SUBDIR = SKILLS_DIR / "skills"
+AGENTS_DIR = SKILLS_DIR / "agents"
 INSTALL_MD = SKILLS_DIR / "INSTALL.md"
 
 FOOTER_HEADER = "## How to improve this skill"
-# matches `claude-skills/commands/<name>.md` inside backticks
-FOOTER_PATH_RE = re.compile(r"`claude-skills/commands/([a-z0-9_-]+\.md)`")
-# matches a row in the "Available commands" table: `| `/<name>` | ... |`
-CATALOG_ROW_RE = re.compile(r"^\|\s*`/([a-z0-9_-]+)`\s*\|", re.MULTILINE)
+
+# Catches any reference of the form `claude-skills/<...>` inside backticks
+# in a footer block, regardless of whether it's a command, skill, or agent.
+FOOTER_PATH_RE = re.compile(r"`(claude-skills/[A-Za-z0-9_/.-]+\.md)`")
+
+# Row in the "Available commands" table: `| `/<name>` | ... |`
+COMMAND_CATALOG_ROW_RE = re.compile(r"^\|\s*`/([a-z0-9_-]+)`\s*\|", re.MULTILINE)
+# Rows in "Available skills" / "Available agents" — same shape: `| `<name>` | ... |`
+NAME_CATALOG_ROW_RE = re.compile(r"^\|\s*`([a-z0-9_-]+)`\s*\|", re.MULTILINE)
 
 
 def list_commands() -> list[Path]:
     return sorted(p for p in COMMANDS_DIR.glob("*.md") if p.is_file())
 
 
+def list_skill_entrypoints() -> list[Path]:
+    """One SKILL.md per skill directory."""
+    if not SKILLS_SUBDIR.is_dir():
+        return []
+    return sorted(
+        p / "SKILL.md"
+        for p in SKILLS_SUBDIR.iterdir()
+        if p.is_dir() and (p / "SKILL.md").is_file()
+    )
+
+
+def list_agents() -> list[Path]:
+    if not AGENTS_DIR.is_dir():
+        return []
+    return sorted(p for p in AGENTS_DIR.glob("*.md") if p.is_file())
+
+
+def all_footer_bearing_files() -> list[Path]:
+    return list_commands() + list_skill_entrypoints() + list_agents()
+
+
+def canonical_relative_path(path: Path) -> str:
+    """The path the footer in this file MUST reference (relative to repo root)."""
+    return str(path.relative_to(REPO_ROOT))
+
+
+def parse_section(install_text: str, header: str, regex: re.Pattern[str]) -> set[str]:
+    """Extract names from a single H2 section's first table."""
+    # Slice from this header to the next H2 (or EOF), then run the row regex.
+    pattern = re.compile(
+        rf"^##\s+{re.escape(header)}\s*$(.*?)(?=^##\s|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(install_text)
+    if not match:
+        return set()
+    return set(regex.findall(match.group(1)))
+
+
 class TestSharedSkills(unittest.TestCase):
-    def test_every_command_has_footer(self) -> None:
-        for path in list_commands():
-            with self.subTest(path=path.name):
+    # ------------------------------------------------------------------ footers
+
+    def test_every_asset_has_footer(self) -> None:
+        files = all_footer_bearing_files()
+        self.assertGreater(len(files), 0, "no shared assets discovered at all")
+        for path in files:
+            with self.subTest(path=str(path.relative_to(REPO_ROOT))):
                 text = path.read_text()
                 self.assertIn(
                     FOOTER_HEADER,
@@ -55,38 +107,64 @@ class TestSharedSkills(unittest.TestCase):
                     f"for the template.",
                 )
 
-    def test_footer_references_own_filename(self) -> None:
-        for path in list_commands():
-            with self.subTest(path=path.name):
+    def test_footer_references_own_canonical_path(self) -> None:
+        for path in all_footer_bearing_files():
+            with self.subTest(path=str(path.relative_to(REPO_ROOT))):
                 text = path.read_text()
                 idx = text.find(FOOTER_HEADER)
                 if idx < 0:
                     self.skipTest("no footer (covered by another test)")
                 footer = text[idx:]
                 referenced = set(FOOTER_PATH_RE.findall(footer))
+                expected = canonical_relative_path(path)
                 self.assertIn(
-                    path.name,
+                    expected,
                     referenced,
-                    f"footer in {path.relative_to(REPO_ROOT)} does not "
-                    f"reference its own filename "
-                    f"`claude-skills/commands/{path.name}`. Found references "
-                    f"to: {sorted(referenced) or 'nothing'}. This usually "
-                    f"means the footer was copy-pasted from another skill — "
-                    f"fix the file name in the footer.",
+                    f"footer in {expected} does not reference its own "
+                    f"canonical path `{expected}`. Found references to: "
+                    f"{sorted(referenced) or 'nothing'}. This usually means "
+                    f"the footer was copy-pasted from another asset — fix "
+                    f"the path in the footer.",
                 )
 
-    def test_install_md_catalog_in_sync(self) -> None:
-        install_text = INSTALL_MD.read_text()
-        catalog_names = set(CATALOG_ROW_RE.findall(install_text))
-        actual_names = {p.stem for p in list_commands()}
+    # ----------------------------------------------------------- catalog sync
 
-        missing = sorted(actual_names - catalog_names)
-        orphans = sorted(catalog_names - actual_names)
+    def test_install_md_commands_catalog_in_sync(self) -> None:
+        install_text = INSTALL_MD.read_text()
+        catalog_names = parse_section(
+            install_text, "Available commands", COMMAND_CATALOG_ROW_RE
+        )
+        actual_names = {p.stem for p in list_commands()}
+        self._assert_sets_match(catalog_names, actual_names, "Available commands")
+
+    def test_install_md_skills_catalog_in_sync(self) -> None:
+        install_text = INSTALL_MD.read_text()
+        catalog_names = parse_section(
+            install_text, "Available skills", NAME_CATALOG_ROW_RE
+        )
+        actual_names = {p.parent.name for p in list_skill_entrypoints()}
+        self._assert_sets_match(catalog_names, actual_names, "Available skills")
+
+    def test_install_md_agents_catalog_in_sync(self) -> None:
+        install_text = INSTALL_MD.read_text()
+        catalog_names = parse_section(
+            install_text, "Available agents", NAME_CATALOG_ROW_RE
+        )
+        actual_names = {p.stem for p in list_agents()}
+        self._assert_sets_match(catalog_names, actual_names, "Available agents")
+
+    # ------------------------------------------------------------------ helpers
+
+    def _assert_sets_match(
+        self, catalog: set[str], actual: set[str], section: str
+    ) -> None:
+        missing = sorted(actual - catalog)
+        orphans = sorted(catalog - actual)
         self.assertSetEqual(
-            catalog_names,
-            actual_names,
-            f"INSTALL.md 'Available commands' table is out of sync with "
-            f"claude-skills/commands/.\n"
+            catalog,
+            actual,
+            f"INSTALL.md '{section}' table is out of sync with the "
+            f"corresponding directory under claude-skills/.\n"
             f"  Missing rows (file exists but no catalog entry): {missing}\n"
             f"  Orphan rows (catalog entry but no file): {orphans}\n"
             f"Update the table in claude-skills/INSTALL.md.",


### PR DESCRIPTION
## Summary

- Adds the **first shared subagent** to the BSG install: `po-manager`, a PO/PM orchestrator scoped to status/reporting (explicitly declines implementation work, so delegation is safe).
- Adds the **first shared full skill**: `po-report`, which generates a dated markdown report from `gh` data. Heavy lifting in bash scripts (`status.sh`, `milestone-progress.sh`, `stale-issues.sh`, `generate-report.sh`) so aggregation is deterministic and free of LLM token cost — `SKILL.md` only narrates and routes.
- Extends the install flow in `INSTALL.md` with a **new step 4** that fetches `claude-skills/agents/` and writes each file to `~/.claude/agents/`. Existing `commands` and `skills` flows are unchanged in behavior; step 3 now also `chmod +x`'s any file under `scripts/` so skills can run their own helpers.
- Extends `test_skills.py`: footer + canonical-path tests now cover commands, `skills/SKILL.md`, and `agents/*.md` uniformly. Two new catalog-sync tests for `Available skills` and `Available agents`. Uses a new `parse_section` helper to slice `INSTALL.md` by H2 so sections can't bleed into each other.

## Why a subagent and not just a slash command

A slash command would work but has two downsides for PO reporting:

1. It runs in your main session's context window, so dumping `gh` output pollutes the conversation.
2. It can't be auto-delegated to — the user has to remember to type `/...`.

The subagent runs in its own context, gets injected with the right skills (`po-report`, `daily-standup`), and the main agent can delegate to it whenever the user asks PO-flavored questions like _"où en est le projet"_ or _"give me a status report"_. Reports persist as dated files under `.claude/reports/` so the chat stays clean.

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — 5/5 green locally
- [ ] CI `claude-skills test` workflow passes on this PR
- [ ] After merge: re-run the install flow in a fresh session — `Install the BSG Claude skills by following https://raw.githubusercontent.com/beyond-scale-group/bsg-workflows/main/claude-skills/INSTALL.md`
- [ ] Verify `~/.claude/agents/po-manager.md` and `~/.claude/skills/po-report/{SKILL.md,references/,scripts/}` are created
- [ ] Verify `chmod +x` was applied on `~/.claude/skills/po-report/scripts/*.sh`
- [ ] Restart Claude Code, ask _"use po-manager to give me a status report on this repo"_, confirm a file lands in `.claude/reports/YYYY-MM-DD-status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)