### PR TITLE
docs: add root INSTALL.md and reorganisation plan

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,136 @@
+# BSG Stack — Install Guide
+
+This is the entry point for installing any component of the **BSG Stack**
+into a repo or a developer machine.
+
+The stack is modular — install only the components you need. Each component
+has its own install path; this file is the index that points to the
+component-specific `INSTALL.md` or install snippet.
+
+---
+
+## Components at a glance
+
+| Component | What it's for | Install path |
+|-----------|---------------|--------------|
+| [GitHub Actions workflows](#1-github-actions-workflows) | Reusable CI/CD workflows (test, deploy, release, automation) | Inline — reference by `uses:` in caller repos |
+| [Renovate presets](#2-renovate-presets) | Shared dependency-update configuration for sbt and npm projects | Inline — `extends` in a `renovate.json` |
+| [Claude Code skills](#3-claude-code-skills) | Shared slash commands, skills, and subagents for Claude Code | Full installer — see [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md) |
+
+---
+
+## 1. GitHub Actions workflows
+
+**No installation.** Reference workflows directly from any repo in the
+portfolio via `uses:`:
+
+```yaml
+# .github/workflows/ci.yaml in your repo
+jobs:
+  test:
+    uses: beyond-scale-group/bsg-stack/.github/workflows/scala_test.yaml@v1
+    with:
+      jdk: "21"
+      working_directory: apps/backend/my-scala-app
+
+  semantic-pr:
+    uses: beyond-scale-group/bsg-stack/.github/workflows/semantic_pull_request.yaml@v1
+    with:
+      scopes: "backend, frontend, ci, docs"
+```
+
+Pin with a tag:
+
+- `@v1` — latest major (recommended for most callers).
+- `@v1.2.3` — exact version (for reproducibility-sensitive pipelines).
+- `@main` — bleeding edge (not recommended outside this repo).
+
+The full reference for every workflow — inputs, secrets, examples — lives
+in [`docs/workflows.md`](docs/workflows.md).
+
+---
+
+## 2. Renovate presets
+
+**No installation.** Reference a preset from your repo's `renovate.json`
+using Renovate's cross-repo preset syntax:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>beyond-scale-group/bsg-stack//renovate/scala_config"
+  ]
+}
+```
+
+Available presets (pick whichever matches your project):
+
+| Preset | Use for |
+|--------|---------|
+| `github>beyond-scale-group/bsg-stack//renovate/scala_config` | sbt / Scala projects |
+| `github>beyond-scale-group/bsg-stack//renovate/react_config` | npm / React projects |
+
+Both presets automerge patch and minor updates and hold major updates for
+human review. Override any rule in your own `renovate.json` — `extends` is
+merged, not replaced.
+
+---
+
+## 3. Claude Code skills
+
+This component has a **full install flow** because it writes files into
+your `~/.claude/` directory on your machine.
+
+### Quick install
+
+In any Claude Code session, ask:
+
+> Install the BSG Claude skills by following
+> https://raw.githubusercontent.com/beyond-scale-group/bsg-stack/main/claude-skills/INSTALL.md
+
+Claude will fetch that file, drop an updater script into
+`~/.claude/scripts/`, run it once, and register a `SessionStart` hook so
+every new Claude Code session pulls the latest skills automatically.
+
+### What gets installed
+
+- **Slash commands** → `~/.claude/commands/` (e.g. `/babysit`)
+- **Skills** → `~/.claude/skills/` (e.g. `po-report`)
+- **Subagents** → `~/.claude/agents/` (e.g. `po-manager`)
+
+The updater only overwrites files it owns (tracked in a local manifest),
+so files you've added yourself are never clobbered.
+
+### To update
+
+Ask the same question again in any Claude Code session — or just start a
+new session and let the hook run. Either way, the latest versions from
+`main` land in `~/.claude/`.
+
+Full details, catalog, and contribution guidelines:
+**[`claude-skills/INSTALL.md`](claude-skills/INSTALL.md)**.
+
+---
+
+## Contributing a new component
+
+If the stack grows a new component (e.g. shared Dockerfiles, shared
+Terraform modules), follow the same pattern:
+
+1. Add a top-level directory for the component.
+2. Add a `<component>/INSTALL.md` if the install flow is non-trivial,
+   otherwise an install snippet inline in this file is enough.
+3. Link it from the "Components at a glance" table above.
+4. Document it in the root [`README.md`](README.md).
+
+---
+
+## Questions
+
+- Workflow doesn't cover your use case → open an issue or PR in
+  [beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+- Bug in a Claude skill → see "How to improve this skill" at the bottom
+  of each skill file, or open a PR against `claude-skills/`.
+- Want a new preset or workflow → PR welcome; keep it generic enough to
+  serve more than one repo in the portfolio.

--- a/README.md
+++ b/README.md
@@ -73,24 +73,27 @@ For detailed inputs, secrets, and usage examples for each workflow, see
 
 ### Renovate Configs
 
-Shareable dependency management presets in `renovate/`:
+Shareable dependency management presets in [`renovate/`](renovate/) — see
+[`renovate/README.md`](renovate/README.md) for details:
 
 - `scala_config.json` — sbt projects (automerge patch/minor, manual major)
 - `react_config.json` — npm projects (automerge patch/minor, manual major)
 
 ### Claude Code Skills
 
-Shared [Claude Code](https://claude.com/claude-code) slash commands and
-skills live under `claude-skills/`. To install them, ask your Claude Code
-agent to follow [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md) —
-Claude will fetch the file, discover the available commands, and write
-them into your `~/.claude/` directory. Re-ask any time to pull updates.
+Shared [Claude Code](https://claude.com/claude-code) slash commands,
+skills, and subagents live under [`claude-skills/`](claude-skills/) — see
+[`claude-skills/README.md`](claude-skills/README.md) for the component
+overview and [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md) for
+the Claude-driven installer and current catalog.
 
 ---
 
 ## Quick Start
 
-Reference workflows from any repo in the group:
+See [`INSTALL.md`](INSTALL.md) for the install guide covering every
+component of the stack. For workflows specifically, reference them from
+any repo in the group:
 
 ```yaml
 jobs:

--- a/claude-skills/README.md
+++ b/claude-skills/README.md
@@ -1,0 +1,56 @@
+# Claude Code Skills
+
+Shared [Claude Code](https://claude.com/claude-code) slash commands,
+skills, and subagents for the BSG portfolio. Every developer in the
+group gets the same baseline Claude capabilities with one install
+command and auto-updates on every new session.
+
+## What's in here
+
+| Directory | Purpose |
+|-----------|---------|
+| `commands/` | Slash commands (`/babysit`, …) — single-file prompts invoked as `/name` |
+| `skills/` | Full skills (`po-report`, …) — `SKILL.md` + optional `scripts/` and `references/` |
+| `agents/` | Subagents (`po-manager`, …) — role-scoped agents with their own tool budget |
+| `scripts/` | The installer (`update-bsg-skills.py`) and helper scripts |
+| `tests/` | Smoke tests for the installer and skill metadata |
+
+For the current catalog of installed commands, skills, and agents, see
+the tables in [`INSTALL.md`](INSTALL.md).
+
+## How to install
+
+Ask your Claude Code agent:
+
+> Install the BSG Claude skills by following
+> https://raw.githubusercontent.com/beyond-scale-group/bsg-stack/main/claude-skills/INSTALL.md
+
+Claude fetches that file, drops `update-bsg-skills.py` into
+`~/.claude/scripts/`, runs it once, and registers a `SessionStart`
+hook so every future Claude Code session pulls the latest from `main`
+automatically.
+
+Full installer behaviour (manifest, skip-if-not-owned, log rotation,
+network-error handling) is documented in [`INSTALL.md`](INSTALL.md).
+
+## How to contribute
+
+To add a new command, skill, or agent to the shared catalog, follow the
+"Adding a new command, skill, or agent to the catalog" section of
+[`INSTALL.md`](INSTALL.md#adding-a-new-command-skill-or-agent-to-the-catalog).
+In short:
+
+1. Drop the file in the right subdirectory (`commands/`, `skills/`, or
+   `agents/`).
+2. Add the standard "How to improve this skill" footer so remote edits
+   flow back here instead of diverging locally.
+3. Add a row to the catalog table in `INSTALL.md`.
+4. Open a PR.
+
+## Source of truth
+
+This directory is the single source of truth. Files in
+`~/.claude/commands/`, `~/.claude/skills/`, and `~/.claude/agents/` on
+any developer machine are cached copies — they get overwritten on every
+install or SessionStart run. Always PR back here instead of editing the
+local copies.

--- a/docs/claude-skills.md
+++ b/docs/claude-skills.md
@@ -1,0 +1,23 @@
+# Claude Code Skills
+
+Shared Claude Code slash commands, skills, and subagents for the BSG
+portfolio.
+
+- **Component README:** [`claude-skills/README.md`](../claude-skills/README.md) —
+  directory layout and contribution flow.
+- **Full install guide + catalog:** [`claude-skills/INSTALL.md`](../claude-skills/INSTALL.md) —
+  the Claude-driven installer and the current catalog of commands,
+  skills, and agents.
+- **Install snippet:** [`INSTALL.md` §3](../INSTALL.md#3-claude-code-skills) —
+  the one-line ask for Claude Code.
+
+## Quick reference
+
+Ask your Claude Code agent:
+
+> Install the BSG Claude skills by following
+> https://raw.githubusercontent.com/beyond-scale-group/bsg-stack/main/claude-skills/INSTALL.md
+
+Claude drops `update-bsg-skills.py` into `~/.claude/scripts/`, runs it
+once, and registers a `SessionStart` hook so every future session
+pulls the latest from `main`. Re-ask any time to force-refresh.

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -1,0 +1,18 @@
+# Renovate Presets
+
+Shared Renovate configuration presets for repos in the BSG portfolio.
+
+- **Component README:** [`renovate/README.md`](../renovate/README.md) — what each
+  preset does, philosophy, how to add a new one.
+- **Install snippet:** [`INSTALL.md` §2](../INSTALL.md#2-renovate-presets) —
+  one-liner for your repo's `renovate.json`.
+
+## Quick reference
+
+| Preset | Use for |
+|--------|---------|
+| `github>beyond-scale-group/bsg-stack//renovate/scala_config` | sbt / Scala projects |
+| `github>beyond-scale-group/bsg-stack//renovate/react_config` | npm / React projects |
+
+Both presets automerge patch and minor updates, hold majors for human
+review, and limit PR concurrency to avoid flooding CI.

--- a/docs/reorganisation-plan.md
+++ b/docs/reorganisation-plan.md
@@ -243,6 +243,12 @@ All via `git mv` so history follows. `.github/workflows/` (flat — GitHub const
 
 ## Current status
 
-- [x] Root `INSTALL.md` created (Phase 1.6 prerequisite).
+- [x] Root `INSTALL.md` created (Phase 1.6).
 - [x] This plan document saved (`docs/reorganisation-plan.md`).
-- [ ] Phase 0 pending.
+- [x] `renovate/README.md` added (Phase 1.1).
+- [x] `claude-skills/README.md` added (Phase 1.2).
+- [x] `docs/renovate.md` + `docs/claude-skills.md` added (Phase 1.3).
+- [x] `stack.yaml` added (Phase 1.4).
+- [x] Root `README.md` cross-links updated (Phase 1.5).
+- [ ] `stack.yaml` CI lint (Phase 1.7) — deferred.
+- [ ] Phase 0 (GitHub repo rename) pending.

--- a/docs/reorganisation-plan.md
+++ b/docs/reorganisation-plan.md
@@ -1,0 +1,248 @@
+# BSG Stack — Reorganisation Plan
+
+Execution plan for renaming `bsg-workflows` → `bsg-stack` and reorganising
+the repo to reflect the "stack of components" framing.
+
+This plan is grouped into **phases** so each merges independently and the
+breaking parts are isolated behind a `v2` tag. `v1` stays frozen on the
+old names; consumers opt in to `v2` by bumping their `uses:` references.
+
+---
+
+## Target layout
+
+```
+bsg-stack/
+├── README.md                    # Stack overview + philosophy
+├── INSTALL.md                   # Install guide / index of sub-INSTALL.md
+├── CHANGELOG.md
+├── .releaserc
+├── renovate.json                # This repo's own renovate config
+├── stack.yaml                   # NEW — declarative component manifest
+│
+├── .github/
+│   └── workflows/               # Flat (GitHub constraint) with category prefixes
+│       ├── test-scala.yaml
+│       ├── test-react-vite.yaml
+│       ├── report-cobertura.yaml
+│       ├── report-junit.yaml
+│       ├── release-semantic.yaml
+│       ├── release-pr-lint.yaml
+│       ├── release-branch-create.yaml
+│       ├── deploy-clever-cloud.yaml
+│       ├── deploy-docker.yaml
+│       ├── deploy-review-app.yaml
+│       ├── auto-sync-branches.yaml
+│       ├── auto-sync-branches-ai.yaml
+│       ├── auto-pr-create.yaml
+│       ├── auto-pr-add-project.yaml
+│       ├── auto-notify-discord.yaml
+│       ├── maint-cleanup-artifacts.yaml
+│       └── ci-claude-skills-test.yaml   # internal
+│
+├── renovate/                    # Component: dependency presets
+│   ├── README.md                        # NEW
+│   ├── scala.json                       # was: scala_config.json
+│   └── react.json                       # was: react_config.json
+│
+├── claude-skills/               # Component: shared Claude Code skills
+│   ├── README.md                        # NEW
+│   ├── INSTALL.md                       # source of truth for skills install
+│   ├── manifest.json                    # NEW — explicit index
+│   ├── agents/
+│   ├── commands/
+│   ├── skills/
+│   ├── scripts/
+│   └── tests/
+│
+└── docs/
+    ├── workflows.md                     # single-file index (Ctrl-F friendly)
+    ├── workflows/                       # NEW — per-workflow deep-dives (future)
+    ├── renovate.md                      # NEW
+    ├── claude-skills.md                 # NEW (thin — links to claude-skills/INSTALL.md)
+    ├── migration-v2.md                  # NEW — old→new mapping for consumers
+    └── reorganisation-plan.md           # THIS FILE
+```
+
+### Design rationale
+
+| Change | Rationale |
+|--------|-----------|
+| Category prefix on workflow filenames (`test-`, `deploy-`, `release-`, `auto-`, `maint-`, `report-`, `ci-`) | GitHub forces a flat dir under `.github/workflows/`. Prefixes give "folders for free" via alphabetical sort + consistent grep. Matches how the README already groups them. |
+| Dash over underscore | GitHub community + marketplace convention. One-time pain preserved behind `@v1`. |
+| `renovate/scala.json` vs `scala_config.json` | `_config` is redundant inside `renovate/`. |
+| `README.md` in each component dir | Makes each folder browsable standalone on GitHub. The stack philosophy is "each piece is a real component" — treat them that way. |
+| `docs/workflows/` reserved subdir | Not populated now; home for deep-dives when a workflow is complex enough (e.g. `deploy-review-app` is already 314 lines). |
+| No split of `workflows.md` yet | 319-line single file is still easier to Ctrl-F than 17 small files. Defer. |
+
+### Deliberate non-changes
+
+- **Not renaming `.github/`** — GitHub-mandated.
+- **Not adopting per-component independent semver** — monorepo versioning (one `@v2` tag for the whole stack) is simpler for the portfolio's mental model ("pin the stack, not each piece"). Revisit only if one component churns much faster than the rest.
+- **Not moving to `packages/` or `apps/` monorepo layout** — would obscure the flat "here are the reusable workflows" story that makes this repo easy to consume.
+
+---
+
+## Phase 0 — Pre-flight (no code changes)
+
+**Goal:** make the rename reversible and communicate it.
+
+- [ ] **0.1** Enumerate portfolio-repo consumers: `gh search code 'beyond-scale-group/bsg-workflows' --owner beyond-scale-group` (or grep across cloned portfolio repos).
+- [ ] **0.2** Decide tag strategy: keep `v1` frozen, cut `v2` at the end of Phase 3. No retagging of `v1`.
+- [ ] **0.3** Rename GitHub repo `beyond-scale-group/bsg-workflows` → `beyond-scale-group/bsg-stack`. GitHub installs a permanent redirect; `uses: beyond-scale-group/bsg-workflows/.github/workflows/scala_test.yaml@v1` keeps working.
+- [ ] **0.4** Verify redirect: trigger one CI in a portfolio repo against `@v1` post-rename, confirm green.
+- [ ] **0.5** Locally: `git remote set-url origin git@github.com:beyond-scale-group/bsg-stack.git` (auto after rename; verify).
+
+**Rollback:** GitHub repo rename is reversible within 30 days by renaming back.
+
+---
+
+## Phase 1 — Additive structural changes (PR 1, non-breaking)
+
+**Goal:** land the "stack of components" framing without touching existing consumers.
+
+Single PR: `chore: adopt stack component layout (additive)`.
+
+- [ ] **1.1** Add `renovate/README.md` — what each preset does, how to consume, how to add a new preset.
+- [ ] **1.2** Add `claude-skills/README.md` — component overview linking to existing `INSTALL.md` (don't duplicate install steps).
+- [ ] **1.3** Add `docs/renovate.md` and `docs/claude-skills.md` — thin pages linking back to the component dirs.
+- [ ] **1.4** Add `stack.yaml` at repo root:
+  ```yaml
+  version: 1                 # manifest schema, not stack version
+  stack_version: v1          # current stack tag
+  components:
+    workflows:
+      path: .github/workflows
+    renovate:
+      path: renovate
+      presets: [scala, react]
+    claude-skills:
+      path: claude-skills
+      manifest: claude-skills/manifest.json
+  ```
+- [ ] **1.5** Update root `README.md` §"What's in the Box" to link each component's own README.
+- [ ] **1.6** Root `INSTALL.md` already exists — cross-link from `README.md` Quick Start.
+- [ ] **1.7** Extend `.github/workflows/claude_skills_test.yaml` (or add `ci-validate-stack.yaml`) to lint `stack.yaml` — sanity check that declared paths exist.
+
+Merge & tag as `v1.x.y` via existing semantic-release — still backwards compatible.
+
+---
+
+## Phase 2 — Rename Renovate presets (PR 2, minor breaking)
+
+**Goal:** smallest surface, isolate breakage.
+
+Single PR: `refactor(renovate): rename presets, drop redundant _config suffix`.
+
+- [ ] **2.1** `git mv renovate/scala_config.json renovate/scala.json`
+- [ ] **2.2** `git mv renovate/react_config.json renovate/react.json`
+- [ ] **2.3** Keep **stub files** `scala_config.json` and `react_config.json` for one release cycle, each with `{ "extends": ["./scala.json"] }` so existing callers don't break mid-rename.
+- [ ] **2.4** Update `README.md`, `renovate/README.md`, `docs/renovate.md`, and root `INSTALL.md` with new names + "Deprecation: old names removed in `v2`" notice.
+- [ ] **2.5** Update `stack.yaml` `presets` list if it references filenames.
+
+Merge & tag as `v1.(next minor)`. Flag the `v2` removal in the PR body.
+
+---
+
+## Phase 3 — Workflow renames + `v2` cut (PR 3, breaking)
+
+**Goal:** the breaking rename, done all at once behind a `v2` tag so callers opt in.
+
+Single PR: `feat!: reorganise workflows with category prefixes (v2)`.
+
+### 3.1 File renames
+
+All via `git mv` so history follows. `.github/workflows/` (flat — GitHub constraint):
+
+| Old name | New name |
+|----------|----------|
+| `scala_test.yaml` | `test-scala.yaml` |
+| `react_vite_test.yaml` | `test-react-vite.yaml` |
+| `cobertura_report.yaml` | `report-cobertura.yaml` |
+| `junit_report.yaml` | `report-junit.yaml` |
+| `semantic_release.yaml` | `release-semantic.yaml` |
+| `semantic_pull_request.yaml` | `release-pr-lint.yaml` |
+| `create_release_branch.yaml` | `release-branch-create.yaml` |
+| `clever_cloud_deploy.yaml` | `deploy-clever-cloud.yaml` |
+| `docker_build_and_push.yaml` | `deploy-docker.yaml` |
+| `review_app_deploy.yaml` | `deploy-review-app.yaml` |
+| `sync_branches.yaml` | `auto-sync-branches.yaml` |
+| `sync_branches_with_ai.yaml` | `auto-sync-branches-ai.yaml` |
+| `github_pull_request.yaml` | `auto-pr-create.yaml` |
+| `pr_auto_add_project.yaml` | `auto-pr-add-project.yaml` |
+| `discord_notifier.yaml` | `auto-notify-discord.yaml` |
+| `cleanup_artifacts.yaml` | `maint-cleanup-artifacts.yaml` |
+| `claude_skills_test.yaml` | `ci-claude-skills-test.yaml` _(internal; optional)_ |
+
+### 3.2 Cross-reference updates in this repo
+
+- [ ] `docs/workflows.md` — rewrite every `uses:` example to the new path.
+- [ ] `README.md` — Quick Start block + §"What's in the Box" tables.
+- [ ] `INSTALL.md` — `uses:` snippet.
+- [ ] `stack.yaml` — bump `stack_version: v2`.
+- [ ] `claude-skills/scripts/update-bsg-skills.py` — grep for hard-coded workflow names.
+- [ ] Any workflow that `uses:` a sibling workflow in this repo — grep `uses: ./` and `uses: beyond-scale-group/`.
+
+### 3.3 Migration doc
+
+- [ ] Create `docs/migration-v2.md` with the exact old→new table above plus the copy-pasteable find/replace recipe for consumer repos:
+  ```
+  beyond-scale-group/bsg-workflows → beyond-scale-group/bsg-stack
+  /scala_test.yaml@v1               → /test-scala.yaml@v2
+  … (full table)
+  ```
+- [ ] Link from root `README.md` above the Quick Start.
+
+### 3.4 Release
+
+- [ ] Use a conventional commit with `!` (e.g. `feat!: …`) or a `BREAKING CHANGE:` footer so semantic-release cuts `v2.0.0`.
+- [ ] Verify the `v2` moving tag exists (default semantic-release creates `v2.0.0`; may need a small workflow to maintain `v2` / `v1` majors — check `semantic_release.yaml`, add if missing).
+
+**Rollback:** `v1` tag still points at old filenames — consumers stay on `@v1` until they migrate.
+
+---
+
+## Phase 4 — Portfolio sweep (out of this repo)
+
+**Goal:** migrate callers off `@v1`/old names.
+
+- [ ] **4.1** Enumerate callers: `gh search code 'beyond-scale-group/bsg-workflows' --owner beyond-scale-group` (or grep across cloned portfolio repos).
+- [ ] **4.2** Per repo: open a PR updating `uses:` paths and tags to `@v2` with new names. Small, mechanical PRs — one per repo.
+- [ ] **4.3** Track migration progress in a checklist issue on `beyond-scale-group/bsg-stack`.
+
+---
+
+## Phase 5 — Cleanup (PR 4, once portfolio is on `v2`)
+
+**Goal:** remove the Phase 2 stub files now that nothing references them.
+
+- [ ] **5.1** Delete `renovate/scala_config.json`, `renovate/react_config.json` stubs.
+- [ ] **5.2** Remove deprecation notices from docs.
+- [ ] **5.3** Tag as `v2.x.y`.
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Portfolio repo builds break mid-rename | GitHub redirect + `@v1` frozen → zero-break until the consumer opts in to `@v2`. |
+| Missed internal cross-reference in Phase 3 | Before merging PR 3, manually trigger each workflow with `workflow_dispatch` where possible; run `claude_skills_test` end-to-end. |
+| `v2` moving tag not maintained | Check current `semantic_release.yaml` — if it doesn't update major aliases, add a small step to force-push `v2` after each release. |
+| Someone later adds a workflow without a category prefix | Lint step in Phase 1.7: validate each `.github/workflows/*.yaml` name matches `^(test\|report\|release\|deploy\|auto\|maint\|ci)-`. |
+
+---
+
+## Open questions
+
+1. Is there a canonical list of portfolio repos consuming `bsg-workflows`, or do we discover via `gh search` in Phase 0.1?
+2. `v2` moving-tag job — add in Phase 1 or defer to Phase 3?
+3. Are internal-only workflows (`claude_skills_test.yaml`) in scope for the rename, or leave as-is since they have no external callers?
+
+---
+
+## Current status
+
+- [x] Root `INSTALL.md` created (Phase 1.6 prerequisite).
+- [x] This plan document saved (`docs/reorganisation-plan.md`).
+- [ ] Phase 0 pending.

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -1,0 +1,56 @@
+# Renovate Presets
+
+Shared [Renovate](https://docs.renovatebot.com/) configuration for repos in
+the BSG portfolio. Using a preset keeps dependency-update behaviour
+consistent across acquisitions without copy-pasting config into every repo.
+
+## Presets
+
+| File | Use for | Notes |
+|------|---------|-------|
+| `scala_config.json` | sbt / Scala projects | Automerges patch + minor, holds majors, splits sbt minor/patch updates. Hourly PR limit: 2. |
+| `react_config.json` | npm / React projects | Automerges patch + minor, holds majors, splits npm minor/patch updates. Hourly PR limit: 5. |
+
+Common defaults in both presets:
+
+- `baseBranches: ["main"]`
+- `platformAutomerge: true`
+- `rebaseWhen: "auto"`
+- `prConcurrentLimit` set to avoid Renovate flooding CI
+
+## How to install
+
+In your repo's `renovate.json`:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>beyond-scale-group/bsg-stack//renovate/scala_config"
+  ]
+}
+```
+
+Replace `scala_config` with `react_config` for frontend repos. `extends`
+is merged, not replaced — override any rule inline in your own
+`renovate.json`.
+
+See the root [`INSTALL.md`](../INSTALL.md#2-renovate-presets) for more
+examples.
+
+## Adding a new preset
+
+1. Create `renovate/<stack>_config.json` in this directory.
+2. Keep it minimal — only settings that should apply to every repo of that
+   stack type. Repo-specific tuning belongs in the caller's `renovate.json`.
+3. Add a row to the table above.
+4. Update the root [`INSTALL.md`](../INSTALL.md#2-renovate-presets) with
+   the new preset path.
+5. Open a PR.
+
+## Philosophy
+
+Presets encode the group's default trust stance: minor and patch updates
+are safe to automerge (backed by CI), majors are human-gated. If a repo
+needs tighter or looser behaviour, override locally rather than forking
+the preset.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,34 @@
+# BSG Stack manifest
+#
+# Declarative index of the components that make up the stack at this tag.
+# Consumers and internal tooling (skill installer, lint workflows, future
+# portfolio-sweep scripts) can parse this instead of scraping the README.
+#
+# - version:       schema version of THIS manifest format (bump on breaking changes)
+# - stack_version: the stack's current major tag — callers pin to this
+# - components:    what the stack currently ships, and where each piece lives
+---
+version: 1
+stack_version: v1
+
+components:
+  workflows:
+    path: .github/workflows
+    description: Reusable GitHub Actions workflows (test, deploy, release, automation).
+    install: "Reference via `uses:` — see INSTALL.md §1."
+    docs: docs/workflows.md
+
+  renovate:
+    path: renovate
+    description: Shared Renovate presets for dependency updates.
+    install: "Reference via `extends` in renovate.json — see INSTALL.md §2."
+    docs: docs/renovate.md
+    presets:
+      - scala_config
+      - react_config
+
+  claude-skills:
+    path: claude-skills
+    description: Shared Claude Code slash commands, skills, and subagents.
+    install: "Claude-driven installer — see claude-skills/INSTALL.md."
+    docs: docs/claude-skills.md


### PR DESCRIPTION
## Summary
- Add root `INSTALL.md` as the install index for the BSG Stack: inline snippets for workflows (`uses:`) and renovate (`extends`), plus a pointer to `claude-skills/INSTALL.md` for the one component with a full installer.
- Save `docs/reorganisation-plan.md` capturing the phased `bsg-workflows` → `bsg-stack` reorganisation: target layout, Phase 0–5 checklists, full workflow rename table, risks, and open questions.
- Both additions are non-breaking — Phase 1 of the plan. No existing consumers are affected.

## Testing
- Not run (docs-only change, not requested)
