### PR TITLE
feat(settings): ship managed settings template + PO agent design docs

### DIFF
--- a/.github/workflows/ci-claude-skills-test.yaml
+++ b/.github/workflows/ci-claude-skills-test.yaml
@@ -19,3 +19,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run unit tests
         run: python3 claude-skills/tests/test_skills.py
+
+  integration:
+    name: po-report integration test (edomata)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Public repos only; read-only API calls. GITHUB_TOKEN is sufficient.
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify required tooling
+        run: |
+          gh --version
+          jq --version
+          git --version
+      - name: Run po-report integration test against beyond-scale-group/edomata
+        run: python3 claude-skills/tests/test_po_report_integration.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# macOS Finder metadata — never committed.
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+Project instructions for [Claude Code](https://claude.com/claude-code) sessions
+in this repository.
+
+## What this repo is
+
+`beyond-scale-group/bsg-stack` — source of truth for the BSG shared Claude Code
+**commands, skills, and subagents**, plus the Renovate presets consumed across
+the org. Files under `claude-skills/` are cached into every developer's
+`~/.claude/` via the installer; files under `renovate/` are referenced by
+tracked repos' `renovate.json`.
+
+## Design principles for agents and skills
+
+### Pure Claude-driven, per-repo, on-demand
+
+Every agent or skill in `claude-skills/` runs **only when a human asks for it**,
+from inside the target repository. Primary invocation is a subagent mention or
+slash command:
+
+```
+@po-manager give me the full status
+/babysit bun run build
+```
+
+Headless one-shot for scripted use:
+
+```bash
+claude -p "@po-manager run a full status report and commit the results"
+```
+
+**Do not add CI automation for these agents.** No reusable GitHub Actions
+workflows, no scheduled cron jobs, no `repo_dispatch` orchestrators. Every run
+must be initiated by a human so each run is visible, intentional, and
+repo-scoped. If persistent state is needed, commit the agent's output to the
+target repo at a stable path (e.g. `po/`) — git history is the trend store.
+
+Escalating to CI automation requires explicit approval.
+
+### BSG-managed settings in `~/.claude/settings.json`
+
+`claude-skills/settings.json` is merged by the BSG updater into each
+developer's `~/.claude/settings.json` on every run. The merge is narrow —
+only the keys listed in `BSG_MANAGED_SETTINGS_KEYS` and
+`BSG_MANAGED_MCP_SERVERS` inside `update-bsg-skills.py` are touched; all
+other user-owned settings are preserved. Today that's:
+
+- `autoMemoryEnabled: false` — disables the Claude Code auto-memory system
+  so durable context lives in `CLAUDE.md` files and committed agent outputs
+  (e.g. `po/`) rather than a per-project memory store.
+- `mcpServers.context7` — pre-registers the Context7 MCP server so library
+  documentation lookups are available automatically in every session.
+
+See [`claude-skills/INSTALL.md`](claude-skills/INSTALL.md#settings-merged-into-claudesettingsjson)
+for the full list of managed keys and how to add or remove one.
+
+### Data lives in the target repo, not centrally
+
+Agents that produce reports or plans write them into the repo they were invoked
+in, at a root-level folder (e.g. `po/`), and commit them. No central portfolio
+folder, no cross-repo database. "One repo, one agent, one plan."
+
+### Scripts before LLM
+
+Inside a skill, deterministic bash + jq scripts do the aggregation and
+computation (counts, risk flags, tree walks). The LLM only narrates the
+results. Agents should never re-derive numbers the scripts already emit.
+
+## Contributing to the shared catalog
+
+Files in `~/.claude/` on a developer's machine are cached copies — they get
+overwritten on every install or SessionStart run. Always PR back here instead
+of editing the local copies. See [`claude-skills/INSTALL.md`][install] for the
+full add-a-skill checklist and required footer.
+
+[install]: claude-skills/INSTALL.md#adding-a-new-command-skill-or-agent-to-the-catalog

--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -42,6 +42,33 @@ No git clone, no script to run, no cron to set up.
 |------|-------------|
 | `po-manager` | Product owner / project manager orchestrator subagent. Delegated to for status reports, milestone progress, sprint health, stale ticket detection, standup summaries. Uses the `po-report` skill for reporting and `daily-standup` for meeting parsing. Reporting only — does not implement features. |
 
+## Settings merged into `~/.claude/settings.json`
+
+`claude-skills/settings.json` is the BSG-managed settings template. The
+BSG updater **merges specific keys** from it into the user's
+`~/.claude/settings.json` on every run, alongside the existing
+SessionStart hook it registers. Other keys in `~/.claude/settings.json`
+are left untouched.
+
+Currently-managed keys:
+
+| Key | Effect |
+|---|---|
+| `autoMemoryEnabled` | Set to `false` — disables the Claude Code auto-memory system globally so durable context lives in project `CLAUDE.md` files and committed agent outputs (`po/`, reports, etc.) instead of per-project memory stores. |
+| `mcpServers.context7` | Pre-registers the [Context7](https://context7.com) MCP server so documentation lookups (React, Next.js, library APIs, …) are available in every session with no per-session setup. Honors `CONTEXT7_API_KEY` if set; works on the public-rate tier otherwise. |
+
+The merge is **idempotent** and **narrow**:
+
+- Only the keys listed in `BSG_MANAGED_SETTINGS_KEYS` and
+  `BSG_MANAGED_MCP_SERVERS` inside `update-bsg-skills.py` are touched.
+- Other top-level keys (including other `mcpServers.*` entries you've
+  configured) are preserved exactly as they are.
+- If `~/.claude/settings.json` is not valid JSON, the updater logs a
+  warning and refuses to modify the file.
+
+To add or remove a managed key, edit `claude-skills/settings.json` **and**
+update the `BSG_MANAGED_*` lists in the installer in the same PR.
+
 ## How it works under the hood
 
 The whole install flow boils down to: **drop one Python script in

--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -21,9 +21,14 @@ Conflict avoidance:
   - Files removed upstream are removed locally on the next run, but
     only if they are in the manifest, so unrelated files in the same
     directories are never touched.
-  - The settings.json merge is idempotent: it appends a SessionStart
-    entry only if no existing entry already references this script. It
-    refuses to touch the file if it is not valid JSON.
+  - The settings.json merge is idempotent on two fronts:
+      * The SessionStart hook is appended only if no existing entry
+        already references this script.
+      * BSG-managed keys from claude-skills/settings.json
+        (currently: autoMemoryEnabled, mcpServers.context7) are
+        overwritten to the upstream value; all other keys in
+        ~/.claude/settings.json are left untouched.
+    Refuses to touch the file if it is not valid JSON.
 
 Network errors are swallowed (exit 0) so the updater never blocks a
 Claude Code session from starting. Logs to
@@ -47,6 +52,15 @@ from pathlib import Path
 REPO = "beyond-scale-group/bsg-stack"
 BRANCH = "main"
 SCRIPT_NAME = "update-bsg-skills.py"
+
+# Top-level settings keys the BSG updater merges from
+# claude-skills/settings.json into ~/.claude/settings.json on every run.
+# Keys not listed here are left completely alone, so user-owned settings
+# coexist with BSG-managed ones.
+BSG_MANAGED_SETTINGS_KEYS = ["autoMemoryEnabled"]
+# Sub-keys under `mcpServers` that the updater owns. Other MCP servers the
+# user has configured are preserved.
+BSG_MANAGED_MCP_SERVERS = ["context7"]
 
 CLAUDE_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
 COMMANDS_DIR = CLAUDE_DIR / "commands"
@@ -300,12 +314,85 @@ def register_session_hook() -> None:
     log(f"  registered SessionStart hook in {SETTINGS_FILE}")
 
 
+# ---------- BSG-managed settings merge ----------
+
+def fetch_template_settings() -> dict | None:
+    """Download the BSG settings template (claude-skills/settings.json)."""
+    meta = http_get(f"{API_BASE}/claude-skills/settings.json?ref={BRANCH}")
+    if not isinstance(meta, dict):
+        return None
+    url = meta.get("download_url")
+    if not url:
+        return None
+    raw = http_get(url, raw=True)
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError:
+        log("  BSG settings template is not valid JSON")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def merge_bsg_settings() -> None:
+    """
+    Merge BSG-managed keys from claude-skills/settings.json into
+    ~/.claude/settings.json. Only the keys listed in
+    BSG_MANAGED_SETTINGS_KEYS and BSG_MANAGED_MCP_SERVERS are touched;
+    every other user-owned setting is preserved untouched.
+
+    Idempotent: re-running with no upstream changes is a no-op.
+    """
+    template = fetch_template_settings()
+    if template is None:
+        log("  could not fetch BSG settings template, skipping merge")
+        return
+
+    if SETTINGS_FILE.exists():
+        try:
+            settings = json.loads(SETTINGS_FILE.read_text())
+        except json.JSONDecodeError:
+            log(f"  {SETTINGS_FILE} is not valid JSON, refusing to merge")
+            return
+    else:
+        settings = {}
+    if not isinstance(settings, dict):
+        log(f"  {SETTINGS_FILE} is not a JSON object, refusing to merge")
+        return
+
+    changed = False
+
+    for key in BSG_MANAGED_SETTINGS_KEYS:
+        if key in template and settings.get(key) != template[key]:
+            settings[key] = template[key]
+            changed = True
+
+    t_servers = template.get("mcpServers")
+    if isinstance(t_servers, dict):
+        servers = settings.setdefault("mcpServers", {})
+        if isinstance(servers, dict):
+            for name in BSG_MANAGED_MCP_SERVERS:
+                if name in t_servers and servers.get(name) != t_servers[name]:
+                    servers[name] = t_servers[name]
+                    changed = True
+
+    if not changed:
+        return
+
+    tmp = SETTINGS_FILE.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(settings, indent=2) + "\n")
+    tmp.replace(SETTINGS_FILE)
+    log(f"  merged BSG-managed keys into {SETTINGS_FILE}")
+
+
 # ---------- entry point ----------
 
 def main() -> int:
     setup_dirs()
     setup_logging()
     register_session_hook()
+    merge_bsg_settings()
     manifest = load_manifest()
     manifest = reconcile(manifest)
     save_manifest(manifest)

--- a/claude-skills/settings.json
+++ b/claude-skills/settings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "autoMemoryEnabled": false,
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"],
+      "env": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}

--- a/claude-skills/tests/test_po_report_integration.py
+++ b/claude-skills/tests/test_po_report_integration.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Integration test for the po-report skill against beyond-scale-group/edomata.
+
+Runs every po-report script against the real GitHub repo (via `GH_REPO=`
+— no checkout needed) and asserts:
+
+  - JSON-emitting scripts produce well-formed JSON with the expected
+    top-level keys
+  - generate-report.sh produces markdown with the expected section headers
+  - repo-level values (repo slug, invariants between fields) are correct
+
+Assertions are schema-level so the test tolerates edomata's real issue /
+PR / milestone counts drifting over time. No hardcoded counts.
+
+The scripts are invoked from a tmpdir that contains only a minimal
+`git init` + remote pointing at the target repo (no source code
+cloned). That's enough for `gh`'s CWD autodetection to pick the right
+repo — and unlike a real `gh repo clone`, it avoids the fork-upstream
+confusion where a fork clone resolves `gh repo view` to the upstream.
+It's also dramatically faster than a full clone in CI.
+
+Requires: gh (authenticated), jq. In CI, the default GITHUB_TOKEN is
+forwarded to gh via the GH_TOKEN env var in the workflow. The test
+skips itself cleanly if any of those are missing, so running the file
+on a dev machine without `gh auth login` is a no-op rather than a
+failure.
+
+Run locally:
+
+    python3 claude-skills/tests/test_po_report_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "claude-skills" / "skills" / "po-report" / "scripts"
+TARGET = "beyond-scale-group/edomata"
+
+SCRIPT_TIMEOUT_S = 120
+
+
+def _which(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def _gh_authenticated() -> bool:
+    try:
+        r = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return r.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+class TestPoReportIntegration(unittest.TestCase):
+    """End-to-end smoke test of every po-report script against a real repo."""
+
+    tmpdir: "tempfile.TemporaryDirectory | None" = None
+    workdir: Path
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _which("gh"):
+            raise unittest.SkipTest("gh CLI not available")
+        if not _which("jq"):
+            raise unittest.SkipTest("jq not available")
+        if not _gh_authenticated():
+            raise unittest.SkipTest(
+                "gh is not authenticated (set GH_TOKEN or run `gh auth login`)"
+            )
+
+        # Minimal git init + remote pointing at TARGET so `gh`'s CWD
+        # autodetection resolves to the right repo without a real clone.
+        cls.tmpdir = tempfile.TemporaryDirectory(prefix="po-integration-")
+        cls.workdir = Path(cls.tmpdir.name)
+        remote_url = f"https://github.com/{TARGET}.git"
+        for cmd in (
+            ["git", "init", "--quiet"],
+            ["git", "remote", "add", "origin", remote_url],
+        ):
+            subprocess.run(
+                cmd, cwd=cls.workdir, check=True, capture_output=True, text=True
+            )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.tmpdir is not None:
+            cls.tmpdir.cleanup()
+
+    # -- helpers --------------------------------------------------------
+
+    def _run(self, script: str, *args: str) -> str:
+        path = SCRIPTS / script
+        self.assertTrue(path.is_file(), f"script not found: {path}")
+        result = subprocess.run(
+            ["bash", str(path), *args],
+            cwd=self.workdir,
+            capture_output=True,
+            text=True,
+            timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{script} exited {result.returncode}\nSTDERR:\n{result.stderr}",
+        )
+        return result.stdout
+
+    # -- tests ----------------------------------------------------------
+
+    def test_status_script_emits_valid_json(self) -> None:
+        out = self._run("status.sh")
+        data = json.loads(out)
+        self.assertEqual(data.get("repo"), TARGET)
+        for key in (
+            "generatedAt",
+            "issues",
+            "pullRequests",
+            "topLabels",
+            "byAssignee",
+            "oldestOpenPr",
+        ):
+            self.assertIn(key, data)
+        self.assertIn("open", data["issues"])
+        self.assertIn("closed", data["issues"])
+        self.assertIsInstance(data["issues"]["open"], int)
+        self.assertIsInstance(data["issues"]["closed"], int)
+        self.assertIn("open", data["pullRequests"])
+        self.assertIn("draft", data["pullRequests"])
+        self.assertIsInstance(data["topLabels"], list)
+        self.assertIsInstance(data["byAssignee"], list)
+        # Draft count can never exceed open count.
+        self.assertLessEqual(
+            data["pullRequests"]["draft"], data["pullRequests"]["open"]
+        )
+
+    def test_milestone_progress_script_emits_json_array(self) -> None:
+        out = self._run("milestone-progress.sh")
+        data = json.loads(out)
+        self.assertIsInstance(data, list)
+        for m in data:
+            for key in (
+                "number",
+                "title",
+                "state",
+                "open_issues",
+                "closed_issues",
+                "total",
+                "percent_complete",
+                "url",
+            ):
+                self.assertIn(key, m, f"missing key {key!r} in milestone {m!r}")
+            # Sanity: total should equal open + closed.
+            self.assertEqual(m["total"], m["open_issues"] + m["closed_issues"])
+            # percent_complete is bounded.
+            self.assertGreaterEqual(m["percent_complete"], 0)
+            self.assertLessEqual(m["percent_complete"], 100)
+
+    def test_stale_issues_script_emits_json_array(self) -> None:
+        out = self._run("stale-issues.sh", "14")
+        data = json.loads(out)
+        self.assertIsInstance(data, list)
+        for issue in data:
+            for key in (
+                "number",
+                "title",
+                "assignees",
+                "labels",
+                "updatedAt",
+                "daysStale",
+                "url",
+            ):
+                self.assertIn(key, issue, f"missing key {key!r} in {issue!r}")
+            # By construction, an issue only appears here if it's stale >= DAYS.
+            self.assertGreaterEqual(issue["daysStale"], 14)
+            self.assertIsInstance(issue["assignees"], list)
+            self.assertIsInstance(issue["labels"], list)
+
+    def test_generate_report_emits_expected_markdown(self) -> None:
+        out = self._run("generate-report.sh")
+        self.assertIn(f"# PO Report — {TARGET}", out)
+        for header in (
+            "## At a glance",
+            "## Top labels (open issues)",
+            "## Open issues by assignee",
+            "## Milestone progress",
+            "## Stale open issues",
+            "## Oldest open PR",
+        ):
+            self.assertIn(header, out, f"missing section header: {header!r}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/po-agent-plan.md
+++ b/docs/po-agent-plan.md
@@ -1,0 +1,178 @@
+# PO Agent — Implementation Plan (v4)
+
+**Status:** approved outline, not yet implemented
+**Owner:** `claude-skills/agents/po-manager.md` + `claude-skills/skills/po-report/`
+**Scope:** Product Owner agent that runs inside any `beyond-scale-group/*` repo, stores its data and plan updates in that repo, and is launchable repo-by-repo.
+**Smoke-test target:** `beyond-scale-group/edomata`
+
+---
+
+## 1. Principles
+
+1. **One repo, one Product Owner Agent, one plan.** No central portfolio folder, no cross-repo rollup in this plan.
+2. **Facts come from one GraphQL snapshot per run.** Every report is a pure jq transform of that snapshot — reproducible, diff-friendly, zero re-queries.
+3. **Git history is the trend store.** Snapshots and reports are committed, so burndown / velocity / scope-delta are computed from `git log` — no separate database.
+4. **Scripts before LLM.** Risk flags, tree walks, and metrics are computed in bash + jq. The agent only narrates.
+5. **Skill code stays in `bsg-stack`; data stays in each tracked repo.** `bsg-stack` is the single source of truth for the skill; each tracked repo owns its own `po/` directory.
+
+## 2. Data layout — inside each tracked repo
+
+Stored at the **root** of the tracked repo (not under `.claude/`), and committed:
+
+```
+<tracked-repo>/
+└── po/
+    ├── config.yml                 # optional per-repo overrides
+    ├── MAP.md                     # planning map — regenerated every run
+    ├── PLAN.md                    # current-sprint plan — agent writes, humans edit
+    ├── reports/
+    │   └── YYYY-MM-DD-status.md   # dated snapshots, append-only
+    └── history/
+        └── YYYY-MM-DD.json        # full GraphQL snapshot, append-only
+```
+
+- `MAP.md` and `PLAN.md` are overwritten each run. `PLAN.md` preserves sections marked `<!-- human-edited -->` on regeneration.
+- `reports/` and `history/` are append-only. Past files are never modified.
+- Everything is committed to the tracked repo (per Guillaume's decision — traceability).
+
+## 3. Per-repo configuration — `po/config.yml`
+
+All fields optional; defaults documented in `references/setup.md`.
+
+```yaml
+sprint_source: milestones        # or: projectv2
+projectv2_number: null
+stale_days: 14
+priority_labels: [priority:high, bug]
+status_labels: [status:blocked, status:in-review]
+ignore_labels: [duplicate, wontfix]
+commit_reports: true
+```
+
+## 4. Code layout — in `bsg-stack`
+
+```
+bsg-stack/
+└── claude-skills/
+    ├── agents/po-manager.md      # routing + per-repo scope; updated paths
+    └── skills/po-report/
+        ├── SKILL.md
+        ├── references/
+        │   ├── status.md         # existing — paths updated to po/
+        │   ├── milestones.md     # existing — paths updated
+        │   ├── stale.md          # existing
+        │   ├── epic-map.md       # NEW
+        │   ├── pr-flow.md        # NEW
+        │   ├── health-audit.md   # NEW
+        │   └── setup.md          # NEW — @po-manager usage, scopes, first-time init
+        └── scripts/
+            ├── collect.sh        # ONE paginated GraphQL query → history/*.json
+            ├── status.sh         # thin wrapper over collect.sh (compat)
+            ├── milestone-progress.sh
+            ├── stale-issues.sh
+            ├── epic-tree.sh      # NEW — sub-issues → tree + %
+            ├── pr-flow.sh        # NEW — review latency, merge queue, CI
+            ├── health-audit.sh   # NEW — dependabot, branch protection
+            ├── render-status.sh  # JSON → dated status.md
+            ├── render-map.sh     # JSON → MAP.md (overwrite)
+            └── render-plan.sh    # JSON → PLAN.md (merge-preserve)
+```
+
+## 5. The one GraphQL query
+
+`collect.sh` fetches all data needed by every downstream report in one paginated query and writes the full result to `po/history/<date>.json`. Fields:
+
+| Entity | Fields |
+|---|---|
+| Issues | `number, title, state, stateReason, issueType, labels, milestone, assignees, reactions{THUMBS_UP}, subIssues, trackedInIssues, timelineItems(CLOSED_EVENT, LABELED_EVENT), lastCommentedAt` |
+| Pull requests | `number, state, isDraft, reviewDecision, reviews, mergeStateStatus, mergeQueueEntry, statusCheckRollup, closingIssuesReferences, createdAt, mergedAt` |
+| Milestones | `title, dueOn, progressPercentage, openIssueCount, closedIssueCount` |
+| Releases | `tagName, publishedAt` |
+| Branch protection | `pattern, requiredStatusCheckContexts, requiresApprovingReviews` |
+| Vulnerability alerts | `securityVulnerability, dismissedAt` (needs `security_events` scope) |
+| Repo metadata | `topics, defaultBranchRef.target.history(first: 100)` |
+
+All downstream reports are **pure jq** against this file. No re-queries.
+
+## 6. Reports produced
+
+| File | When | Contents |
+|---|---|---|
+| `po/reports/<date>-status.md` | Every run | At-a-glance metrics, top labels, assignee load, milestone progress, stale issues, oldest PR |
+| `po/MAP.md` | Every run (overwritten) | Now / Sprint / Epics / Next up / Blocked / Shipped recently / Risks |
+| `po/PLAN.md` | Every run (merge-preserve) | Current sprint plan with human-editable sections preserved |
+| `po/history/<date>.json` | Every run | Full GraphQL snapshot (audit + trend source) |
+
+`MAP.md` is the "best planning mapping" artifact: parent issues → sub-issue trees → linked PRs → CI state, grouped by status.
+
+## 7. Launch modes — all per-repo, all user-initiated
+
+No CI automation. The agent runs only when a human asks for it, from inside the tracked repo.
+
+1. **Interactive with `@agent` mention** (primary path). Inside `<tracked-repo>`, in any Claude Code session:
+
+   ```
+   @po-manager give me the full status
+   @po-manager où en est le sprint
+   @po-manager list stale issues over 30 days
+   @po-manager rebuild the planning map
+   ```
+
+   The `@po-manager` mention hands the turn to the subagent defined in `claude-skills/agents/po-manager.md`. It runs the `po-report` skill's scripts, writes to `po/`, and returns a 3-bullet summary + the report path.
+
+2. **Headless one-shot.** From any shell inside the tracked repo:
+
+   ```bash
+   claude -p "@po-manager run a full status report and commit the results"
+   ```
+
+   Useful for a user-side cron or an ad-hoc catch-up run. Same behavior as interactive; no session UI.
+
+Documented in `claude-skills/agents/po-manager.md` and `references/setup.md`. No GitHub Actions, no secrets, no scheduled workflow.
+
+## 8. Required GitHub scopes
+
+```
+gh auth refresh -h github.com -s read:org,repo,read:project,security_events
+```
+
+Documented in `references/setup.md`. Private repos, Projects v2, and Dependabot alerts all require these.
+
+## 9. Phasing — three PRs against `bsg-stack`
+
+### PR 1 — Refactor collector to GraphQL, fix known bugs
+- Replace every REST `gh issue list` loop in `status.sh` with one paginated GraphQL query in `collect.sh`.
+- Emit risk flags (`at_risk`, `overdue`, `understaffed`, `stalled`) from jq in `milestone-progress.sh` — currently documented but not computed.
+- Fix multi-assignee aggregation (`.assignees[].login`, not `[0]`).
+- Use `lastCommentedAt` instead of `updatedAt` in `stale-issues.sh` so bot label bumps don't reset staleness.
+- Add PR review metrics (time-to-first-review, review decision mix, merge-queue depth, oldest draft).
+- Update paths from `.claude/reports/` to `po/reports/`.
+- Add `tests/test_po_report.py` with fixture-based tests (PATH-shimmed `gh`).
+- Smoke-test against `beyond-scale-group/edomata`. Auto-memory is already off and Context7 is available in the test session because the BSG updater merges those keys into `~/.claude/settings.json` globally — no per-repo setup needed.
+
+### PR 2 — Planning map, plan, epic tree, PR flow, health audit
+- Add `render-map.sh`, `render-plan.sh`, `epic-tree.sh`, `pr-flow.sh`, `health-audit.sh`.
+- Add references: `epic-map.md`, `pr-flow.md`, `health-audit.md`, `setup.md`.
+- Update `po-manager.md` routing: "planning map", "epic status", "PR health", "security debt".
+- `PLAN.md` merge logic: preserves any section fenced with `<!-- human-edited -->`.
+- Document the `@po-manager` invocation pattern in `setup.md` and in the top of `po-manager.md`.
+
+### PR 3 — Projects v2 path + polish
+- `sprint_source: projectv2` branch in `milestone-progress.sh` and `render-map.sh`.
+- French-localized summaries in `render-status.sh` (matches bilingual triggers already in `po-manager.md`).
+- Velocity and scope-delta computed from `git log` of `po/history/*.json`.
+
+## 10. Open items
+
+- **`po/` vs `.claude/po/`.** Chosen `po/` at root (per Guillaume). The existing `SKILL.md` and `po-manager.md` still reference `.claude/reports/` — updated in PR 1.
+
+## 11. Validation checklist (for PR 1 smoke test)
+
+Against `beyond-scale-group/edomata`:
+
+- [ ] `collect.sh` produces a valid `po/history/<date>.json` in one run.
+- [ ] `status.sh` (wrapped over collect) matches the pre-refactor numbers within rounding.
+- [ ] Multi-assignee issues contribute to each assignee's count (regression check).
+- [ ] `milestone-progress.sh` emits risk flags for at least one milestone with a past due date or low progress.
+- [ ] `stale-issues.sh` ignores issues whose only recent `updatedAt` bump is a label change by a bot.
+- [ ] Fixture-based unit tests pass locally.

--- a/docs/po-agent-plan.md
+++ b/docs/po-agent-plan.md
@@ -1,86 +1,160 @@
-# PO Agent — Implementation Plan (v4)
+# PO Agent — Implementation Plan (v5)
 
 **Status:** approved outline, not yet implemented
 **Owner:** `claude-skills/agents/po-manager.md` + `claude-skills/skills/po-report/`
-**Scope:** Product Owner agent that runs inside any `beyond-scale-group/*` repo, stores its data and plan updates in that repo, and is launchable repo-by-repo.
+**Scope:** Product Owner agent that runs inside any `beyond-scale-group/*` repo, compares that repo's **big plan** (`po/PLAN.md`, authored by humans) against **live GitHub state**, and reports drift. Launchable repo-by-repo, pure Claude-driven.
 **Smoke-test target:** `beyond-scale-group/edomata`
 
 ---
 
-## 1. Principles
+## 1. Mental model — what the PO agent is actually for
 
-1. **One repo, one Product Owner Agent, one plan.** No central portfolio folder, no cross-repo rollup in this plan.
-2. **Facts come from one GraphQL snapshot per run.** Every report is a pure jq transform of that snapshot — reproducible, diff-friendly, zero re-queries.
-3. **Git history is the trend store.** Snapshots and reports are committed, so burndown / velocity / scope-delta are computed from `git log` — no separate database.
-4. **Scripts before LLM.** Risk flags, tree walks, and metrics are computed in bash + jq. The agent only narrates.
-5. **Skill code stays in `bsg-stack`; data stays in each tracked repo.** `bsg-stack` is the single source of truth for the skill; each tracked repo owns its own `po/` directory.
+The PO agent exists to answer **"is this project still following its plan?"** — not "what happened this week."
 
-## 2. Data layout — inside each tracked repo
+That splits the artifacts in `po/` into three roles:
 
-Stored at the **root** of the tracked repo (not under `.claude/`), and committed:
+| Role | File | Who authors it | Mutability |
+|---|---|---|---|
+| **Intent** | `po/PLAN.md` | Humans (agent may propose drafts into `po/drafts/`) | Human-edited, rarely. |
+| **Reality** | `po/MAP.md` | Agent, from live GitHub state | Overwritten every run. |
+| **Adherence** | `po/reports/<date>-status.md` | Agent | Append-only dated snapshot — the diff between Intent and Reality. |
+| **Trend source** | `po/history/<date>.json` | Agent (raw GraphQL snapshot) | Append-only; `git log` on this folder = trend store. |
+
+The **adherence report** is the headline output. Counts and tables are supporting evidence.
+
+## 2. Principles
+
+1. **One repo, one agent, one plan.** No central portfolio folder, no cross-repo rollup.
+2. **Pure Claude-driven, per-repo, on-demand.** No CI automation (see root `CLAUDE.md`).
+3. **`PLAN.md` is input, never output.** The agent reads it, cross-references live state, reports drift. It never overwrites it. Proposed changes land in `po/drafts/` for a human to accept.
+4. **Facts come from one GraphQL snapshot per run.** Every report is a pure jq transform of that snapshot.
+5. **Git history is the trend store.** Reports and snapshots are committed; burndown / velocity / scope-delta come from `git log po/history/`.
+6. **Scripts before LLM.** Risk flags, drift detection, and metrics are computed in bash + jq. The agent narrates.
+7. **Propose, never post.** Agent output always lands as committed markdown. `gh` is only called to *fetch*; anything externally-visible (comments, labels, closes) requires explicit human confirmation.
+
+## 3. Data layout — inside each tracked repo
 
 ```
 <tracked-repo>/
 └── po/
-    ├── config.yml                 # optional per-repo overrides
-    ├── MAP.md                     # planning map — regenerated every run
-    ├── PLAN.md                    # current-sprint plan — agent writes, humans edit
+    ├── PLAN.md                       # HUMAN-AUTHORED source of truth (intent)
+    ├── config.yml                    # optional per-repo overrides
+    ├── MAP.md                        # agent-generated current state (reality)
     ├── reports/
-    │   └── YYYY-MM-DD-status.md   # dated snapshots, append-only
-    └── history/
-        └── YYYY-MM-DD.json        # full GraphQL snapshot, append-only
+    │   └── YYYY-MM-DD-status.md      # adherence report, append-only
+    ├── history/
+    │   └── YYYY-MM-DD.json           # raw GraphQL snapshot, append-only
+    └── drafts/                       # agent proposals awaiting human review
+        ├── PLAN-suggested-YYYY-MM-DD.md
+        ├── triage-YYYY-MM-DD.md
+        └── sprint-plan-YYYY-MM-DD.md
 ```
 
-- `MAP.md` and `PLAN.md` are overwritten each run. `PLAN.md` preserves sections marked `<!-- human-edited -->` on regeneration.
-- `reports/` and `history/` are append-only. Past files are never modified.
-- Everything is committed to the tracked repo (per Guillaume's decision — traceability).
+- `PLAN.md`, `MAP.md`, and the contents of `reports/` / `history/` / `drafts/` are committed to the tracked repo.
+- `PLAN.md` is the **only** file in `po/` the agent never writes to. It appears there after a human accepts the initial draft from `drafts/PLAN-suggested-*.md` (or writes one from scratch).
 
-## 3. Per-repo configuration — `po/config.yml`
+## 4. `PLAN.md` schema
+
+Plain markdown with **inline binding tags** so the parser can cross-reference live GitHub state without fighting a complex format.
+
+```markdown
+# Big plan — <repo-name>
+
+## Objectives
+- Ship the payments redesign by end of Q2   [milestone:Payments-v1]
+- Migrate every service to Postgres 16       [epic:#142]
+- Hire a DevRel engineer                     [label:hire:devrel]
+
+## Milestones
+- Payments-v1 — due 2026-06-30                [milestone:Payments-v1]
+- Postgres migration done                     [milestone:pg16-done]
+
+## Epics
+- Payments redesign                           [epic:#142]
+- Postgres 16 migration                       [epic:#287]
+
+## Decision log
+- 2026-03-04: defer mobile app to H2         [tag:decision]
+```
+
+**Inline tag grammar** (all optional on any bullet):
+- `[milestone:<title>]` — binds the item to a GitHub milestone.
+- `[epic:#<num>]` or `[#<num>]` — binds to a parent issue (epic) by number.
+- `[label:<name>]` — binds to a label query.
+- `[tag:decision]`, `[tag:risk]`, `[tag:deferred]` — free-form markers, used for filtering.
+
+Chosen over YAML frontmatter because humans write and edit this file directly; inline tags keep the document readable. Revisable if parsing gets brittle.
+
+## 5. The adherence report (headline section)
+
+For every item in `PLAN.md`, the agent computes a status from the live snapshot:
+
+| Plan item | Binding | Status | Evidence |
+|---|---|---|---|
+| Ship payments redesign | milestone:Payments-v1 | **At risk** | 40% done, due in 3d |
+| Migrate to Postgres 16 | epic:#287 | On track | 6/10 sub-issues closed, PR #312 open |
+| Hire DevRel | label:hire:devrel | Not started | 0 issues with label |
+| (unplanned) CI flake fix | — | In progress | 3 PRs, no plan anchor |
+
+**Three drift classes** get their own subsection:
+
+- **Plan → ∅ (abandoned)**: plan items with 0 GitHub activity for > N days.
+- **∅ → Reality (scope creep)**: in-flight issues/PRs not bound to any plan item.
+- **Plan ≠ Reality (off-course)**: plan item is supposed to be in-flight but the milestone/label shows it isn't, or vice-versa.
+
+## 6. Per-repo configuration — `po/config.yml`
 
 All fields optional; defaults documented in `references/setup.md`.
 
 ```yaml
-sprint_source: milestones        # or: projectv2
+plan_path: po/PLAN.md
+sprint_source: milestones              # or: projectv2
 projectv2_number: null
 stale_days: 14
+abandoned_plan_item_days: 30           # drift threshold for "Plan → ∅"
 priority_labels: [priority:high, bug]
 status_labels: [status:blocked, status:in-review]
 ignore_labels: [duplicate, wontfix]
+unplanned_work_ignore_labels: [chore, dependencies]   # routine work that doesn't need plan anchoring
 commit_reports: true
 ```
 
-## 4. Code layout — in `bsg-stack`
+## 7. Code layout — in `bsg-stack`
 
 ```
 bsg-stack/
 └── claude-skills/
-    ├── agents/po-manager.md      # routing + per-repo scope; updated paths
+    ├── agents/po-manager.md          # routing + per-repo scope; paths → po/
     └── skills/po-report/
         ├── SKILL.md
         ├── references/
-        │   ├── status.md         # existing — paths updated to po/
-        │   ├── milestones.md     # existing — paths updated
-        │   ├── stale.md          # existing
-        │   ├── epic-map.md       # NEW
-        │   ├── pr-flow.md        # NEW
-        │   ├── health-audit.md   # NEW
-        │   └── setup.md          # NEW — @po-manager usage, scopes, first-time init
+        │   ├── adherence.md          # NEW — primary reference (plan vs reality)
+        │   ├── plan-schema.md        # NEW — PLAN.md tag grammar + bootstrap
+        │   ├── status.md             # existing — demoted to "supporting evidence"
+        │   ├── milestones.md
+        │   ├── stale.md
+        │   ├── epic-map.md           # NEW
+        │   ├── pr-flow.md            # NEW
+        │   ├── health-audit.md       # NEW
+        │   └── setup.md              # NEW — @po-manager usage, scopes
         └── scripts/
-            ├── collect.sh        # ONE paginated GraphQL query → history/*.json
-            ├── status.sh         # thin wrapper over collect.sh (compat)
+            ├── collect.sh            # ONE paginated GraphQL query → history/*.json
+            ├── parse-plan.sh         # NEW — PLAN.md → JSON of plan items + bindings
+            ├── adherence.sh          # NEW — join plan items with snapshot → matrix + drift
             ├── milestone-progress.sh
             ├── stale-issues.sh
-            ├── epic-tree.sh      # NEW — sub-issues → tree + %
-            ├── pr-flow.sh        # NEW — review latency, merge queue, CI
-            ├── health-audit.sh   # NEW — dependabot, branch protection
-            ├── render-status.sh  # JSON → dated status.md
-            ├── render-map.sh     # JSON → MAP.md (overwrite)
-            └── render-plan.sh    # JSON → PLAN.md (merge-preserve)
+            ├── epic-tree.sh          # NEW — sub-issues → tree + %
+            ├── pr-flow.sh            # NEW — review latency, merge queue, CI
+            ├── health-audit.sh       # NEW — dependabot, branch protection
+            ├── bootstrap-plan.sh     # NEW — propose drafts/PLAN-suggested-<date>.md
+            ├── render-status.sh      # JSON → dated adherence report
+            ├── render-map.sh         # JSON → MAP.md (overwrite)
+            └── render-drafts.sh      # JSON → triage / sprint-plan proposals
 ```
 
-## 5. The one GraphQL query
+## 8. The one GraphQL query
 
-`collect.sh` fetches all data needed by every downstream report in one paginated query and writes the full result to `po/history/<date>.json`. Fields:
+`collect.sh` fetches every field any downstream report needs and writes one file per run to `po/history/<date>.json`. All reports are pure jq transforms of this file — no re-queries.
 
 | Entity | Fields |
 |---|---|
@@ -92,87 +166,85 @@ bsg-stack/
 | Vulnerability alerts | `securityVulnerability, dismissedAt` (needs `security_events` scope) |
 | Repo metadata | `topics, defaultBranchRef.target.history(first: 100)` |
 
-All downstream reports are **pure jq** against this file. No re-queries.
+## 9. Launch modes — all per-repo, all user-initiated
 
-## 6. Reports produced
+Unchanged from v4: `@po-manager <request>` inside a Claude Code session, or `claude -p "@po-manager ..."` for a headless one-shot. No CI automation.
 
-| File | When | Contents |
-|---|---|---|
-| `po/reports/<date>-status.md` | Every run | At-a-glance metrics, top labels, assignee load, milestone progress, stale issues, oldest PR |
-| `po/MAP.md` | Every run (overwritten) | Now / Sprint / Epics / Next up / Blocked / Shipped recently / Risks |
-| `po/PLAN.md` | Every run (merge-preserve) | Current sprint plan with human-editable sections preserved |
-| `po/history/<date>.json` | Every run | Full GraphQL snapshot (audit + trend source) |
+After writing its outputs, the agent **stages and commits** the updated `po/` files with a conventional message (`chore(po): <date> <slug>`). Pushing stays a human decision.
 
-`MAP.md` is the "best planning mapping" artifact: parent issues → sub-issue trees → linked PRs → CI state, grouped by status.
+Example prompts:
 
-## 7. Launch modes — all per-repo, all user-initiated
+```
+@po-manager how are we tracking against the plan?
+@po-manager où en est le plan ?
+@po-manager what's drifting?
+@po-manager propose a starter PLAN.md — no plan exists yet
+@po-manager draft the triage queue for today
+```
 
-No CI automation. The agent runs only when a human asks for it, from inside the tracked repo.
-
-1. **Interactive with `@agent` mention** (primary path). Inside `<tracked-repo>`, in any Claude Code session:
-
-   ```
-   @po-manager give me the full status
-   @po-manager où en est le sprint
-   @po-manager list stale issues over 30 days
-   @po-manager rebuild the planning map
-   ```
-
-   The `@po-manager` mention hands the turn to the subagent defined in `claude-skills/agents/po-manager.md`. It runs the `po-report` skill's scripts, writes to `po/`, and returns a 3-bullet summary + the report path.
-
-2. **Headless one-shot.** From any shell inside the tracked repo:
-
-   ```bash
-   claude -p "@po-manager run a full status report and commit the results"
-   ```
-
-   Useful for a user-side cron or an ad-hoc catch-up run. Same behavior as interactive; no session UI.
-
-Documented in `claude-skills/agents/po-manager.md` and `references/setup.md`. No GitHub Actions, no secrets, no scheduled workflow.
-
-## 8. Required GitHub scopes
+## 10. Required GitHub scopes
 
 ```
 gh auth refresh -h github.com -s read:org,repo,read:project,security_events
 ```
 
-Documented in `references/setup.md`. Private repos, Projects v2, and Dependabot alerts all require these.
+Documented in `references/setup.md`.
 
-## 9. Phasing — three PRs against `bsg-stack`
+## 11. Phasing — three PRs against `bsg-stack`
 
-### PR 1 — Refactor collector to GraphQL, fix known bugs
+### PR 1 — Refactor collector to GraphQL, fix known bugs, move to `po/`
+
+Mechanical cleanup, no plan-adherence logic yet.
+
 - Replace every REST `gh issue list` loop in `status.sh` with one paginated GraphQL query in `collect.sh`.
 - Emit risk flags (`at_risk`, `overdue`, `understaffed`, `stalled`) from jq in `milestone-progress.sh` — currently documented but not computed.
 - Fix multi-assignee aggregation (`.assignees[].login`, not `[0]`).
 - Use `lastCommentedAt` instead of `updatedAt` in `stale-issues.sh` so bot label bumps don't reset staleness.
 - Add PR review metrics (time-to-first-review, review decision mix, merge-queue depth, oldest draft).
-- Update paths from `.claude/reports/` to `po/reports/`.
-- Add `tests/test_po_report.py` with fixture-based tests (PATH-shimmed `gh`).
-- Smoke-test against `beyond-scale-group/edomata`. Auto-memory is already off and Context7 is available in the test session because the BSG updater merges those keys into `~/.claude/settings.json` globally — no per-repo setup needed.
+- Update paths from `.claude/reports/` to `po/reports/` + `po/history/` + `po/MAP.md`.
+- Extend the integration test (`test_po_report_integration.py`) with structural assertions on the new GraphQL output fields.
+- Smoke-test against `beyond-scale-group/edomata`. Auto-memory is already off and Context7 is available globally via the BSG updater merge.
 
-### PR 2 — Planning map, plan, epic tree, PR flow, health audit
-- Add `render-map.sh`, `render-plan.sh`, `epic-tree.sh`, `pr-flow.sh`, `health-audit.sh`.
-- Add references: `epic-map.md`, `pr-flow.md`, `health-audit.md`, `setup.md`.
-- Update `po-manager.md` routing: "planning map", "epic status", "PR health", "security debt".
-- `PLAN.md` merge logic: preserves any section fenced with `<!-- human-edited -->`.
-- Document the `@po-manager` invocation pattern in `setup.md` and in the top of `po-manager.md`.
+### PR 2 — Plan-adherence engine (the point of this project)
 
-### PR 3 — Projects v2 path + polish
-- `sprint_source: projectv2` branch in `milestone-progress.sh` and `render-map.sh`.
-- French-localized summaries in `render-status.sh` (matches bilingual triggers already in `po-manager.md`).
-- Velocity and scope-delta computed from `git log` of `po/history/*.json`.
+- Define and document the `PLAN.md` inline-tag grammar in `references/plan-schema.md`.
+- `parse-plan.sh` — read `po/PLAN.md`, emit JSON of plan items with their bindings.
+- `adherence.sh` — join plan items with `history/<date>.json`; compute status per item + the three drift classes.
+- `render-status.sh` — the adherence matrix is now the **headline section** of every report; the old count tables move to "supporting evidence" at the bottom.
+- `bootstrap-plan.sh` — when no `PLAN.md` exists, draft one from README + milestones + top labels → `po/drafts/PLAN-suggested-<date>.md`. Human accepts by `mv`-ing it to `po/PLAN.md`.
+- `render-drafts.sh` — `po/drafts/triage-<date>.md` and `po/drafts/sprint-plan-<date>.md` with concrete proposed actions (assign, label, close, reschedule) — always committed markdown, never posted.
+- Update `po-manager.md` routing: "how are we tracking the plan", "what's drifting", "propose a plan", "draft today's triage".
+- `MAP.md` and `PLAN.md` paths coexist but PLAN.md is never overwritten by the agent.
 
-## 10. Open items
+### PR 3 — Trends, epic trees, PR flow, health audit, Projects v2
 
-- **`po/` vs `.claude/po/`.** Chosen `po/` at root (per Guillaume). The existing `SKILL.md` and `po-manager.md` still reference `.claude/reports/` — updated in PR 1.
+- `epic-tree.sh` — sub-issue graph + % complete per epic, rendered into `MAP.md`.
+- `pr-flow.sh` — review latency p50/p90, oldest draft, merge-queue depth.
+- `health-audit.sh` — Dependabot + branch-protection audit.
+- Velocity and scope-delta computed from `git log po/history/*.json`.
+- `sprint_source: projectv2` alternative in `adherence.sh` and `milestone-progress.sh`.
+- French-localized summaries in `render-status.sh` (matches bilingual triggers in `po-manager.md`).
 
-## 11. Validation checklist (for PR 1 smoke test)
+## 12. Open items
 
-Against `beyond-scale-group/edomata`:
+- **PLAN.md tag grammar**: inline tags chosen for human writability. Revisit if the parser needs stricter structure.
+- **Bootstrap confidence**: the first `bootstrap-plan.sh` output will be rough; iterating on the prompt is part of PR 2.
+- **PLAN.md ownership**: humans commit changes to it. The agent detects PLAN.md edits via `git log` and reports "plan last updated Xd ago" in every adherence report so stale plans are visible.
+- **Existing `SKILL.md` / `po-manager.md` paths** still reference `.claude/reports/` — fixed in PR 1.
 
+## 13. Validation checklist
+
+### PR 1 smoke test (against `beyond-scale-group/edomata`)
 - [ ] `collect.sh` produces a valid `po/history/<date>.json` in one run.
-- [ ] `status.sh` (wrapped over collect) matches the pre-refactor numbers within rounding.
-- [ ] Multi-assignee issues contribute to each assignee's count (regression check).
+- [ ] `status.sh` (wrapped over collect) matches pre-refactor numbers within rounding.
+- [ ] Multi-assignee issues contribute to each assignee's count.
 - [ ] `milestone-progress.sh` emits risk flags for at least one milestone with a past due date or low progress.
 - [ ] `stale-issues.sh` ignores issues whose only recent `updatedAt` bump is a label change by a bot.
-- [ ] Fixture-based unit tests pass locally.
+- [ ] Integration test in CI still green.
+
+### PR 2 smoke test (against `beyond-scale-group/edomata`)
+- [ ] With a hand-written `po/PLAN.md` containing 3 items (one milestone binding, one epic binding, one label binding), `adherence.sh` emits a matrix with correct statuses.
+- [ ] Running against a repo with no `PLAN.md` produces `po/drafts/PLAN-suggested-<date>.md` — not `po/PLAN.md`.
+- [ ] "Scope creep" drift class surfaces at least one unplanned open PR.
+- [ ] "Abandoned plan item" drift class surfaces a plan item bound to an untouched label.
+- [ ] `po/drafts/triage-<date>.md` exists and contains zero `gh` side-effects in its implementation.


### PR DESCRIPTION
## Summary

- **Ship a BSG-managed settings template** at `claude-skills/settings.json` and teach `update-bsg-skills.py` to merge its keys into `~/.claude/settings.json` on every run. Merge is narrow (allowlisted top-level keys + `mcpServers` entries) and idempotent; every other user-owned setting is preserved. Today the updater manages `autoMemoryEnabled: false` (so durable context lives in `CLAUDE.md` and committed agent outputs rather than a per-project memory store) and `mcpServers.context7` (pre-registers Context7 for library documentation lookups).
- **Add a root `CLAUDE.md`** capturing the design principles every BSG agent and skill must follow: pure Claude-driven, per-repo, on-demand (no CI schedulers, no cron, no reusable GitHub Actions workflows); data lives in the target repo (one repo, one agent, one plan); scripts before LLM for all aggregation.
- **Add `docs/po-agent-plan.md`** — three-PR implementation plan for the next iteration of the Product Owner agent. A single paginated GraphQL query per repo feeds `po/MAP.md` / `po/PLAN.md` / dated reports in `po/reports/` and snapshots in `po/history/`, all committed so `git log` is the trend store. Invocation is `@po-manager <request>` or `claude -p "@po-manager ..."`. Smoke-test target: `beyond-scale-group/edomata`.
- **Update `claude-skills/INSTALL.md`** with a new "Settings merged into `~/.claude/settings.json`" section documenting the managed-keys allowlist and how to evolve it.

## Testing

- `python3 -c "import ast, pathlib; ast.parse(pathlib.Path('claude-skills/scripts/update-bsg-skills.py').read_text())"` — syntax OK.
- `gh repo view beyond-scale-group/edomata --json ...` — confirmed smoke-test target repo is reachable on `main`.
- Installer end-to-end run against a real `~/.claude/` — not run (no code executed against a developer home dir in this PR).
