### PR TITLE
refactor(renovate): rename presets, drop redundant _config suffix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ using Renovate's cross-repo preset syntax:
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>beyond-scale-group/bsg-stack//renovate/scala_config"
+    "github>beyond-scale-group/bsg-stack//renovate/scala"
   ]
 }
 ```
@@ -68,12 +68,17 @@ Available presets (pick whichever matches your project):
 
 | Preset | Use for |
 |--------|---------|
-| `github>beyond-scale-group/bsg-stack//renovate/scala_config` | sbt / Scala projects |
-| `github>beyond-scale-group/bsg-stack//renovate/react_config` | npm / React projects |
+| `github>beyond-scale-group/bsg-stack//renovate/scala` | sbt / Scala projects |
+| `github>beyond-scale-group/bsg-stack//renovate/react` | npm / React projects |
 
 Both presets automerge patch and minor updates and hold major updates for
 human review. Override any rule in your own `renovate.json` — `extends` is
 merged, not replaced.
+
+> **Deprecation:** the old paths `renovate/scala_config` and
+> `renovate/react_config` still work (they re-extend the new names) but
+> will be removed in **`v2`**. Update your `renovate.json` at your
+> convenience.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ For detailed inputs, secrets, and usage examples for each workflow, see
 Shareable dependency management presets in [`renovate/`](renovate/) — see
 [`renovate/README.md`](renovate/README.md) for details:
 
-- `scala_config.json` — sbt projects (automerge patch/minor, manual major)
-- `react_config.json` — npm projects (automerge patch/minor, manual major)
+- `scala.json` — sbt projects (automerge patch/minor, manual major)
+- `react.json` — npm projects (automerge patch/minor, manual major)
+
+> The old paths `scala_config.json` / `react_config.json` remain as
+> compatibility stubs and will be removed in `v2`.
 
 ### Claude Code Skills
 

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -11,8 +11,13 @@ Shared Renovate configuration presets for repos in the BSG portfolio.
 
 | Preset | Use for |
 |--------|---------|
-| `github>beyond-scale-group/bsg-stack//renovate/scala_config` | sbt / Scala projects |
-| `github>beyond-scale-group/bsg-stack//renovate/react_config` | npm / React projects |
+| `github>beyond-scale-group/bsg-stack//renovate/scala` | sbt / Scala projects |
+| `github>beyond-scale-group/bsg-stack//renovate/react` | npm / React projects |
 
 Both presets automerge patch and minor updates, hold majors for human
 review, and limit PR concurrency to avoid flooding CI.
+
+> **Deprecation:** the old paths `renovate/scala_config` and
+> `renovate/react_config` still work (they re-extend the new names) but
+> will be removed in **`v2`**. Update your `renovate.json` at your
+> convenience.

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -8,8 +8,10 @@ consistent across acquisitions without copy-pasting config into every repo.
 
 | File | Use for | Notes |
 |------|---------|-------|
-| `scala_config.json` | sbt / Scala projects | Automerges patch + minor, holds majors, splits sbt minor/patch updates. Hourly PR limit: 2. |
-| `react_config.json` | npm / React projects | Automerges patch + minor, holds majors, splits npm minor/patch updates. Hourly PR limit: 5. |
+| `scala.json` | sbt / Scala projects | Automerges patch + minor, holds majors, splits sbt minor/patch updates. Hourly PR limit: 2. |
+| `react.json` | npm / React projects | Automerges patch + minor, holds majors, splits npm minor/patch updates. Hourly PR limit: 5. |
+
+> **Deprecation:** `scala_config.json` and `react_config.json` remain as compatibility stubs that re-extend the new names. They will be removed in **`v2`**. Migrate callers to the new paths at your convenience.
 
 Common defaults in both presets:
 
@@ -26,12 +28,12 @@ In your repo's `renovate.json`:
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>beyond-scale-group/bsg-stack//renovate/scala_config"
+    "github>beyond-scale-group/bsg-stack//renovate/scala"
   ]
 }
 ```
 
-Replace `scala_config` with `react_config` for frontend repos. `extends`
+Replace `scala` with `react` for frontend repos. `extends`
 is merged, not replaced — override any rule inline in your own
 `renovate.json`.
 
@@ -40,7 +42,7 @@ examples.
 
 ## Adding a new preset
 
-1. Create `renovate/<stack>_config.json` in this directory.
+1. Create `renovate/<stack>.json` in this directory.
 2. Keep it minimal — only settings that should apply to every repo of that
    stack type. Repo-specific tuning belongs in the caller's `renovate.json`.
 3. Add a row to the table above.

--- a/renovate/react.json
+++ b/renovate/react.json
@@ -1,0 +1,27 @@
+{
+  "baseBranches": ["main"],
+  "platformAutomerge": true,
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 5,
+  "rebaseWhen": "auto",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "groupName": "all patch updates",
+      "groupSlug": "all-patch",
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "matchManagers": ["npm"],
+      "separateMinorPatch": true
+    }
+  ]
+}

--- a/renovate/react_config.json
+++ b/renovate/react_config.json
@@ -1,27 +1,5 @@
 {
-  "baseBranches": ["main"],
-  "platformAutomerge": true,
-  "prHourlyLimit": 5,
-  "prConcurrentLimit": 5,
-  "rebaseWhen": "auto",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch"],
-      "groupName": "all patch updates",
-      "groupSlug": "all-patch",
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["minor"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    },
-    {
-      "matchManagers": ["npm"],
-      "separateMinorPatch": true
-    }
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "DEPRECATED — use `renovate/react` instead. Kept as a compatibility stub; will be removed in v2.",
+  "extends": ["github>beyond-scale-group/bsg-stack//renovate/react"]
 }

--- a/renovate/scala.json
+++ b/renovate/scala.json
@@ -1,0 +1,27 @@
+{
+  "baseBranches": ["main"],
+  "platformAutomerge": true,
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 3,
+  "rebaseWhen": "auto",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "groupName": "all patch updates",
+      "groupSlug": "all-patch",
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "matchDatasources": ["sbt"],
+      "separateMinorPatch": true
+    }
+  ]
+}

--- a/renovate/scala_config.json
+++ b/renovate/scala_config.json
@@ -1,27 +1,5 @@
 {
-  "baseBranches": ["main"],
-  "platformAutomerge": true,
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "auto",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch"],
-      "groupName": "all patch updates",
-      "groupSlug": "all-patch",
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["minor"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    },
-    {
-      "matchDatasources": ["sbt"],
-      "separateMinorPatch": true
-    }
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "DEPRECATED — use `renovate/scala` instead. Kept as a compatibility stub; will be removed in v2.",
+  "extends": ["github>beyond-scale-group/bsg-stack//renovate/scala"]
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,6 +24,10 @@ components:
     install: "Reference via `extends` in renovate.json — see INSTALL.md §2."
     docs: docs/renovate.md
     presets:
+      - scala
+      - react
+    # Compatibility stubs kept for one release cycle; removed in v2.
+    deprecated_presets:
       - scala_config
       - react_config
 


### PR DESCRIPTION
## Summary

- `renovate/scala_config.json` → `renovate/scala.json`
- `renovate/react_config.json` → `renovate/react.json`
- Old paths kept as **compat stubs** (re-extend the new names) — removed in `v2`.
- Docs updated: `README.md`, `renovate/README.md`, `docs/renovate.md`, `INSTALL.md`, `stack.yaml`.

## Why

Per the [reorganisation plan](../blob/main/docs/reorganisation-plan.md) Phase 2:

> `_config` is redundant inside `renovate/`.

Smallest-surface breaking change, isolated from the larger Phase 3 rename so the deprecation clock can start ticking now.

## Plan deviation — worth calling out

The plan suggested stubs of the form `{ "extends": ["./scala.json"] }` (relative path). Renovate's preset resolver doesn't support relative file extends — presets are fetched as remote refs. I used the canonical cross-repo form instead:

```json
{
  "extends": ["github>beyond-scale-group/bsg-stack//renovate/scala"]
}
```

This works today from any caller that extended the old path.

## Caller impact

- Callers using `github>beyond-scale-group/bsg-stack//renovate/scala_config` → unaffected (stub delegates to the new preset).
- Callers using the new path immediately → just works.
- No known current callers use either form (found via `gh search` in beyond-scale-group/bsg-stack#23 Phase 0.1 — portfolio hasn't adopted the Renovate presets yet).

## Refs

- Tracking: beyond-scale-group/bsg-stack#23 (Phase 2)
- Plan: [`docs/reorganisation-plan.md`](../blob/main/docs/reorganisation-plan.md#phase-2--rename-renovate-presets-pr-2-minor-breaking)

## Test plan

- [ ] `semantic-pull-request` check passes (conventional `refactor(renovate):` title)
- [ ] Renovate preset validator (if CI runs it) is green on new files
- [ ] Manual: in a test repo, point `extends` at `github>beyond-scale-group/bsg-stack//renovate/scala_config@refactor/renovate-preset-names` and confirm the stub resolves to the real preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)