### PR TITLE
fix: add resend_api_key secret to review app workflow

### DIFF
--- a/.github/workflows/deploy-review-app.yaml
+++ b/.github/workflows/deploy-review-app.yaml
@@ -113,6 +113,8 @@ on:
         required: false
       google_api_key:
         required: false
+      resend_api_key:
+        required: false
       jwt_secret:
         required: false
 
@@ -141,6 +143,7 @@ jobs:
       TF_VAR_backend_url_internal: ${{ inputs.tf_var_backend_url_internal }}
       TF_VAR_backend_api_key: ${{ secrets.backend_api_key }}
       TF_VAR_google_api_key: ${{ secrets.google_api_key }}
+      TF_VAR_resend_api_key: ${{ secrets.resend_api_key }}
       TF_VAR_jwt_secret: ${{ secrets.jwt_secret }}
 
     steps:


### PR DESCRIPTION
## Summary
- Add `resend_api_key` optional secret input to `deploy-review-app.yaml`
- Map it to `TF_VAR_resend_api_key` for Terraform consumption
- Needed by ExpertFlow Scala review apps for email notification (RESEND_LIVE_MODE=false in review)