### PR TITLE
docs: rebrand bsg-workflows to bsg-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,42 @@
-# bsg-workflows
+# BSG STACK — THE INFRASTRUCTURE THAT RUNS THE EMPIRE
 
-Reusable GitHub Actions workflows for Beyond Scale Group projects.
+*"You don't scale an empire with copy-paste. You scale it with a stack."*
 
-## Workflows
+---
 
-### Build & Test
+## The Story
+
+It started with a simple problem: every new software company acquired by BSG came with its own CI/CD workflows, its own conventions, its own duct tape. Three acquisitions in, we had three different Scala pipelines, two ways to deploy on Clever Cloud, and zero consistency.
+
+We did what any engineer would do: we centralized. One repo, reusable workflows, shared conventions. But we didn't stop there.
+
+Because BSG isn't a fund that buys and flips. It's a **forever hold**. Every piece of software we acquire, we keep. Forever. And when you're holding 50 software companies forever, you need a **shared stack** — not just workflows, but the entire connective tissue that ties the portfolio together: CI/CD, Renovate configs, Claude Code skills, release conventions, review apps, notifications.
+
+**bsg-stack** is BSG's `gstack`. The shared technical foundation for every company in the group. One repo, one source of truth, zero duplication.
+
+---
+
+## What's in the Box
+
+### GitHub Actions Workflows
+
+Reusable workflows, ready to plug into any repo in the portfolio.
+
+#### Build & Test
 
 | Workflow | Description | Stack |
 |----------|-------------|-------|
 | `scala_test.yaml` | Compile, test, coverage (scoverage) | Scala 3 / sbt |
 | `react_vite_test.yaml` | Build, lint, test | React / Vite / TypeScript |
 
-### Coverage & Reports
+#### Coverage & Reports
 
 | Workflow | Description |
 |----------|-------------|
 | `cobertura_report.yaml` | Publish Cobertura coverage on PR |
 | `junit_report.yaml` | Publish JUnit test results on PR checks |
 
-### Release & Versioning
+#### Release & Versioning
 
 | Workflow | Description |
 |----------|-------------|
@@ -26,7 +44,7 @@ Reusable GitHub Actions workflows for Beyond Scale Group projects.
 | `semantic_pull_request.yaml` | Enforce conventional commit PR titles |
 | `create_release_branch.yaml` | Create release branches from tags, clean up old RCs |
 
-### Deployment
+#### Deployment
 
 | Workflow | Description |
 |----------|-------------|
@@ -34,7 +52,7 @@ Reusable GitHub Actions workflows for Beyond Scale Group projects.
 | `docker_build_and_push.yaml` | Build multi-platform Docker images, push to registry |
 | `review_app_deploy.yaml` | Terraform-based review apps for PRs on Clever Cloud |
 
-### Automation
+#### Automation
 
 | Workflow | Description |
 |----------|-------------|
@@ -44,7 +62,7 @@ Reusable GitHub Actions workflows for Beyond Scale Group projects.
 | `pr_auto_add_project.yaml` | Auto-add PRs to GitHub Projects |
 | `discord_notifier.yaml` | Send Discord notifications |
 
-### Maintenance
+#### Maintenance
 
 | Workflow | Description |
 |----------|-------------|
@@ -53,38 +71,54 @@ Reusable GitHub Actions workflows for Beyond Scale Group projects.
 For detailed inputs, secrets, and usage examples for each workflow, see
 **[docs/workflows.md](docs/workflows.md)**.
 
+### Renovate Configs
+
+Shareable dependency management presets in `renovate/`:
+
+- `scala_config.json` — sbt projects (automerge patch/minor, manual major)
+- `react_config.json` — npm projects (automerge patch/minor, manual major)
+
+### Claude Code Skills
+
+Shared [Claude Code](https://claude.com/claude-code) slash commands and
+skills live under `claude-skills/`. To install them, ask your Claude Code
+agent to follow [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md) —
+Claude will fetch the file, discover the available commands, and write
+them into your `~/.claude/` directory. Re-ask any time to pull updates.
+
+---
+
 ## Quick Start
 
-Reference workflows from your repo:
+Reference workflows from any repo in the group:
 
 ```yaml
 jobs:
   test:
-    uses: beyond-scale-group/bsg-workflows/.github/workflows/scala_test.yaml@v1
+    uses: beyond-scale-group/bsg-stack/.github/workflows/scala_test.yaml@v1
     with:
       jdk: "21"
       working_directory: apps/backend/my-scala-app
 
   semantic-pr:
-    uses: beyond-scale-group/bsg-workflows/.github/workflows/semantic_pull_request.yaml@v1
+    uses: beyond-scale-group/bsg-stack/.github/workflows/semantic_pull_request.yaml@v1
     with:
       scopes: "backend, frontend, ci, docs"
 ```
 
-## Renovate Configs
+That's it. No fork, no copy, no drift.
 
-Shareable Renovate presets in `renovate/`:
+---
 
-- `scala_config.json` — sbt projects (automerge patch/minor, manual major)
-- `react_config.json` — npm projects (automerge patch/minor, manual major)
+## The Philosophy
 
-## Claude Code Skills
+Every BSG software company inherits the stack automatically. New acquisition? Plug in the workflows, activate Renovate, install the Claude skills. Within an hour, the repo meets group standards.
 
-Shared [Claude Code](https://claude.com/claude-code) slash commands and
-skills live under `claude-skills/`. To install them, ask your Claude Code
-agent to follow [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md) --
-Claude will fetch the file, discover the available commands, and write
-them into your `~/.claude/` directory. Re-ask any time to pull updates.
+This is the **BSG effect** applied to infrastructure: centralize to accelerate, standardize to scale, automate to free up human time.
+
+50 software companies, one stack. That's how you build an empire.
+
+---
 
 ## Versioning
 

--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -15,7 +15,7 @@ as the catalog of what's available.
 In any Claude Code session, ask:
 
 > Install the BSG Claude skills by following
-> https://raw.githubusercontent.com/beyond-scale-group/bsg-workflows/main/claude-skills/INSTALL.md
+> https://raw.githubusercontent.com/beyond-scale-group/bsg-stack/main/claude-skills/INSTALL.md
 
 Claude will fetch this file, discover the commands, skills, and agents
 listed below, and install them under `~/.claude/`. **To pick up updates
@@ -101,14 +101,14 @@ rather than part of its role:
 ## How to improve this skill
 
 This file is a cached copy of `claude-skills/commands/<name>.md` in
-[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
 That repo is the single source of truth — `~/.claude/commands/<name>.md` is
 overwritten every time the BSG install flow runs.
 
 If the user asks you to improve, fix, or extend this skill, do **not** edit
 the local file. Instead:
 
-1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
 2. Edit `claude-skills/commands/<name>.md` on a feature branch
 3. Open a pull request against `main`
 
@@ -140,7 +140,7 @@ clobbering files it does not own).**
 Fetch the raw content from:
 
 ```
-https://raw.githubusercontent.com/beyond-scale-group/bsg-workflows/main/claude-skills/scripts/update-bsg-skills.py
+https://raw.githubusercontent.com/beyond-scale-group/bsg-stack/main/claude-skills/scripts/update-bsg-skills.py
 ```
 
 ### 2. Install it

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -76,14 +76,14 @@ Keep it tight. The user can open the file for the details.
 ## How to improve this skill
 
 This file is a cached copy of `claude-skills/agents/po-manager.md` in
-[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
 That repo is the single source of truth — `~/.claude/agents/po-manager.md` is
 overwritten every time the BSG install flow runs.
 
 If the user asks you to improve, fix, or extend this skill, do **not** edit
 the local file. Instead:
 
-1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
 2. Edit `claude-skills/agents/po-manager.md` on a feature branch
 3. Open a pull request against `main`
 

--- a/claude-skills/commands/babysit.md
+++ b/claude-skills/commands/babysit.md
@@ -83,14 +83,14 @@ When evaluating whether a PR can be merged, apply these criteria strictly:
 ## How to improve this skill
 
 This file is a cached copy of `claude-skills/commands/babysit.md` in
-[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
 That repo is the single source of truth — `~/.claude/commands/babysit.md` is
 overwritten every time the BSG install flow runs.
 
 If the user asks you to improve, fix, or extend this skill, do **not** edit
 the local file. Instead:
 
-1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
 2. Edit `claude-skills/commands/babysit.md` on a feature branch
 3. Open a pull request against `main`
 

--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -3,7 +3,7 @@
 update-bsg-skills.py
 
 Refreshes the cached BSG shared Claude Code commands and skills from
-beyond-scale-group/bsg-workflows@main into the user's ~/.claude/.
+beyond-scale-group/bsg-stack@main into the user's ~/.claude/.
 
 Designed to be invoked by a Claude Code SessionStart hook so every new
 session picks up the latest version automatically. The script also
@@ -30,7 +30,7 @@ Claude Code session from starting. Logs to
 ~/.claude/logs/update-bsg-skills.log (rotated at 256 KiB).
 
 This file is a cached copy of claude-skills/scripts/update-bsg-skills.py
-in beyond-scale-group/bsg-workflows. The repo is the source of truth;
+in beyond-scale-group/bsg-stack. The repo is the source of truth;
 the local copy is overwritten on every run.
 """
 
@@ -44,7 +44,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-REPO = "beyond-scale-group/bsg-workflows"
+REPO = "beyond-scale-group/bsg-stack"
 BRANCH = "main"
 SCRIPT_NAME = "update-bsg-skills.py"
 

--- a/claude-skills/skills/po-report/SKILL.md
+++ b/claude-skills/skills/po-report/SKILL.md
@@ -71,14 +71,14 @@ summary in the chat — do **not** dump the full report inline.
 ## How to improve this skill
 
 This file is a cached copy of `claude-skills/skills/po-report/SKILL.md` in
-[beyond-scale-group/bsg-workflows](https://github.com/beyond-scale-group/bsg-workflows).
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
 That repo is the single source of truth — `~/.claude/skills/po-report/SKILL.md` is
 overwritten every time the BSG install flow runs.
 
 If the user asks you to improve, fix, or extend this skill, do **not** edit
 the local file. Instead:
 
-1. `gh repo clone beyond-scale-group/bsg-workflows` (or work in an existing clone)
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
 2. Edit `claude-skills/skills/po-report/SKILL.md` on a feature branch
 3. Open a pull request against `main`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -26,7 +26,7 @@ Compiles and runs Scala tests with optional code coverage reporting (scoverage).
 ```yaml
 jobs:
   test:
-    uses: beyond-scale-group/bsg-workflows/.github/workflows/scala_test.yaml@v1
+    uses: beyond-scale-group/bsg-stack/.github/workflows/scala_test.yaml@v1
     with:
       jdk: "21"
       working_directory: apps/backend/my-app
@@ -53,7 +53,7 @@ Builds and lints a React/Vite project with optional testing.
 ```yaml
 jobs:
   test:
-    uses: beyond-scale-group/bsg-workflows/.github/workflows/react_vite_test.yaml@v1
+    uses: beyond-scale-group/bsg-stack/.github/workflows/react_vite_test.yaml@v1
     with:
       node_version: "22"
       working_directory: apps/frontend


### PR DESCRIPTION
## Summary
- Rename `beyond-scale-group/bsg-workflows` to `beyond-scale-group/bsg-stack` across all Claude skill files, the updater script, and workflow usage examples
- Rewrite README with a story-driven narrative framing the repo as BSG's shared technical foundation (the `gstack` of BSG), inspired by the bsg-lbo repo tone — all in US English
- Preserves the full workflow/skill/renovate catalog intact

## Testing
- Not run (not requested)

> Note: once this PR lands, the GitHub repo itself should be renamed from `bsg-workflows` to `bsg-stack` so that the URL references in the Claude skills updater (`update-bsg-skills.py`) resolve. GitHub preserves redirects for the old name.
