### PR TITLE
feat(ocr): add /ocr skill with local-first cascade

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -29,11 +29,13 @@ No git clone, no script to run, no cron to set up.
 | Name | Description |
 |------|-------------|
 | `/babysit` | Monitor a long-running or flaky process (shell command or CI run), diagnose failures, fix root causes, retry until green. Includes PR mergeability rules. |
+| `/ocr` | Extract text from images and PDFs without uploading them into Claude's multimodal context. Cascades through Apple Vision (macOS) → Tesseract/OCRmyPDF → Mistral OCR API, writing `<source>.ocr.md` next to the source. Designed to save Anthropic tokens on document-heavy workflows. |
 
 ## Available skills
 
 | Name | Description |
 |------|-------------|
+| `ocr` | OCR toolkit that cascades local engines (Apple Vision, Tesseract) before reaching for the Mistral OCR API. Exposes `ocr.sh` as the orchestrator plus per-engine scripts. Any agent about to read an image or scanned PDF should call this skill first and read the resulting `.ocr.md` instead of sending the raw file to Claude. |
 | `po-report` | Product owner reporting for the current GitHub repo. One paginated GraphQL snapshot feeds every report (status, milestone progress with risk flags, stale issues, PR flow) written under `po/reports/` with the raw snapshot committed to `po/history/<date>.json`. Heavy lifting in bash + jq (zero LLM cost), narration in the skill. |
 
 ## Available agents

--- a/claude-skills/commands/ocr.md
+++ b/claude-skills/commands/ocr.md
@@ -1,0 +1,82 @@
+Extract text from an image or PDF **without** uploading it into Claude's context: $ARGUMENTS
+
+You are invoking the `ocr` skill. The goal is to save Anthropic tokens by
+running OCR locally (or via a cheap OCR-only API) and producing a plain text /
+markdown file the agent can read instead of the raw image.
+
+## How to run
+
+1. **Parse arguments.** Typical forms:
+   - `/ocr path/to/file.pdf` — auto-cascade, output next to source
+   - `/ocr path/to/image.png --engine vision` — force a specific engine
+   - `/ocr path/to/file.pdf --force` — overwrite existing `.ocr.md`
+   - `/ocr --install` — install local OCR engines for this system and stop
+   - `/ocr --detect` — print the detected engine + available/missing tools and stop
+
+2. **Never read the image or PDF directly into your context** to transcribe it
+   yourself. That defeats the whole point of this skill. If OCR fails, surface
+   the error; do not fall back to multimodal transcription without the user
+   explicitly asking for it.
+
+3. **Cascade order** (auto mode, matches the `ocr` skill):
+   1. Apple Vision (macOS only, via `ocrit` + `pdftoppm` for PDFs)
+   2. Tesseract (`tesseract` for images, `ocrmypdf` for PDFs)
+   3. Mistral OCR API (only if `MISTRAL_API_KEY` is set **and** steps 1 + 2
+      failed or produced trivially short output)
+
+4. **Output path.** `<source>.ocr.md` in the same directory as the source.
+   If the file already exists, skip unless `--force` is given.
+
+5. **Delegation.** Prefer running the skill's orchestrator directly:
+
+   ```bash
+   bash ~/.claude/skills/ocr/scripts/ocr.sh "$file"
+   ```
+
+   It handles detection, cascade, output path, and idempotency. Only shell out
+   to individual engine scripts (`run-vision.sh`, `run-tesseract.sh`,
+   `run-mistral.sh`) if the user explicitly pinned an engine.
+
+6. **Report back.** One line with the output path and which engine succeeded,
+   e.g. `Wrote report.pdf.ocr.md (vision, 12 pages, 4.2 KB)`. Do **not** paste
+   the extracted text into the chat — the file is the artifact.
+
+## When to invoke automatically
+
+Any time another agent or skill is about to:
+
+- `Read` an image file (`.png`, `.jpg`, `.heic`, `.tiff`, `.webp`, `.bmp`)
+- `Read` a PDF whose text layer is empty or scanned
+- Attach an image to the model context to "see what it says"
+
+…call `/ocr` first and read the resulting `.ocr.md` instead. Rough guide: if
+the image is a screenshot of a UI being debugged, multimodal is fine; if it is
+a document (invoice, scan, whiteboard with text, book page), `/ocr` saves
+tokens and produces better searchable output.
+
+## Refusing gracefully
+
+- If no engine is available and `MISTRAL_API_KEY` is unset, run
+  `bash ~/.claude/skills/ocr/scripts/install-local.sh` in dry-run (print-only)
+  mode and show the user what would be installed. Do not install without
+  confirmation.
+- If the user insists on sending the image to Claude directly, warn them
+  (token cost, no `.ocr.md` for reuse) and proceed only on explicit confirm.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/commands/ocr.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/commands/ocr.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/commands/ocr.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/ocr/SKILL.md
+++ b/claude-skills/skills/ocr/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: ocr
+description: >
+  Extract text from images (PNG, JPG, HEIC, TIFF, WebP, BMP) and PDFs without
+  sending the file into Claude's multimodal context. Cascades through local
+  engines first (Apple Vision on macOS, then Tesseract/OCRmyPDF) and only falls
+  back to the Mistral OCR API if MISTRAL_API_KEY is set and local engines
+  failed. Writes output to <source>.ocr.md next to the source file. Use when
+  the user asks to "OCR this", "extract text from <image|pdf>", "read the
+  scan", "transcribe <file>", or when another agent is about to upload a
+  document screenshot or scanned PDF into the model context. The point is to
+  save Anthropic tokens — never use multimodal transcription as the default.
+version: 0.1.0
+---
+
+# OCR Skill
+
+Extract text from images and PDFs cheaply and deterministically. The skill's
+whole reason to exist is **token economy**: send Claude the extracted text,
+never the raw image, unless the user explicitly asks for multimodal analysis.
+
+## Hard rules
+
+1. **Never read an image/PDF into the agent's context to "OCR it with the
+   model".** That costs tokens and produces no reusable artifact. Call the
+   orchestrator script and read the resulting `.ocr.md` file instead.
+2. **Always write to `<source>.ocr.md` in the same directory as the source.**
+   This keeps the artifact discoverable and cacheable. If the file already
+   exists, treat it as a cache hit unless `--force` is given.
+3. **Cascade, don't skip.** Auto mode tries engines in order. If a cheap local
+   engine works, never call the paid API.
+4. **Zero telemetry.** The Mistral API call deletes its uploaded file after
+   extraction. No content is persisted outside the local repo.
+5. **Scripts do the work.** This SKILL.md narrates; the `scripts/` directory
+   contains the actual logic. Do not re-implement OCR in-chat.
+
+## Cascade
+
+| Priority | Engine         | Prereqs                                    | Cost per page |
+| -------- | -------------- | ------------------------------------------ | ------------- |
+| 1        | Apple Vision   | macOS + `ocrit` (images) + `pdftoppm` (pdf) | $0           |
+| 2        | Tesseract      | `tesseract` (images) + `ocrmypdf` (pdf)    | $0            |
+| 3        | Mistral OCR    | `MISTRAL_API_KEY` env var                  | ~$0.002       |
+| — (refused) | Claude multimodal | —                                      | tokens $$     |
+
+Auto mode (`--engine auto`, the default):
+
+1. Try engine #1. If the output file exists and has ≥ 10 non-whitespace
+   characters per page, stop.
+2. Otherwise try engine #2.
+3. Otherwise, if `MISTRAL_API_KEY` is set, try engine #3.
+4. Otherwise fail with a helpful install hint.
+
+The user can pin an engine with `--engine vision|tesseract|mistral`. In that
+case no cascade — the skill either succeeds with that engine or fails.
+
+## Available scripts
+
+All scripts live in `scripts/`. `ocr.sh` is the orchestrator — prefer it over
+calling the engine scripts directly.
+
+| Script              | Purpose                                                          |
+| ------------------- | ---------------------------------------------------------------- |
+| `ocr.sh`            | Orchestrator. `ocr.sh <file> [--engine X] [--force]`. Handles detection, cascade, idempotency, and output path. |
+| `detect-engine.sh`  | Emits JSON describing OS, detected primary engine, available tools, and missing tools. |
+| `install-local.sh`  | Installs local engines for the current OS (`ocrit`, `tesseract`, `ocrmypdf`, `poppler`). `--dry-run` to print-only. |
+| `run-vision.sh`     | Apple Vision via `ocrit` (+ `pdftoppm` for PDFs). macOS only.    |
+| `run-tesseract.sh`  | Tesseract (+ `ocrmypdf` for PDFs). Cross-platform.               |
+| `run-mistral.sh`    | Mistral OCR API wrapper. Uploads, runs OCR, deletes the upload.  |
+
+## Output convention
+
+```
+invoice.pdf          →  invoice.pdf.ocr.md
+screenshot.png       →  screenshot.png.ocr.md
+/tmp/scan.jpg        →  /tmp/scan.jpg.ocr.md
+```
+
+The `.ocr.md` suffix (rather than replacing the extension) preserves the
+original filename so agents can reason about the source type.
+
+Content layout in the output file:
+
+```markdown
+# OCR: <source basename>
+
+- Engine: <vision|tesseract|mistral>
+- Source: <absolute path>
+- Run at: <ISO timestamp>
+- Pages: <N>  (PDFs only)
+
+---
+
+<extracted markdown, page-separated with --- for PDFs>
+```
+
+## Intent routing
+
+| User says…                                                  | Do…                                                     |
+| ----------------------------------------------------------- | ------------------------------------------------------- |
+| "OCR this", "extract text from X", "read the scan"          | `bash scripts/ocr.sh <path>`                            |
+| "Use Mistral", "accuracy matters"                           | `bash scripts/ocr.sh <path> --engine mistral`           |
+| "Install the OCR tools"                                     | `bash scripts/install-local.sh`                         |
+| "What OCR engine would you use?", "check my system"         | `bash scripts/detect-engine.sh \| jq`                   |
+| "OCR this folder of scans"                                  | Loop over files, calling `ocr.sh` once per file         |
+
+For an unknown file type, consult `references/engines.md` first.
+
+## When to invoke from another agent
+
+Before uploading an image/PDF into Claude's multimodal context, check:
+
+- Is it a document (invoice, scan, book page, whiteboard with text)? → Call
+  `/ocr` and read the `.ocr.md`.
+- Is it a UI screenshot being debugged? → Multimodal is fine; OCR loses
+  layout.
+- Is it a chart/diagram? → Multimodal; OCR only captures legend text.
+
+The rule of thumb: **if the content is mostly words, OCR it first**.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/ocr/SKILL.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/skills/ocr/SKILL.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/skills/ocr/SKILL.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/ocr/references/engines.md
+++ b/claude-skills/skills/ocr/references/engines.md
@@ -1,0 +1,98 @@
+# OCR engines — when to use what
+
+The `ocr` skill cascades through three engines. This reference explains the
+trade-offs so the agent can pick intelligently when the user asks for a
+specific engine or when auto-mode fails.
+
+## 1. Apple Vision (macOS only, free)
+
+**How it's invoked**: `ocrit` binary (images) + `pdftoppm` → PNG → `ocrit`
+(PDFs).
+
+**Strengths:**
+- Fastest local option on Apple Silicon — no model download, no CPU inference.
+- Excellent accuracy on clean printed text, receipts, signs, handwriting.
+- Produces simple plain text (no layout reconstruction, but clean).
+
+**Weaknesses:**
+- macOS only. A Linux server will never have this engine.
+- Does not natively reconstruct tables, columns, or reading order for complex
+  multi-column layouts.
+- No language hints — it auto-detects, which can misfire on mixed scripts.
+
+**When to pick explicitly (`--engine vision`):**
+- Single-page screenshots / photos / scans of simple printed text
+- Anything where "local, free, fast" beats "layout fidelity"
+
+## 2. Tesseract (cross-platform, free)
+
+**How it's invoked**: `tesseract` (images), `ocrmypdf` with its built-in
+Tesseract backend (PDFs).
+
+**Strengths:**
+- Runs anywhere (macOS, Linux server, container).
+- 100+ languages available via `tessdata` packages.
+- `ocrmypdf` produces a searchable PDF + pulls text via `pdftotext -layout`,
+  preserving column reading order better than Vision.
+
+**Weaknesses:**
+- Less accurate than Apple Vision on Apple Silicon for most documents.
+- Sensitive to image quality — benefits from 300 DPI input; noisy scans need
+  preprocessing.
+- No structured output (tables, equations) without extra tooling.
+
+**When to pick explicitly (`--engine tesseract`):**
+- Running on a Linux server where `vision` is unavailable.
+- Multi-language documents where you can specify `-l fra+eng` etc.
+- PDFs where you want a searchable output PDF as a side effect (edit
+  `run-tesseract.sh` to keep `$tmp_pdf`).
+
+## 3. Mistral OCR API (paid, ~$0.002/page)
+
+**How it's invoked**: uploads to `/v1/files` (purpose=ocr) → signs a short URL
+→ `/v1/ocr` with `mistral-ocr-latest` → per-page markdown.
+
+**Strengths:**
+- Best-in-class layout reconstruction: tables become HTML tables, equations
+  become LaTeX, reading order is correct on multi-column layouts.
+- Handles scanned PDFs, photos, and complex documents end-to-end with no
+  preprocessing.
+- Output is structured markdown that downstream tools (and Claude) can parse
+  directly.
+
+**Weaknesses:**
+- Costs money (~$2 per 1000 pages, ~$1 with batch).
+- Sends the document to Mistral's servers — not suitable for confidential
+  material without an enterprise agreement.
+- Requires a `MISTRAL_API_KEY` (env var; see `MISTRAL_API_BASE` for Vertex /
+  La Plateforme routing).
+
+**When to pick explicitly (`--engine mistral`):**
+- The document has tables, equations, or multi-column layout that local
+  engines mangle.
+- Accuracy matters more than cost (legal contracts, accounting documents,
+  research papers).
+- Running on a headless server without GPU and the document is > 10 pages
+  (Mistral's API is often faster than local Tesseract for bulk PDFs).
+
+## Never use: Claude multimodal
+
+Uploading the raw image/PDF into Claude's context "to read it" costs tokens
+proportional to image size and produces no reusable artifact. It is always
+more expensive than the worst-case OCR cascade above.
+
+The only exception is when the user **explicitly asks for visual analysis
+beyond transcription** — e.g. "describe the chart in this PDF", "what's the
+color scheme of this screenshot". OCR only extracts words; visual reasoning
+needs the model.
+
+## Validation heuristic
+
+The orchestrator considers an engine "successful" if the output file has
+≥ 10 non-whitespace characters. This is deliberately loose:
+
+- A blank page or pure-image page legitimately produces little text.
+- A total engine failure typically produces 0 bytes or a single error line.
+
+If an engine repeatedly "succeeds" but produces garbage on your corpus,
+lower the bar in `ocr.sh::validate()` and open an issue.

--- a/claude-skills/skills/ocr/references/install.md
+++ b/claude-skills/skills/ocr/references/install.md
@@ -1,0 +1,86 @@
+# Installing local OCR engines
+
+The `ocr` skill works zero-config if you only use the Mistral API. For
+token-free local OCR (the default cascade), install a few lightweight tools.
+
+## macOS
+
+```bash
+brew install ocrit       # Apple Vision CLI — primary on macOS
+brew install tesseract   # cross-platform fallback
+brew install ocrmypdf    # PDF wrapper (uses Tesseract backend)
+brew install poppler     # provides pdftoppm + pdftotext + pdfinfo
+```
+
+Or let the skill do it:
+
+```bash
+bash ~/.claude/skills/ocr/scripts/install-local.sh
+# or preview:
+bash ~/.claude/skills/ocr/scripts/install-local.sh --dry-run
+```
+
+## Linux (Debian / Ubuntu)
+
+```bash
+sudo apt-get install -y tesseract-ocr ocrmypdf poppler-utils
+```
+
+For languages other than English, also install `tesseract-ocr-<lang>`:
+
+```bash
+sudo apt-get install -y tesseract-ocr-fra tesseract-ocr-deu
+```
+
+## Other Linux distros
+
+Adjust to your package manager:
+
+- Fedora / RHEL: `sudo dnf install tesseract ocrmypdf poppler-utils`
+- Arch: `sudo pacman -S tesseract ocrmypdf poppler`
+- Alpine: `apk add tesseract-ocr ocrmypdf poppler-utils`
+
+## Server / CI runners
+
+If the repo runs OCR in CI:
+
+- Prefer the Mistral API (`MISTRAL_API_KEY` secret) for speed and accuracy on
+  small corpora.
+- For self-hosted Tesseract in CI, install `tesseract-ocr ocrmypdf
+  poppler-utils` via the runner's package manager and cache the tessdata
+  directory.
+
+## Mistral API setup
+
+1. Get a key at <https://console.mistral.ai>.
+2. Export it:
+   ```bash
+   export MISTRAL_API_KEY=...
+   ```
+3. Optional: point at Vertex / an alternate endpoint:
+   ```bash
+   export MISTRAL_API_BASE=https://us-central1-aiplatform.googleapis.com/v1/...
+   export MISTRAL_OCR_MODEL=mistral-ocr-2512   # pin a specific version
+   ```
+4. Verify: `bash ~/.claude/skills/ocr/scripts/detect-engine.sh | jq .mistral_key`
+   should print `true`.
+
+## Verification
+
+After install, the skill should report a primary engine other than `none`:
+
+```bash
+bash ~/.claude/skills/ocr/scripts/detect-engine.sh | jq
+```
+
+Example output on a healthy macOS setup:
+
+```json
+{
+  "os": "Darwin",
+  "engine": "vision",
+  "available": ["ocrit", "pdftoppm", "tesseract", "ocrmypdf"],
+  "missing":   [],
+  "mistral_key": true
+}
+```

--- a/claude-skills/skills/ocr/scripts/detect-engine.sh
+++ b/claude-skills/skills/ocr/scripts/detect-engine.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Emit a JSON description of the best available OCR engine on this system.
+#
+# Output shape:
+#   {
+#     "os": "Darwin" | "Linux" | ...,
+#     "engine": "vision" | "tesseract" | "mistral" | "none",
+#     "available": ["ocrit", "tesseract", ...],
+#     "missing":   ["ocrmypdf", ...],
+#     "mistral_key": true | false
+#   }
+#
+# "engine" is the preferred engine in auto mode:
+#   macOS with ocrit  → vision
+#   tesseract present → tesseract
+#   MISTRAL_API_KEY   → mistral
+#   otherwise         → none
+
+set -euo pipefail
+
+has() { command -v "$1" >/dev/null 2>&1; }
+
+os="$(uname -s)"
+
+# Tools we care about, in a stable order. Each row: "name:is_relevant"
+declare -a tools
+if [[ "$os" == "Darwin" ]]; then
+  tools=(ocrit pdftoppm tesseract ocrmypdf)
+else
+  tools=(tesseract ocrmypdf pdftoppm)
+fi
+
+available=()
+missing=()
+for t in "${tools[@]}"; do
+  if has "$t"; then
+    available+=("$t")
+  else
+    missing+=("$t")
+  fi
+done
+
+mistral_key=false
+[[ -n "${MISTRAL_API_KEY:-}" ]] && mistral_key=true
+
+engine=none
+if [[ "$os" == "Darwin" ]] && has ocrit; then
+  engine=vision
+elif has tesseract; then
+  engine=tesseract
+elif [[ "$mistral_key" == "true" ]]; then
+  engine=mistral
+fi
+
+# Render JSON arrays safely even when empty.
+to_json_array() {
+  if (( $# == 0 )); then
+    printf '[]'
+  else
+    printf '%s\n' "$@" | jq -R . | jq -s .
+  fi
+}
+
+avail_json="$(to_json_array "${available[@]+"${available[@]}"}")"
+missing_json="$(to_json_array "${missing[@]+"${missing[@]}"}")"
+
+jq -n \
+  --arg os "$os" \
+  --arg engine "$engine" \
+  --argjson available "$avail_json" \
+  --argjson missing "$missing_json" \
+  --argjson mistral_key "$mistral_key" \
+  '{os:$os, engine:$engine, available:$available, missing:$missing, mistral_key:$mistral_key}'

--- a/claude-skills/skills/ocr/scripts/install-local.sh
+++ b/claude-skills/skills/ocr/scripts/install-local.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Install local OCR engines for this system.
+#
+# Usage:
+#   install-local.sh            # install missing tools
+#   install-local.sh --dry-run  # print what would be installed, don't run it
+#
+# Supported OS: macOS (Homebrew), Debian/Ubuntu (apt-get).
+# Other Linux distros: prints manual instructions and exits 0.
+
+set -euo pipefail
+
+dry_run=0
+[[ "${1:-}" == "--dry-run" ]] && dry_run=1
+
+os="$(uname -s)"
+has() { command -v "$1" >/dev/null 2>&1; }
+
+run() {
+  if (( dry_run )); then
+    printf '[dry-run] %s\n' "$*"
+  else
+    echo "+ $*"
+    "$@"
+  fi
+}
+
+case "$os" in
+  Darwin)
+    if ! has brew; then
+      echo "Homebrew is required. Install from https://brew.sh and re-run." >&2
+      exit 2
+    fi
+    pkgs=()
+    has ocrit     || pkgs+=(ocrit)       # Apple Vision CLI for images
+    has tesseract || pkgs+=(tesseract)   # Fallback for images
+    has ocrmypdf  || pkgs+=(ocrmypdf)    # PDF wrapper (uses Tesseract by default)
+    has pdftoppm  || pkgs+=(poppler)     # pdftoppm for PDF → PNG rasterization
+    if (( ${#pkgs[@]} == 0 )); then
+      echo "All OCR tools already installed."
+    else
+      run brew install "${pkgs[@]}"
+    fi
+    ;;
+  Linux)
+    if has apt-get; then
+      pkgs=()
+      has tesseract || pkgs+=(tesseract-ocr)
+      has ocrmypdf  || pkgs+=(ocrmypdf)
+      has pdftoppm  || pkgs+=(poppler-utils)
+      if (( ${#pkgs[@]} == 0 )); then
+        echo "All OCR tools already installed."
+      else
+        run sudo apt-get update
+        run sudo apt-get install -y "${pkgs[@]}"
+      fi
+    else
+      cat >&2 <<'EOF'
+Unsupported Linux package manager. Install manually:
+  - tesseract-ocr (or equivalent)
+  - ocrmypdf
+  - poppler-utils (for pdftoppm)
+EOF
+      exit 2
+    fi
+    ;;
+  *)
+    echo "Unsupported OS: $os. Install tesseract + ocrmypdf + poppler manually." >&2
+    exit 2
+    ;;
+esac
+
+echo
+echo "Done. Run 'bash $(dirname "$0")/detect-engine.sh | jq' to verify."

--- a/claude-skills/skills/ocr/scripts/ocr.sh
+++ b/claude-skills/skills/ocr/scripts/ocr.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# OCR orchestrator.
+#
+# Usage:
+#   ocr.sh <source-file> [--engine auto|vision|tesseract|mistral] [--force]
+#   ocr.sh --detect
+#   ocr.sh --install [--dry-run]
+#
+# Writes <source>.ocr.md next to the source. In auto mode, cascades:
+#   1. Apple Vision (macOS only)
+#   2. Tesseract
+#   3. Mistral OCR API (only if MISTRAL_API_KEY is set)
+# and stops at the first engine that produces a non-trivial output.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  sed -n '3,13p' "$0"
+  exit "${1:-0}"
+}
+
+# ------- arg parsing -----------------------------------------------------
+
+src=""
+engine="auto"
+force=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    --detect)
+      bash "$here/detect-engine.sh"
+      exit 0
+      ;;
+    --install)
+      shift
+      bash "$here/install-local.sh" "$@"
+      exit $?
+      ;;
+    --engine) engine="${2:?}"; shift 2 ;;
+    --force)  force=1; shift ;;
+    --)       shift; src="${1:?}"; shift ;;
+    -*)       echo "Unknown flag: $1" >&2; usage 2 ;;
+    *)
+      if [[ -z "$src" ]]; then src="$1"; shift
+      else echo "Too many positional args: $1" >&2; usage 2
+      fi
+      ;;
+  esac
+done
+
+[[ -n "$src" ]] || usage 2
+[[ -f "$src" ]] || { echo "File not found: $src" >&2; exit 2; }
+
+out="${src}.ocr.md"
+
+if [[ -f "$out" && $force -eq 0 ]]; then
+  echo "$out (cached; use --force to re-run)"
+  exit 0
+fi
+
+# Validate: non-empty file with at least 10 non-whitespace characters.
+# This catches "ocrit produced 2 bytes of garbage" failure modes.
+validate() {
+  local f="$1"
+  [[ -s "$f" ]] || return 1
+  local nonws
+  nonws="$(tr -d '[:space:]' < "$f" | wc -c | tr -d ' ')"
+  [[ "$nonws" -ge 10 ]]
+}
+
+try() {
+  local eng="$1"
+  case "$eng" in
+    vision)    bash "$here/run-vision.sh"    "$src" "$out" >/dev/null ;;
+    tesseract) bash "$here/run-tesseract.sh" "$src" "$out" >/dev/null ;;
+    mistral)   bash "$here/run-mistral.sh"   "$src" "$out" >/dev/null ;;
+    *) return 2 ;;
+  esac
+}
+
+run_single() {
+  local eng="$1"
+  if try "$eng" && validate "$out"; then
+    printf '%s (%s)\n' "$out" "$eng"
+    return 0
+  fi
+  return 1
+}
+
+# ------- execution -------------------------------------------------------
+
+if [[ "$engine" != "auto" ]]; then
+  # Pinned engine: either it works or it fails. No cascade.
+  if run_single "$engine"; then exit 0; fi
+  echo "Engine '$engine' failed. Inspect $out (if written) or rerun with --engine auto." >&2
+  exit 1
+fi
+
+# Auto mode: cascade.
+detect_json="$(bash "$here/detect-engine.sh")"
+os="$(printf '%s' "$detect_json" | jq -r .os)"
+mistral_available="$(printf '%s' "$detect_json" | jq -r .mistral_key)"
+
+tried=()
+
+if [[ "$os" == "Darwin" ]] && command -v ocrit >/dev/null 2>&1; then
+  tried+=(vision)
+  if run_single vision; then exit 0; fi
+fi
+
+if command -v tesseract >/dev/null 2>&1 || command -v ocrmypdf >/dev/null 2>&1; then
+  tried+=(tesseract)
+  if run_single tesseract; then exit 0; fi
+fi
+
+if [[ "$mistral_available" == "true" ]]; then
+  tried+=(mistral)
+  if run_single mistral; then exit 0; fi
+fi
+
+# Nothing worked.
+if (( ${#tried[@]} == 0 )); then
+  cat >&2 <<EOF
+No OCR engine available. Run:
+
+  bash $here/install-local.sh
+
+to install local engines, or set MISTRAL_API_KEY to use the Mistral OCR API.
+EOF
+else
+  echo "All OCR engines failed: ${tried[*]}" >&2
+  printf 'Detection:\n%s\n' "$detect_json" >&2
+fi
+exit 1

--- a/claude-skills/skills/ocr/scripts/run-mistral.sh
+++ b/claude-skills/skills/ocr/scripts/run-mistral.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Run OCR using the Mistral OCR API (mistral-ocr-latest).
+#
+# Usage: run-mistral.sh <source> <output.ocr.md>
+#
+# Requires: MISTRAL_API_KEY env var, curl, jq.
+# Uploads the file to Mistral's /v1/files endpoint with purpose=ocr, fetches
+# a short-lived signed URL, runs OCR, concatenates per-page markdown, and
+# deletes the uploaded file. No content is persisted on Mistral's side beyond
+# the call.
+
+set -euo pipefail
+
+src="${1:?source file required}"
+out="${2:?output path required}"
+
+: "${MISTRAL_API_KEY:?MISTRAL_API_KEY is required for the Mistral OCR engine}"
+
+command -v curl >/dev/null || { echo "curl is required" >&2; exit 2; }
+command -v jq   >/dev/null || { echo "jq is required"   >&2; exit 2; }
+
+api="${MISTRAL_API_BASE:-https://api.mistral.ai}"
+model="${MISTRAL_OCR_MODEL:-mistral-ocr-latest}"
+
+abs_src="$(cd "$(dirname "$src")" && pwd)/$(basename "$src")"
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# 1. Upload file.
+upload_resp="$(curl -sS --fail-with-body "$api/v1/files" \
+  -H "Authorization: Bearer $MISTRAL_API_KEY" \
+  -F "purpose=ocr" \
+  -F "file=@${src}")"
+file_id="$(printf '%s' "$upload_resp" | jq -r '.id // empty')"
+[[ -n "$file_id" ]] || { echo "Upload failed: $upload_resp" >&2; exit 1; }
+
+cleanup() {
+  curl -sS -X DELETE "$api/v1/files/$file_id" \
+    -H "Authorization: Bearer $MISTRAL_API_KEY" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# 2. Get a short-lived signed URL for the uploaded file.
+url_resp="$(curl -sS --fail-with-body "$api/v1/files/$file_id/url?expiry=1" \
+  -H "Authorization: Bearer $MISTRAL_API_KEY")"
+signed_url="$(printf '%s' "$url_resp" | jq -r '.url // empty')"
+[[ -n "$signed_url" ]] || { echo "Failed to sign URL: $url_resp" >&2; exit 1; }
+
+# 3. Run OCR. Use document_url for PDFs, image_url for images.
+ext="$(printf '%s' "${src##*.}" | tr '[:upper:]' '[:lower:]')"
+case "$ext" in
+  pdf)
+    doc_payload="$(jq -n --arg url "$signed_url" \
+      '{type:"document_url", document_url:$url}')"
+    ;;
+  *)
+    doc_payload="$(jq -n --arg url "$signed_url" \
+      '{type:"image_url", image_url:$url}')"
+    ;;
+esac
+
+body="$(jq -n \
+  --arg model "$model" \
+  --argjson document "$doc_payload" \
+  '{model:$model, document:$document, include_image_base64:false}')"
+
+ocr_resp="$(curl -sS --fail-with-body "$api/v1/ocr" \
+  -H "Authorization: Bearer $MISTRAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data "$body")"
+
+# 4. Compose output file.
+pages="$(printf '%s' "$ocr_resp" | jq -r '.pages | length // 0')"
+
+{
+  printf '# OCR: %s\n\n' "$(basename "$src")"
+  printf '%s\n' "- Engine: mistral ($model)"
+  printf '%s\n' "- Source: $abs_src"
+  printf '%s\n' "- Run at: $timestamp"
+  [[ "$pages" != "0" ]] && printf '%s\n' "- Pages: $pages"
+  printf '\n---\n\n'
+} > "$out"
+
+printf '%s' "$ocr_resp" \
+  | jq -r '.pages | map(.markdown // "") | join("\n\n---\n\n")' \
+  >> "$out"
+
+echo "$out"

--- a/claude-skills/skills/ocr/scripts/run-tesseract.sh
+++ b/claude-skills/skills/ocr/scripts/run-tesseract.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Run OCR on an image or PDF using Tesseract (+ OCRmyPDF for PDFs).
+#
+# Usage: run-tesseract.sh <source> <output.ocr.md>
+
+set -euo pipefail
+
+src="${1:?source file required}"
+out="${2:?output path required}"
+
+ext="$(printf '%s' "${src##*.}" | tr '[:upper:]' '[:lower:]')"
+
+abs_src="$(cd "$(dirname "$src")" && pwd)/$(basename "$src")"
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+write_header() {
+  local engine="$1" pages="$2"
+  {
+    printf '# OCR: %s\n\n' "$(basename "$src")"
+    printf '%s\n' "- Engine: $engine"
+    printf '%s\n' "- Source: $abs_src"
+    printf '%s\n' "- Run at: $timestamp"
+    [[ -n "$pages" ]] && printf '%s\n' "- Pages: $pages"
+    printf '\n---\n\n'
+  } > "$out"
+}
+
+case "$ext" in
+  png|jpg|jpeg|tiff|tif|bmp|webp)
+    command -v tesseract >/dev/null || {
+      echo "tesseract not installed." >&2; exit 2;
+    }
+    write_header "tesseract" ""
+    tesseract "$src" - 2>/dev/null >> "$out"
+    ;;
+  pdf)
+    command -v ocrmypdf >/dev/null || {
+      echo "ocrmypdf not installed." >&2; exit 2;
+    }
+    command -v pdftotext >/dev/null || {
+      echo "pdftotext missing. Install poppler-utils / poppler." >&2; exit 2;
+    }
+    tmp_pdf="$(mktemp -t ocr-pdf-XXXXXX).pdf"
+    trap 'rm -f "$tmp_pdf"' EXIT
+    # --skip-text is safer for already-OCR'd PDFs; --force-ocr re-OCRs.
+    # Use --skip-text first, fall back to --force-ocr if OCRmyPDF refuses.
+    if ! ocrmypdf --skip-text --quiet "$src" "$tmp_pdf" 2>/dev/null; then
+      ocrmypdf --force-ocr --quiet "$src" "$tmp_pdf" >/dev/null
+    fi
+    pages="$(pdfinfo "$tmp_pdf" 2>/dev/null | awk '/^Pages:/ {print $2}')"
+    write_header "tesseract" "${pages:-}"
+    pdftotext -layout "$tmp_pdf" - >> "$out"
+    ;;
+  *)
+    echo "run-tesseract.sh: unsupported extension .$ext" >&2; exit 2
+    ;;
+esac
+
+echo "$out"

--- a/claude-skills/skills/ocr/scripts/run-vision.sh
+++ b/claude-skills/skills/ocr/scripts/run-vision.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run OCR on an image or PDF using Apple Vision framework.
+#
+# Usage: run-vision.sh <source> <output.ocr.md>
+#
+# Images: ocrit (Vision-framework binary, brew install ocrit)
+# PDFs:   pdftoppm -> PNG -> ocrit per page -> concatenate
+
+set -euo pipefail
+
+src="${1:?source file required}"
+out="${2:?output path required}"
+
+[[ "$(uname -s)" == "Darwin" ]] || { echo "run-vision.sh: macOS only" >&2; exit 2; }
+command -v ocrit >/dev/null || { echo "ocrit not installed. brew install ocrit" >&2; exit 2; }
+
+ext="$(printf '%s' "${src##*.}" | tr '[:upper:]' '[:lower:]')"
+
+abs_src="$(cd "$(dirname "$src")" && pwd)/$(basename "$src")"
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+write_header() {
+  local engine="$1" pages="$2"
+  {
+    printf '# OCR: %s\n\n' "$(basename "$src")"
+    printf '%s\n' "- Engine: $engine"
+    printf '%s\n' "- Source: $abs_src"
+    printf '%s\n' "- Run at: $timestamp"
+    [[ -n "$pages" ]] && printf '%s\n' "- Pages: $pages"
+    printf '\n---\n\n'
+  } > "$out"
+}
+
+case "$ext" in
+  png|jpg|jpeg|tiff|tif|heic|webp|bmp)
+    tmpdir="$(mktemp -d -t ocrit-XXXXXX)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    ocrit "$src" -o "$tmpdir" > /dev/null
+    txt="$tmpdir/$(basename "${src%.*}").txt"
+    [[ -s "$txt" ]] || { echo "ocrit produced no output for $src" >&2; exit 1; }
+    write_header "vision" ""
+    cat "$txt" >> "$out"
+    ;;
+  pdf)
+    command -v pdftoppm >/dev/null || {
+      echo "pdftoppm missing. brew install poppler" >&2; exit 2;
+    }
+    tmpdir="$(mktemp -d -t ocrit-pdf-XXXXXX)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    pdftoppm -r 200 "$src" "$tmpdir/page" -png
+    pages=("$tmpdir"/page-*.png)
+    [[ -e "${pages[0]}" ]] || { echo "pdftoppm produced no pages for $src" >&2; exit 1; }
+    write_header "vision" "${#pages[@]}"
+    first=1
+    for p in "${pages[@]}"; do
+      ocrit "$p" -o "$tmpdir" > /dev/null
+      txt="${p%.png}.txt"
+      (( first )) || printf '\n\n---\n\n' >> "$out"
+      first=0
+      if [[ -s "$txt" ]]; then
+        cat "$txt" >> "$out"
+      else
+        printf '_(empty page)_\n' >> "$out"
+      fi
+    done
+    ;;
+  *)
+    echo "run-vision.sh: unsupported extension .$ext" >&2; exit 2
+    ;;
+esac
+
+echo "$out"


### PR DESCRIPTION
## Summary

Adds a shared `/ocr` command and `ocr` skill that extracts text from images and PDFs **without** sending them into Claude's multimodal context. Primary goal: save Anthropic tokens on document-heavy workflows by doing OCR locally (or via a cheap OCR-only API) before handing the text to the model.

### Cascade (auto mode)

1. **Apple Vision** via `ocrit` (+ `pdftoppm` for PDFs) — macOS only, $0
2. **Tesseract** via `tesseract` / `ocrmypdf` — cross-platform, $0
3. **Mistral OCR API** (`mistral-ocr-latest`) — only if `MISTRAL_API_KEY` is set and the two local engines failed, ~$0.002/page
4. Claude multimodal is **never** used automatically (it's the whole thing we're trying to avoid)

An engine "succeeds" when its output has ≥ 10 non-whitespace characters; otherwise the orchestrator falls through to the next step.

### Output

`<source>.ocr.md` next to the source file, with a small header (engine, source, timestamp, page count) followed by extracted markdown. Idempotent: a cached `.ocr.md` is returned immediately unless `--force` is passed.

### Files

```
claude-skills/commands/ocr.md
claude-skills/skills/ocr/SKILL.md
claude-skills/skills/ocr/scripts/ocr.sh              # orchestrator
claude-skills/skills/ocr/scripts/detect-engine.sh    # JSON: OS + engine + available/missing
claude-skills/skills/ocr/scripts/install-local.sh    # brew / apt-get, --dry-run supported
claude-skills/skills/ocr/scripts/run-vision.sh       # Apple Vision wrapper
claude-skills/skills/ocr/scripts/run-tesseract.sh    # Tesseract wrapper
claude-skills/skills/ocr/scripts/run-mistral.sh      # Mistral OCR API wrapper
claude-skills/skills/ocr/references/engines.md       # when to use what
claude-skills/skills/ocr/references/install.md       # install per-OS
```

### Design choices

- **Scripts do the work, LLM only narrates** — per `CLAUDE.md` "Scripts before LLM"
- **Local-first cascade** — prioritizes zero-cost engines; only reaches the paid API if local fails (chosen from two alternatives)
- **Output next to source** — simple, discoverable, easy to `.gitignore` globally (`*.ocr.md`)
- **Hard rule in `SKILL.md`**: never read an image/PDF into the agent's context for in-chat transcription

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — 7 tests pass (footers, canonical-path check, INSTALL.md catalog sync)
- [x] `bash -n` on all 6 scripts
- [x] `bash scripts/detect-engine.sh` returns correct JSON on macOS
- [x] `bash scripts/install-local.sh --dry-run` proposes the right Homebrew packages
- [x] End-to-end Tesseract on a generated PNG: recovered `Hello from BSG OCR skill / Line two with numbers 42, 1337`
- [x] Cache hit on 2nd call, `--force` regenerates
- [ ] End-to-end Apple Vision (needs `brew install ocrit` — skipped here, trivially covered by cascade logic)
- [ ] End-to-end Mistral (needs `MISTRAL_API_KEY` — dry-coded from the official API reference)

## Gotcha noted

bash 3.2's builtin `printf` refuses a format string starting with `-` (e.g. `printf '- Engine: %s\n' "$x"`). All scripts use `printf '%s\n' "- Engine: $x"` instead to stay portable on default macOS bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)