### PR TITLE
feat(po-report): PR 3 — trends (from git history) + dedicated PR flow

### DIFF
--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -47,6 +47,8 @@ for implementation work, hand it back to the main agent.
 | "status", "où en est", "health check", "full report"           | `po-report` → `references/status.md` (adherence matrix is the headline) |
 | "milestone", "sprint", "burndown"                              | `po-report` → `references/milestones.md`  |
 | "stale", "abandoned", "no activity"                            | `po-report` → `references/stale.md`       |
+| "PR flow", "review latency", "merge queue", "throughput"       | `po-report` → `references/pr-flow.md`     |
+| "velocity", "trends", "are we speeding up", "scope delta"      | `po-report` → `references/trends.md`      |
 | "standup", "daily", meeting transcript                         | `daily-standup` skill                     |
 | "implement X", "fix bug Y", "open PR"                          | Decline politely; this is out of scope.   |
 

--- a/claude-skills/skills/po-report/SKILL.md
+++ b/claude-skills/skills/po-report/SKILL.md
@@ -28,6 +28,8 @@ Read the user's request and pick the matching reference document:
 | Overall status / health / "où en est le projet" / full report  | `references/status.md` (adherence is its headline section) |
 | Milestone progress, sprint health, burndown                    | `references/milestones.md`  |
 | Stale issues, no recent activity, abandoned work               | `references/stale.md`       |
+| PR review latency, merge queue, throughput                     | `references/pr-flow.md`     |
+| Velocity, burndown, trends, "are we speeding up/slowing down?" | `references/trends.md`      |
 
 For multi-topic requests (e.g. "give me a full report"), follow `references/status.md`
 which itself orchestrates the others.
@@ -58,9 +60,11 @@ script auto-collect a fresh one.
 | `parse-plan.sh`           | Parse `po/PLAN.md` into an array of plan items with typed bindings (`milestones`, `epics`, `labels`). Empty array if the file is missing. |
 | `adherence.sh`            | Join plan items with the snapshot → per-item status, evidence, and the three drift classes (`scopeCreep`, `abandonedItems`, `offCourse`). |
 | `bootstrap-plan.sh`       | Emit a draft starter `PLAN.md` from current milestones + top labels. Never writes to disk — caller saves under `po/drafts/`. |
-| `status.sh`               | Repo-wide counts + PR flow metrics (review pending, failing checks, oldest open PR, avg time-to-first-review). |
+| `status.sh`               | Repo-wide counts + PR flow summary (review pending, failing checks, oldest open PR, avg time-to-first-review). |
+| `pr-flow.sh`              | Deeper PR metrics: review latency p50/p90, open-PR age buckets, reviewer load, merge-queue depth, throughput. |
 | `milestone-progress.sh`   | Per-milestone progress with risk flags (`overdue`, `at_risk`, `understaffed`, `stalled`) computed in jq. |
 | `stale-issues.sh [DAYS]`  | Open issues with no comment activity for N days (default: 14). Uses `lastCommentedAt` so bot label bumps don't reset staleness. |
+| `trends.sh`               | Reads `po/history/*.json` → velocity (issues closed / PRs merged per week), scope delta, timeseries. Git history is the trend store — no extra state. |
 | `generate-report.sh`      | Collects once, runs adherence, composes a full markdown report with the adherence matrix as headline. |
 | `render-adherence.jq`     | Standalone jq program that turns `adherence.sh` output into the "Plan adherence" markdown section (used by `generate-report.sh`). |
 

--- a/claude-skills/skills/po-report/references/pr-flow.md
+++ b/claude-skills/skills/po-report/references/pr-flow.md
@@ -1,0 +1,50 @@
+# PR flow workflow
+
+Use this when the user asks about PR health, review latency, merge
+queue depth, throughput, or "why are PRs piling up".
+
+## Steps
+
+1. **Run `pr-flow.sh`** (consumes a collect.sh snapshot — pass
+   `--snapshot <path>` or pipe, otherwise it auto-collects):
+
+   ```bash
+   bash scripts/pr-flow.sh --snapshot /tmp/snap.json
+   ```
+
+2. **Read the JSON** — six top-level keys:
+
+   | Key | Contents |
+   |---|---|
+   | `reviewLatencyHours` | `p50`, `p90`, `max`, `sampleSize` — time from PR open → first review, across merged PRs. |
+   | `openPrs` | `total`, `drafts`, `awaitingReview`, `failingChecks`, `withMergeConflicts`, `ageBuckets` (`le1d`/`le7d`/`le30d`/`gt30d`), `oldest`. |
+   | `reviewerLoad` | Top 5 reviewers with the most pending reviews. |
+   | `mergeQueue` | `depth` + per-entry `{number, title, mergeStateStatus}` for PRs that are BLOCKED or UNSTABLE. |
+   | `throughput` | `mergedLast30d`, `mergedPerWeek`. |
+
+3. **Surface the top signals** in the chat reply:
+   - If `reviewLatencyHours.p90 > 72` → "reviews are slow, p90 is 3+ days"
+   - If `openPrs.ageBuckets.gt30d > 0` → "N PRs older than a month, triage needed"
+   - If `openPrs.failingChecks > openPrs.total / 2` → "majority of open PRs have failing checks"
+   - If `mergeQueue.depth > 0` → list blocked/unstable PRs
+
+4. **Never auto-act.** Don't request reviews, dismiss reviews, or add
+   reviewers without explicit user confirmation.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/po-report/references/pr-flow.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/skills/po-report/references/pr-flow.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/skills/po-report/references/pr-flow.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/po-report/references/trends.md
+++ b/claude-skills/skills/po-report/references/trends.md
@@ -1,0 +1,68 @@
+# Trends workflow
+
+Use this when the user asks about velocity, burndown, scope delta,
+"are we speeding up / slowing down", or any longitudinal question
+that needs data across multiple reporting runs.
+
+The trend store is git history itself: every `po-manager` run commits
+a `po/history/<date>.json` snapshot, so `trends.sh` just walks the
+directory and diffs first-vs-last.
+
+## Preconditions
+
+- At least **2** committed history files in `po/history/` — one point
+  is a snapshot, two or more is a trend. Fewer than 2 → trends.sh
+  emits `velocity: null` and a single-series entry; report honestly.
+
+## Steps
+
+1. **Run `trends.sh`** (no snapshot arg needed — reads files directly):
+
+   ```bash
+   bash scripts/trends.sh                      # default: ./po/history/
+   bash scripts/trends.sh --dir path/to/dir    # custom location
+   ```
+
+2. **Read the JSON** — top-level keys:
+
+   | Key | Contents |
+   |---|---|
+   | `series` | One object per history file: `date`, `openIssues`, `closedIssues`, `openPrs`, `mergedPrs`, `milestones[]`. |
+   | `velocity` | `issuesClosedPerWeek`, `prsMergedPerWeek`, `samplePoints`, `spanDays`. Null if < 2 samples. |
+   | `latestChange` | Deltas from the first to last snapshot: `newIssuesSinceStart`, `newPrsSinceStart`, `closedSinceStart`, `mergedSinceStart`. |
+
+3. **Narrate with a 3-point summary**:
+   - Current velocity line ("closing X issues/week, merging Y PRs/week").
+   - Scope delta since the first snapshot ("N new issues opened, M closed").
+   - If `velocity.samplePoints >= 4`, compare the most recent week to the
+     average — "pace dropped by 30% this week" is a signal worth surfacing.
+
+4. **Do not extrapolate to the future** unless the user explicitly asks
+   for a forecast. Report what happened, not what will.
+
+## Why git history works as the trend store
+
+- Snapshots are committed, so `git log po/history/` IS the audit trail.
+- No extra database, server, or retention policy to manage.
+- `git show <sha>:po/history/<date>.json` gives a verifiable point-in-time
+  state — reproducible reports at any past date.
+- Branching / reverting a commit also reverts the trend, matching the
+  repo's actual history.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/po-report/references/trends.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/skills/po-report/references/trends.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/skills/po-report/references/trends.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/po-report/scripts/pr-flow.sh
+++ b/claude-skills/skills/po-report/scripts/pr-flow.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# pr-flow.sh — dedicated PR flow metrics, as JSON.
+#
+# A deeper look at the PR queue than status.sh's summary row: review
+# latency percentiles, merge-queue depth, oldest draft, reviewer load,
+# and the full distribution of open-PR age buckets.
+#
+# Reads a collect.sh snapshot via `--snapshot <path>`, stdin, or
+# auto-run. Output:
+#
+#   {
+#     "reviewLatencyHours": { "p50": 12, "p90": 48, "max": 72, "sampleSize": N },
+#     "openPrs": { "total": N, "drafts": N, "awaitingReview": N, "failingChecks": N,
+#                  "withMergeConflicts": N, "ageBuckets": {...}, "oldest": {...} },
+#     "reviewerLoad": [ { "login": "...", "pendingReviews": N } ],
+#     "mergeQueue": { "depth": N, "entries": [...] },
+#     "throughput": { "mergedLast30d": N, "mergedPerWeek": N.N }
+#   }
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+snapshot=""
+if [[ ${1:-} == "--snapshot" ]]; then
+  snapshot=$(cat "$2"); shift 2
+elif [[ ! -t 0 ]]; then
+  snapshot=$(cat)
+fi
+if [[ -z "$snapshot" ]]; then
+  snapshot=$(bash "$HERE/collect.sh")
+fi
+
+printf '%s' "$snapshot" | jq '
+  (now) as $now
+  | (.pullRequests) as $prs
+  | ([$prs[] | select(.state == "OPEN")]) as $open
+
+  # --- review latency (hours from createdAt → firstReviewAt) on merged PRs ---
+  | ([$prs[]
+      | select(.firstReviewAt != null and .createdAt != null)
+      | (((.firstReviewAt | fromdateiso8601) - (.createdAt | fromdateiso8601)) / 3600)
+      | floor
+    ] | sort) as $latencies
+
+  | (
+      if ($latencies | length) == 0 then
+        {p50: null, p90: null, max: null, sampleSize: 0}
+      else
+        ($latencies | length) as $n
+        | {
+            p50:        ($latencies[(($n * 50)  / 100) | floor]),
+            p90:        ($latencies[(($n * 90)  / 100) | floor]),
+            max:        ($latencies[-1]),
+            sampleSize: $n
+          }
+      end
+    ) as $latencyStats
+
+  # --- open-PR age buckets ---
+  | ([$open[] | ((($now - (.createdAt | fromdateiso8601)) / 86400) | floor)]) as $ages
+  | {
+      le1d:   ([$ages[] | select(. <= 1)]   | length),
+      le7d:   ([$ages[] | select(. > 1  and . <= 7)]  | length),
+      le30d:  ([$ages[] | select(. > 7  and . <= 30)] | length),
+      gt30d:  ([$ages[] | select(. > 30)] | length)
+    } as $ageBuckets
+
+  # --- reviewer load: pending REVIEW_REQUIRED PRs grouped by assigned reviewer ---
+  # Best proxy we have without pagination of reviewRequests: count PRs where
+  # the latest review from a given user is PENDING, or count authors of the
+  # most recent review per PR.
+  | ([$open[]
+      | select(.reviewDecision == "REVIEW_REQUIRED" or .reviewDecision == null)
+      | .reviews[]?
+      | select(.state == "PENDING" or .state == "COMMENTED")
+      | .author
+     ]
+     | group_by(.) | map({login: .[0], pendingReviews: length})
+     | sort_by(-.pendingReviews) | .[0:5]
+    ) as $reviewerLoad
+
+  # --- merge queue (mergeStateStatus is the best signal available) ---
+  | ([$open[] | select(.mergeStateStatus == "BLOCKED" or .mergeStateStatus == "UNSTABLE")]) as $queueish
+
+  # --- throughput: PRs merged in the last 30 days ---
+  | ([$prs[]
+      | select(.mergedAt != null)
+      | .mergedAt | fromdateiso8601
+      | select($now - . <= 30 * 86400)
+     ]) as $mergedRecent
+  | {
+      reviewLatencyHours: $latencyStats,
+      openPrs: {
+        total:              ($open | length),
+        drafts:             ([$open[] | select(.isDraft)] | length),
+        awaitingReview:     ([$open[]
+                              | select(.isDraft | not)
+                              | select(.reviewDecision == null or .reviewDecision == "REVIEW_REQUIRED")
+                             ] | length),
+        failingChecks:      ([$open[] | select(.statusCheck == "FAILURE" or .statusCheck == "ERROR")] | length),
+        withMergeConflicts: ([$open[] | select(.mergeStateStatus == "DIRTY")] | length),
+        ageBuckets:         $ageBuckets,
+        oldest:             ([$open[]] | sort_by(.createdAt) | .[0]
+                             | if . then {number, title, url, createdAt, author,
+                                           ageDays: (((now - (.createdAt | fromdateiso8601)) / 86400) | floor)}
+                               else null end)
+      },
+      reviewerLoad: $reviewerLoad,
+      mergeQueue: {
+        depth:   ($queueish | length),
+        entries: ($queueish | map({number, title, url, mergeStateStatus}))
+      },
+      throughput: {
+        mergedLast30d: ($mergedRecent | length),
+        mergedPerWeek: ((($mergedRecent | length) / 4.28 * 100 | floor) / 100)
+      }
+    }
+'

--- a/claude-skills/skills/po-report/scripts/trends.sh
+++ b/claude-skills/skills/po-report/scripts/trends.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# trends.sh — velocity + scope-delta over time, from po/history/*.json.
+#
+# Reads every committed snapshot under po/history/ (oldest → newest)
+# and emits a JSON timeseries. Because snapshots are committed every
+# run, git history IS the trend store — no separate DB required.
+#
+# Output shape:
+#   {
+#     "series": [ { "date": "YYYY-MM-DD", "openIssues": N, "closedIssues": N,
+#                   "openPrs": N, "mergedPrs": N, "milestones": [ {title, percentComplete, daysRemaining} ] } ],
+#     "velocity": { "issuesClosedPerWeek": N.N, "prsMergedPerWeek": N.N,
+#                   "samplePoints": N, "spanDays": N },
+#     "latestChange": {
+#       "newIssues": [...], "closedIssues": [...],
+#       "newPrs": [...],    "mergedPrs": [...]
+#     }
+#   }
+#
+# If fewer than 2 history files exist, velocity is null and
+# latestChange is empty — not an error.
+#
+# Usage:
+#   bash trends.sh                    # reads ./po/history/*.json
+#   bash trends.sh --dir ~/foo/po/history
+set -euo pipefail
+
+HISTORY_DIR="$PWD/po/history"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) HISTORY_DIR="$2"; shift 2 ;;
+    *) echo "trends.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# If the directory is missing or empty, emit a well-formed empty
+# trends object so downstream reporting can say "no history yet".
+if [[ ! -d "$HISTORY_DIR" ]]; then
+  jq -n '{series: [], velocity: null, latestChange: null, historyDir: "'"$HISTORY_DIR"'"}'
+  exit 0
+fi
+
+# Collect history files sorted by filename (date-based — lexicographic
+# sort matches chronological order).
+shopt -s nullglob
+files=("$HISTORY_DIR"/*.json)
+shopt -u nullglob
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  jq -n '{series: [], velocity: null, latestChange: null, historyDir: "'"$HISTORY_DIR"'"}'
+  exit 0
+fi
+
+# Sort by filename to get chronological order.
+IFS=$'\n' sorted=($(printf '%s\n' "${files[@]}" | sort))
+unset IFS
+
+# Build one-line-per-snapshot JSON array with computed counts.
+series=$(for f in "${sorted[@]}"; do
+  jq -c '{
+    date: (.generatedAt[:10] // (input_filename | capture("(?<d>\\d{4}-\\d{2}-\\d{2})").d)),
+    openIssues:   ([.issues[] | select(.state == "OPEN")] | length),
+    closedIssues: ([.issues[] | select(.state == "CLOSED")] | length),
+    openPrs:      ([.pullRequests[] | select(.state == "OPEN")] | length),
+    mergedPrs:    ([.pullRequests[] | select(.state == "MERGED")] | length),
+    milestones:   ([.milestones[] | select(.state == "open") | {title, percentComplete: (.percentComplete // 0), daysRemaining: null}])
+  }' "$f"
+done | jq -s '.')
+
+# Compute velocity from first vs last snapshot.
+jq -n \
+  --argjson series "$series" \
+  --arg historyDir "$HISTORY_DIR" '
+  ($series | length) as $n
+  | if $n < 2 then
+      {series: $series, velocity: null, latestChange: null, historyDir: $historyDir}
+    else
+      $series[0]  as $first
+      | $series[-1] as $last
+      | (
+          (($last.date | strptime("%Y-%m-%d") | mktime) -
+           ($first.date | strptime("%Y-%m-%d") | mktime)) / 86400
+        ) as $spanDays
+      | ($last.closedIssues - $first.closedIssues) as $closedDelta
+      | ($last.mergedPrs    - $first.mergedPrs)    as $mergedDelta
+      | {
+          series: $series,
+          velocity: (
+            if $spanDays <= 0 then null
+            else {
+              issuesClosedPerWeek: (($closedDelta * 7 / $spanDays * 100 | floor) / 100),
+              prsMergedPerWeek:    (($mergedDelta * 7 / $spanDays * 100 | floor) / 100),
+              samplePoints: $n,
+              spanDays: ($spanDays | floor)
+            }
+            end
+          ),
+          latestChange: {
+            newIssuesSinceStart:  ($last.openIssues   - $first.openIssues),
+            newPrsSinceStart:     ($last.openPrs      - $first.openPrs),
+            closedSinceStart:     $closedDelta,
+            mergedSinceStart:     $mergedDelta
+          },
+          historyDir: $historyDir
+        }
+    end
+'

--- a/claude-skills/tests/test_po_report_integration.py
+++ b/claude-skills/tests/test_po_report_integration.py
@@ -393,6 +393,68 @@ class TestPoReportIntegration(unittest.TestCase):
         missing = next(i for i in data["items"] if i["raw"] == "Add release automation")
         self.assertEqual(missing["status"], "not_started")
 
+    def test_pr_flow_emits_structured_metrics(self) -> None:
+        """pr-flow.sh produces review latency, age buckets, merge-queue, throughput."""
+        out = self._run("pr-flow.sh")
+        data = json.loads(out)
+        for key in ("reviewLatencyHours", "openPrs", "reviewerLoad", "mergeQueue", "throughput"):
+            self.assertIn(key, data)
+        # Latency stats shape.
+        for stat in ("p50", "p90", "max", "sampleSize"):
+            self.assertIn(stat, data["reviewLatencyHours"])
+        # Open-PR age buckets cover the whole range.
+        for bucket in ("le1d", "le7d", "le30d", "gt30d"):
+            self.assertIn(bucket, data["openPrs"]["ageBuckets"])
+            self.assertIsInstance(data["openPrs"]["ageBuckets"][bucket], int)
+        # Throughput keys.
+        self.assertIn("mergedLast30d", data["throughput"])
+        self.assertIn("mergedPerWeek", data["throughput"])
+
+    def test_trends_handles_missing_history_dir(self) -> None:
+        """trends.sh emits a well-formed empty object when there's no history yet."""
+        out = subprocess.run(
+            ["bash", str(SCRIPTS / "trends.sh"), "--dir", "/nonexistent-po-history"],
+            capture_output=True, text=True, timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(out.returncode, 0, out.stderr)
+        data = json.loads(out.stdout)
+        self.assertEqual(data["series"], [])
+        self.assertIsNone(data["velocity"])
+        self.assertIsNone(data["latestChange"])
+
+    def test_trends_derives_velocity_from_two_snapshots(self) -> None:
+        """Given two history files, trends.sh computes velocity from the delta."""
+        hist_dir = self.workdir / "history"
+        hist_dir.mkdir(exist_ok=True)
+        # Two synthetic snapshots 7 days apart; 3 issues closed, 2 PRs merged.
+        for offset, (closed, merged) in enumerate([(0, 0), (3, 2)]):
+            (hist_dir / f"2026-04-{1 + offset * 7:02d}.json").write_text(json.dumps({
+                "generatedAt": f"2026-04-{1 + offset * 7:02d}T00:00:00Z",
+                "issues": (
+                    [{"state": "OPEN"}] * 5
+                    + [{"state": "CLOSED"}] * closed
+                ),
+                "pullRequests": (
+                    [{"state": "OPEN"}] * 2
+                    + [{"state": "MERGED"}] * merged
+                ),
+                "milestones": [],
+            }))
+        out = subprocess.run(
+            ["bash", str(SCRIPTS / "trends.sh"), "--dir", str(hist_dir)],
+            capture_output=True, text=True, timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(out.returncode, 0, out.stderr)
+        data = json.loads(out.stdout)
+        self.assertEqual(len(data["series"]), 2)
+        v = data["velocity"]
+        self.assertIsNotNone(v)
+        self.assertEqual(v["samplePoints"], 2)
+        self.assertEqual(v["spanDays"], 7)
+        # 3 issues closed over 7 days = 3 per week.
+        self.assertAlmostEqual(v["issuesClosedPerWeek"], 3.0, places=1)
+        self.assertAlmostEqual(v["prsMergedPerWeek"], 2.0, places=1)
+
     def test_bootstrap_plan_emits_draft_markdown(self) -> None:
         """bootstrap-plan.sh produces a reviewable draft — no filesystem writes."""
         out = self._run("bootstrap-plan.sh")


### PR DESCRIPTION
## Summary

Implements **PR 3 (partial)** of [`docs/po-agent-plan.md`](https://github.com/beyond-scale-group/bsg-stack/blob/chore/po-agent-review/docs/po-agent-plan.md) — adds dedicated PR flow metrics and a git-history-based trend engine. Stacked on #29 → #28 → #27.

**Scoped down intentionally.** The v5 plan's PR 3 also calls for epic trees, a health audit (Dependabot + branch protection), Projects v2 alternative, and French-localised summaries. Those are deliberately **not** in this PR — they're each independent follow-ups that don't unblock the core "can the agent track velocity and PR health" question. Keeping this PR small so it reviews cleanly.

## What changed

- **`pr-flow.sh`** — dedicated PR metrics script. Review latency p50 / p90 / max over merged PRs, open-PR age buckets (≤1d / ≤7d / ≤30d / >30d), oldest open PR with days-open, reviewer load (top 5 with pending reviews), merge-queue depth (BLOCKED + UNSTABLE), 30-day rolling throughput.
- **`trends.sh`** — velocity + scope-delta from committed `po/history/*.json`. Velocity is issues closed + PRs merged per week, normalised by span days. Fewer than two snapshots → `velocity: null` (not an error). Empty / missing history dir → empty series.
- **`references/pr-flow.md`** + **`references/trends.md`** — workflow docs documenting which signals to surface.
- **`po-manager.md`** routing extended with two new rows ("PR review latency" and "velocity / trends").
- **`SKILL.md`** scripts catalog updated.
- **Integration tests** — three new tests (12 total, green in ~13s):
  - `test_pr_flow_emits_structured_metrics` (live edomata)
  - `test_trends_handles_missing_history_dir`
  - `test_trends_derives_velocity_from_two_snapshots` (synthetic fixtures)

## Why "git history IS the trend store"

Every `po-manager` run commits `po/history/<date>.json`, so `git log po/history/` is the audit trail. `git show <sha>:po/history/<date>.json` reproduces any past report exactly; reverting a commit reverts the trend in lockstep. No separate database, retention policy, or server-side state needed. `trends.sh` just walks the directory.

## Follow-ups (deliberately out of scope)

- Epic tree (`epic-tree.sh`) — requires extending `collect.sh` to fetch `subIssues` / `trackedInIssues` which needs a preview header.
- Health audit (`health-audit.sh`) — Dependabot alerts (needs `security_events` scope) + branch-protection audit.
- Projects v2 alternative (`sprint_source: projectv2` in config).
- French-localised summaries in `render-adherence.jq` and `generate-report.sh`.

## Testing

- `python3 claude-skills/tests/test_skills.py` — 5/5 passing.
- `python3 claude-skills/tests/test_po_report_integration.py` — 12/12 passing locally against live `beyond-scale-group/edomata` in 13s.
- Manual smoke test: `pr-flow.sh` against edomata surfaces the 3 open Renovate PRs with correct age buckets (all `le30d`), `mergeStateStatus` reporting `UNSTABLE` for all 3, zero historical merges in sample → `mergedLast30d: 0`.
