### PR TITLE
feat(skills): add google-workspace skill for the official gws CLI

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -34,6 +34,7 @@ No git clone, no script to run, no cron to set up.
 
 | Name | Description |
 |------|-------------|
+| `google-workspace` | Google Workspace CLI skill wrapping the official `gws` tool (github.com/googleworkspace/cli) across Gmail, Calendar, Drive, Sheets, Slides, Docs, Tasks, People, Chat, Meet, Forms, Keep, and the built-in `+workflow` helpers. Ships a preflight (binary/version/auth), an auto-Chrome OAuth helper (`scripts/auth-login.sh`), and an IAM-elevation helper (`scripts/fix-iam-403.sh`) that grants `serviceusage.serviceUsageConsumer` so Drive/Tasks/Chat/People stop 403'ing. Documents the GCP-project gotchas (consent-screen scope registration, Chat app registration) that `--full` alone can't solve. |
 | `po-report` | Product owner reporting for the current GitHub repo. One paginated GraphQL snapshot feeds every report (status, milestone progress with risk flags, stale issues, PR flow) written under `po/reports/` with the raw snapshot committed to `po/history/<date>.json`. Heavy lifting in bash + jq (zero LLM cost), narration in the skill. |
 
 ## Available agents

--- a/claude-skills/skills/google-workspace/SKILL.md
+++ b/claude-skills/skills/google-workspace/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: google-workspace
+description: >-
+  Official Google Workspace CLI (`gws` from github.com/googleworkspace/cli)
+  for Gmail, Calendar, Drive, Sheets, Slides, Tasks, People, Chat, Meet,
+  Forms, Keep, Classroom, plus cross-service workflow helpers. Use whenever
+  the user works with Google Workspace from their own account — send/read/
+  triage email, list/schedule/search calendar events, search/upload/share
+  Drive files, read/append Sheets, create Slides, manage Tasks or Contacts,
+  post in Chat, fetch Meet records, read/write Forms, or run
+  `+standup-report`, `+meeting-prep`, `+email-to-task`, `+weekly-digest`,
+  `+file-announce`. Triggers include "send an email", "check my inbox",
+  "triage gmail", "what's on my calendar", "next meeting", "find a Drive
+  file", "upload to Drive", "read this sheet", "post in Chat", "today's
+  standup", "weekly digest", "envoyer un mail", "agenda du jour",
+  "prochaine réunion", "Google Workspace". Not for Admin SDK / user
+  provisioning — use the `workspace-admin` skill instead.
+---
+
+# Google Workspace (`gws`)
+
+The official Google Workspace CLI. Every Workspace API is reachable via a
+uniform pattern, plus curated `+` helpers for the 90% of common tasks.
+
+Binary: `/opt/homebrew/bin/gws` (npm package `@googleworkspace/cli`,
+installed globally — upgrade with `npm install -g @googleworkspace/cli@latest`).
+This CLI evolves fast — **never assume memorized flags**, verify with
+`gws <svc> --help` or `gws schema <svc.res.method>` before scripting.
+
+For Admin SDK (user provisioning on `the-shift.ai`), use the separate
+`workspace-admin` skill — `gws` doesn't cover Admin APIs.
+
+## Preflight (run first, every session)
+
+Before issuing any `gws` command, run these three checks once per session.
+They are cheap, catch the common failure modes up front, and take under a
+second:
+
+```bash
+# 1. Binary present + version (installed via npm, not Homebrew)
+command -v gws >/dev/null || { echo "gws not installed: npm install -g @googleworkspace/cli@latest"; exit 1; }
+INSTALLED=$(gws --version | head -1 | awk '{print $2}')
+
+# 2. Up-to-date? (soft check — warn, don't block)
+LATEST=$(npm view @googleworkspace/cli version 2>/dev/null || echo "")
+[ -n "$LATEST" ] && [ "$INSTALLED" != "$LATEST" ] && \
+  echo "⚠ gws $INSTALLED installed, $LATEST available → npm install -g @googleworkspace/cli@latest"
+
+# 3. Auth valid? stdout=JSON, stderr=keyring chatter (discarded).
+#    v0.22+ rejects --format json; the command emits JSON unconditionally.
+gws auth status 2>/dev/null \
+  | jq -e '.token_valid == true and .encrypted_credentials_exists == true' >/dev/null \
+  || { echo "⚠ gws auth invalid — running the auth helper…"; \
+       bash "$(dirname "$0")/scripts/auth-login.sh"; }
+```
+
+If any check fails, surface it to the user **before** attempting the task:
+
+- **Binary missing** → `npm install -g @googleworkspace/cli@latest`
+- **Outdated** → warn, but continue; suggest the upgrade command.
+  APIs and flags change — if a flag behaves unexpectedly, re-check
+  `gws <svc> --help` against the user's installed version.
+- **Auth invalid / `invalid_rapt`** → run **[`scripts/auth-login.sh`](scripts/auth-login.sh)**.
+  It starts `gws auth login`, extracts the OAuth URL from stdout, opens
+  it in Google Chrome (or the OS default browser as fallback), waits
+  for the callback, and verifies `token_valid == true` before exiting.
+
+  **Defaults to `--full`** (all available scopes including
+  `cloud-platform` + `pubsub`). Gives you the widest API surface in one
+  consent flow. You can narrow later if needed.
+
+  ⚠ `--full` does **not** fix `403 Caller does not have required
+  permission to use project …` errors on Drive/Tasks/Chat/People — those
+  are **GCP IAM** problems, not OAuth-scope problems. See the
+  "403 on Drive/Tasks/Chat/People" section below.
+
+  Override when you want narrower scopes:
+  ```
+  bash scripts/auth-login.sh --readonly
+  bash scripts/auth-login.sh --services gmail,calendar,drive
+  bash scripts/auth-login.sh --scopes https://www.googleapis.com/auth/drive.readonly
+  ```
+  **Always prefer this helper over bare `gws auth login`** — it saves
+  the user a copy/paste step, opens Chrome, and confirms success.
+
+### Stay current with the tool's shape
+
+`gws` adds services, helpers, and flags often. When in doubt, **prefer
+discovery over memory** — in this order:
+
+1. **Live help from the installed binary** (fastest, always right for *this* machine):
+   ```bash
+   gws --help                         # top-level services
+   gws <service> --help               # resources + helpers for a service
+   gws <service> <resource> --help    # methods on a resource
+   gws schema <service.resource.method> [--resolve-refs]   # full params/body
+   ```
+
+2. **Context7 for the latest upstream docs** (recent README, new helpers,
+   release notes — ahead of the installed binary if it's out of date):
+   ```
+   Library ID: /googleworkspace/cli
+   Use the mcp__context7__query-docs tool with that library ID and a
+   specific question, e.g. "How do I send a Gmail message with an
+   attachment?" or "What's the new syntax for drive files list --page-all?"
+   ```
+   Call context7 whenever:
+   - a command errors with "unknown flag" or unexpected output
+   - the user asks about a feature not documented here
+   - the installed `gws` version is lower than the latest Homebrew version
+   - you need examples beyond the `--help` text
+
+3. **This skill's reference files** — stable baseline patterns, but may
+   lag behind the upstream CLI. Treat as the starting point, not the
+   source of truth.
+
+This skill documents v0.16.0 patterns. If the installed version is newer,
+trust the live `--help` output and context7 over this document, and
+mention any drift to the user.
+
+## Decision tree
+
+```
+Common task?     → use a +helper (prefer)        §Helpers
+Raw API call?    → gws <svc> <res> <method>      §Raw API
+Cross-service?   → gws workflow +<name>          §Workflow
+Unknown schema?  → gws schema <svc.res.method>   references/raw-api.md
+```
+
+Default to `+helpers` before raw API calls. They handle tedious encoding
+(RFC 2822 for Gmail, RFC 3339 for Calendar, A1 for Sheets, multipart for
+Drive, space resolution for Chat).
+
+## Helpers — the fast path
+
+Full flags in [references/helpers.md](references/helpers.md).
+
+| Service | Helpers |
+|---|---|
+| `gmail` | `+send`, `+triage`, `+reply`, `+reply-all`, `+forward`, `+watch` |
+| `calendar` | `+insert`, `+agenda` (`--today` / `--tomorrow` / `--week` / `--days N`) |
+| `drive` | `+upload` |
+| `sheets` | `+read`, `+append` |
+| `chat` | `+send` |
+| `workflow` | `+standup-report`, `+meeting-prep`, `+email-to-task`, `+weekly-digest`, `+file-announce` |
+
+Quick taste:
+
+```bash
+gws gmail +triage --max 10 --format table
+gws gmail +send --to alice@x.com --subject 'Ping' --body 'hi'
+gws calendar +agenda --today --format table
+gws calendar +insert --summary 'Review' \
+  --start '2026-04-17T10:00:00+02:00' --end '2026-04-17T10:30:00+02:00' \
+  --attendee alice@x.com
+gws drive +upload ./report.pdf --parent FOLDER_ID --name 'Q1 Report.pdf'
+gws sheets +read --spreadsheet $ID --range 'Sheet1!A1:D10' --format csv
+gws sheets +append --spreadsheet $ID --json-values '[["Alice",100,true]]'
+gws chat +send --space spaces/AAAAxxxx --text 'Deploy done ✅'
+gws workflow +standup-report --format table
+```
+
+## Raw API — everything else
+
+Pattern: `gws <service> <resource> [sub-resource] <method> [--params JSON] [--json BODY]`
+
+```bash
+gws gmail users messages list --params '{"userId":"me","q":"is:unread newer_than:7d","maxResults":10}'
+gws drive files list --params '{"q":"mimeType=\"application/pdf\" and trashed=false","pageSize":20,"fields":"files(id,name,modifiedTime)"}'
+gws sheets spreadsheets values get --params '{"spreadsheetId":"ID","range":"Sheet1!A1:D10"}'
+gws calendar events list --params '{"calendarId":"primary","timeMin":"2026-04-16T00:00:00Z","singleEvents":true,"orderBy":"startTime"}'
+```
+
+Discover any method's params **first**:
+
+```bash
+gws schema gmail.users.messages.list
+gws schema drive.files.create --resolve-refs
+```
+
+See [references/raw-api.md](references/raw-api.md) for pagination
+(`--page-all`, `--page-limit`), uploads (`--upload`, `--upload-content-type`),
+binary downloads (`--output`), formats, and exit codes.
+
+## Service-specific knowledge
+
+Load only the file for the service being used:
+
+- [references/gmail.md](references/gmail.md) — search operator cheat sheet, labels, threads, attachments
+- [references/calendar.md](references/calendar.md) — RFC3339 time formats, recurrence, free/busy, calendar IDs vs names
+- [references/drive.md](references/drive.md) — Drive query language, MIME types, sharing/permissions, shared drives
+- [references/sheets.md](references/sheets.md) — A1 notation, `valueInputOption`, batchUpdate patterns
+- [references/recipes.md](references/recipes.md) — cross-service multi-step recipes
+
+For Slides, Docs, Tasks, People, Chat, Meet, Keep, Forms, Classroom:
+discover via `gws <svc> --help` and `gws schema <svc.res.method>`.
+
+## Agent-friendly conventions
+
+- **`--dry-run`** validates the request locally without calling Google. Use
+  it to verify shape before any mutating call.
+- **`--format json`** (default) for parsing; `--format table` for humans;
+  `--format csv` for spreadsheet paste; `--format yaml` for diffs.
+- **`--page-all`** emits NDJSON (one JSON object per page). Pipe to `jq -s`
+  for a single array. Limit with `--page-limit N --page-delay MS`.
+- **Exit codes** (check `$?`):
+  - `0` ok · `1` API error · `2` auth · `3` validation ·
+  - `4` discovery · `5` internal.
+- **Environment overrides**:
+  - `GOOGLE_WORKSPACE_CLI_TOKEN` — pre-obtained access token (highest priority)
+  - `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` — alt config dir (default `~/.config/gws`)
+  - `GOOGLE_WORKSPACE_PROJECT_ID` — alt GCP project for quota/billing
+  - `GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE` / `_MODE` — Model Armor defaults
+
+## Safety rules
+
+Confirm with the user **before** any command that:
+
+- **Sends** — `gmail +send`, `gmail +reply*`, `gmail +forward`, `chat +send`,
+  `workflow +file-announce`, any `messages.send` / `spaces.messages.create`
+- **Creates calendar events** with `--attendee` (invitations go out immediately)
+- **Writes to Sheets/Docs/Slides** — `sheets +append`, `values.update`,
+  `spreadsheets.batchUpdate`, `documents.batchUpdate`, `presentations.batchUpdate`
+- **Modifies Drive permissions** — `drive permissions create/update/delete`,
+  shared-drive moves
+- **Deletes anything** — `files.delete`, `messages.trash`, `events.delete`,
+  `tasks.delete`
+
+Everything else (read, list, search, export, `--dry-run`) proceeds directly.
+
+When uncertain, run with `--dry-run` first and show the output before
+executing for real.
+
+## Chat API: "Google Chat app not found"
+
+Symptom: `gws chat spaces list` (and most `chat.*` endpoints) return
+`403 insufficient authentication scopes`, but your token clearly has
+`chat.spaces` / `chat.spaces.readonly`. A direct curl reveals the real
+error: `404 Google Chat app not found`.
+
+Cause: the Chat API requires the GCP project to have a **registered Chat
+app configuration** (name, description, state) before any endpoint will
+respond — even for pure user-context reads. Unlike Drive/Calendar/etc.
+which work with just the API enabled, Chat needs the app registered.
+
+Fix (one-time, GCP Console):
+
+1. Open https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat?project=<PROJECT_ID>
+2. Fill in **App name**, **Avatar URL**, **Description**
+3. Under **Functionality**, tick the boxes you need ("Receive 1:1 messages",
+   "Join spaces and group conversations")
+4. Leave **Connection settings** as "App URL" or "HTTP endpoint URL" — for
+   read-only user-context CLI use, any placeholder URL works (it's never
+   called; you're not a webhook bot)
+5. Set **Visibility** to "Make this Chat app available to specific people
+   and groups in Workspace domain" and add your email
+6. Save
+
+Then Chat APIs respond to user credentials.
+
+## "Insufficient authentication scopes" — OAuth consent screen
+
+Symptom: after a clean `gws auth login --full`, some services still fail
+with `403 Request had insufficient authentication scopes`, and inspecting
+the access token (`gws auth export --unmasked` → `tokeninfo`) shows only a
+subset of the scopes you requested.
+
+Cause: Google silently drops any scope in the OAuth URL that **isn't
+registered on the project's consent screen**. The user can't tick a
+scope they're not being shown.
+
+Fix (one-time, manual — GCP Console):
+
+1. Open https://console.cloud.google.com/apis/credentials/consent?project=<PROJECT_ID>
+2. Edit the app → Scopes → "Add or Remove Scopes"
+3. Paste the missing scopes (e.g. `.../chat.spaces`, `.../contacts`,
+   `.../directory.readonly`) into the filter and check each
+4. Save & Continue
+5. Re-run `bash scripts/auth-login.sh --full` and tick every checkbox on
+   the consent screen
+
+The enhanced `auth-login.sh` introspects the granted scopes after login
+and warns if `--full` was asked but specific scope families were dropped.
+
+## 403 on Drive/Tasks/Chat/People — GCP project IAM
+
+Symptom:
+
+```
+403 Caller does not have required permission to use project <PROJECT_ID>.
+Grant the caller the roles/serviceusage.serviceUsageConsumer role …
+```
+
+This happens because Drive, Tasks, Chat, and People APIs enforce
+`serviceusage.services.use` on the GCP project tied to the OAuth client.
+Gmail and Calendar skip that check — which is why they work while the
+rest return 403 on the same token. OAuth scopes are irrelevant here;
+re-authing with `--full` will **not** help.
+
+Three fixes — pick one:
+
+**A. Run the bundled IAM helper** (fastest if you own the project):
+```bash
+bash scripts/fix-iam-403.sh              # detect project + user, grant role, verify
+bash scripts/fix-iam-403.sh --enable-apis  # also `gcloud services enable` the APIs
+```
+The helper auto-derives the project from `gws auth status`, fetches your
+email via Gmail (the one API that always works pre-fix), ensures `gcloud`
+is authenticated, applies `roles/serviceusage.serviceUsageConsumer`,
+waits for propagation, and verifies with a Drive probe. Overrides:
+`GWS_PROJECT_ID=…` / `GWS_USER_EMAIL=…`.
+
+Equivalent raw command if you prefer to run gcloud yourself:
+```bash
+gcloud projects add-iam-policy-binding <PROJECT_ID> \
+  --member=user:<your-email> \
+  --role=roles/serviceusage.serviceUsageConsumer
+```
+
+**B. Point `gws` at a different GCP project you own** (cleanest,
+avoids touching shared projects):
+```bash
+export GOOGLE_WORKSPACE_PROJECT_ID=<your-own-project-id>
+# Add to ~/.zshrc.user to persist across shells
+```
+No re-auth required — `gws` will route quota to the new project.
+
+**C. Run `gws auth setup`** to let `gws` create a fresh GCP project
+wired for you automatically. Requires `gcloud` installed + logged in.
+This also replaces the OAuth client.
+
+Find the current project with `gws auth status | jq .project_id`.
+
+## Common pitfalls
+
+- **Gmail `+send` can't attach files.** For attachments use the raw API:
+  `gws gmail users messages send --json '{"raw":"<base64 RFC2822>"}'`.
+- **Calendar `+insert` doesn't add Meet conferencing.** For conference
+  links use `events insert` with `conferenceData` + `conferenceDataVersion=1`.
+- **Sheets ranges need quoting** when sheet names contain spaces:
+  `--range "'Sales Data'!A1:C10"`.
+- **Drive search** uses the Drive query language by default —
+  free-text: `q: fullText contains 'foo'`. See references/drive.md.
+- **Chat space names** look like `spaces/AAAAxxxx`. Find them with
+  `gws chat spaces list`.
+- **Token invalidation** (`invalid_rapt`) after sensitive changes requires
+  re-running `gws auth login`.
+- **Version drift** — if a flag shown here errors out, the installed `gws`
+  may be ahead of this skill. Run `gws <svc> --help` and prefer the live
+  output.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/google-workspace/SKILL.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/skills/google-workspace/SKILL.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/skills/google-workspace/SKILL.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/google-workspace/references/calendar.md
+++ b/claude-skills/skills/google-workspace/references/calendar.md
@@ -1,0 +1,148 @@
+# Calendar
+
+Prefer `+insert` and `+agenda` for common tasks. Raw API for recurrence,
+Meet conferencing, free/busy queries, ACLs, secondary calendars.
+
+## Time format (critical)
+
+Events use **RFC 3339** with timezone offset:
+
+```
+2026-04-17T10:00:00+02:00     Paris
+2026-04-17T09:00:00-07:00     Los Angeles
+2026-04-17T08:00:00Z          UTC
+```
+
+Never omit the offset. For all-day events, use `date` instead of `dateTime`:
+`{"date": "2026-04-17"}`.
+
+## Calendar identifiers
+
+- `primary` — the authenticated user's main calendar
+- `email@domain.com` — direct email as calendar ID
+- `groupid@group.calendar.google.com` — shared/group calendars
+
+List them:
+
+```bash
+gws calendar calendarList list --params '{"maxResults":50}' --format table
+```
+
+## List / search events
+
+```bash
+# Upcoming events on primary (next 10)
+gws calendar events list --params '{
+  "calendarId":"primary",
+  "timeMin":"2026-04-16T00:00:00Z",
+  "singleEvents":true,
+  "orderBy":"startTime",
+  "maxResults":10
+}'
+
+# Text search
+gws calendar events list --params '{
+  "calendarId":"primary",
+  "q":"review",
+  "timeMin":"2026-04-01T00:00:00Z",
+  "singleEvents":true,
+  "orderBy":"startTime"
+}'
+```
+
+Always set `"singleEvents": true` when listing — otherwise recurring events
+appear only as their series definition, not as individual occurrences.
+
+## Create an event (raw, with Meet link)
+
+```bash
+gws calendar events insert --params '{"calendarId":"primary","conferenceDataVersion":1,"sendUpdates":"all"}' \
+  --json '{
+    "summary":"Product sync",
+    "description":"Weekly product review",
+    "start":{"dateTime":"2026-04-17T10:00:00+02:00","timeZone":"Europe/Paris"},
+    "end":  {"dateTime":"2026-04-17T11:00:00+02:00","timeZone":"Europe/Paris"},
+    "attendees":[{"email":"alice@x.com"},{"email":"bob@x.com"}],
+    "conferenceData":{
+      "createRequest":{"requestId":"req-abc123","conferenceSolutionKey":{"type":"hangoutsMeet"}}
+    }
+  }'
+```
+
+`sendUpdates` values: `all` · `externalOnly` · `none`.
+
+## Recurring events
+
+Use [RRULE (RFC 5545)](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)
+strings in a `recurrence` array:
+
+```json
+"recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;UNTIL=20260630T000000Z"]
+```
+
+Common patterns:
+
+```
+RRULE:FREQ=DAILY;COUNT=10
+RRULE:FREQ=WEEKLY;BYDAY=MO
+RRULE:FREQ=MONTHLY;BYMONTHDAY=1
+RRULE:FREQ=MONTHLY;BYDAY=1MO            first Monday of each month
+RRULE:FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=25
+```
+
+## Update / move / delete
+
+```bash
+# Patch specific fields
+gws calendar events patch --params '{"calendarId":"primary","eventId":"EVENT_ID","sendUpdates":"all"}' \
+  --json '{"summary":"Updated title"}'
+
+# Change time
+gws calendar events patch --params '{"calendarId":"primary","eventId":"EVENT_ID"}' \
+  --json '{"start":{"dateTime":"..."},"end":{"dateTime":"..."}}'
+
+# Delete
+gws calendar events delete --params '{"calendarId":"primary","eventId":"EVENT_ID","sendUpdates":"all"}'
+```
+
+## Free/busy query
+
+```bash
+gws calendar freebusy query --json '{
+  "timeMin":"2026-04-17T08:00:00+02:00",
+  "timeMax":"2026-04-17T20:00:00+02:00",
+  "items":[{"id":"alice@x.com"},{"id":"bob@x.com"}]
+}'
+```
+
+Returns per-user busy blocks only — no event details.
+
+## Respond to an invite
+
+```bash
+gws calendar events patch --params '{"calendarId":"primary","eventId":"EVENT_ID","sendUpdates":"externalOnly"}' \
+  --json '{"attendees":[{"email":"me@x.com","responseStatus":"accepted"}]}'
+```
+
+`responseStatus`: `accepted` · `declined` · `tentative` · `needsAction`.
+
+## Share a calendar (ACL)
+
+```bash
+# List
+gws calendar acl list --params '{"calendarId":"primary"}'
+
+# Add reader
+gws calendar acl insert --params '{"calendarId":"primary"}' \
+  --json '{"scope":{"type":"user","value":"alice@x.com"},"role":"reader"}'
+```
+
+Roles: `none` · `freeBusyReader` · `reader` · `writer` · `owner`.
+
+## Quick agenda via helper
+
+```bash
+gws calendar +agenda --today --format table
+gws calendar +agenda --week
+gws calendar +agenda --days 3 --timezone Europe/Paris
+```

--- a/claude-skills/skills/google-workspace/references/drive.md
+++ b/claude-skills/skills/google-workspace/references/drive.md
@@ -1,0 +1,177 @@
+# Drive
+
+Prefer `+upload` for uploading. Raw API for search, permissions, folders,
+shared drives, exports, and copies.
+
+## Drive query language (`q` param)
+
+Passed as `q` inside `--params`. Strings are quoted with escaped
+double-quotes inside JSON.
+
+```
+name = 'Quarterly report.pdf'
+name contains 'report'
+fullText contains 'invoice 2026'        free-text search
+mimeType = 'application/pdf'
+mimeType != 'application/vnd.google-apps.folder'
+'FOLDER_ID' in parents                   items inside a folder
+'me' in owners
+'alice@x.com' in writers
+sharedWithMe = true
+starred = true
+trashed = false                          default includes trashed; filter explicitly
+modifiedTime > '2026-01-01T00:00:00Z'
+createdTime < '2026-04-01T00:00:00Z'
+```
+
+Operators: `=` `!=` `<` `<=` `>` `>=` `contains` · combine with `and` / `or`
+/ `not` and parentheses.
+
+## Common MIME types
+
+```
+folder                    application/vnd.google-apps.folder
+google doc                application/vnd.google-apps.document
+google sheet              application/vnd.google-apps.spreadsheet
+google slides             application/vnd.google-apps.presentation
+google form               application/vnd.google-apps.form
+google drawing            application/vnd.google-apps.drawing
+shortcut                  application/vnd.google-apps.shortcut
+pdf                       application/pdf
+word                      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+excel                     application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+image                     image/png, image/jpeg, image/webp
+```
+
+## List / search
+
+```bash
+# All PDFs modified in the last week
+gws drive files list --params '{
+  "q":"mimeType=\"application/pdf\" and modifiedTime>\"2026-04-09T00:00:00Z\" and trashed=false",
+  "pageSize":50,
+  "fields":"files(id,name,modifiedTime,owners(emailAddress)),nextPageToken",
+  "orderBy":"modifiedTime desc"
+}'
+
+# Contents of a folder
+gws drive files list --params '{
+  "q":"'"'"'FOLDER_ID'"'"' in parents and trashed=false",
+  "pageSize":100,
+  "fields":"files(id,name,mimeType,size)"
+}'
+
+# Paginate all results
+gws drive files list --params '{"q":"trashed=false","pageSize":100}' \
+  --page-all --page-limit 50
+```
+
+Include shared drives in listings:
+
+```bash
+gws drive files list --params '{
+  "q":"name contains '\''report'\''",
+  "supportsAllDrives":true,
+  "includeItemsFromAllDrives":true,
+  "corpora":"allDrives"
+}'
+```
+
+## Create a folder
+
+```bash
+gws drive files create --json '{
+  "name":"New folder",
+  "mimeType":"application/vnd.google-apps.folder",
+  "parents":["PARENT_FOLDER_ID"]
+}'
+```
+
+## Upload
+
+Prefer `+upload` helper. Raw:
+
+```bash
+gws drive files create \
+  --json '{"name":"report.pdf","parents":["FOLDER_ID"]}' \
+  --upload ./report.pdf
+```
+
+## Download / export
+
+```bash
+# Native Drive file (binary)
+gws drive files get --params '{"fileId":"FILE_ID","alt":"media"}' --output ./file.bin
+
+# Export a Google Doc to PDF
+gws drive files export --params '{"fileId":"DOC_ID","mimeType":"application/pdf"}' --output ./doc.pdf
+
+# Export a Sheet to CSV (first sheet only, Drive export limitation)
+gws drive files export --params '{"fileId":"SHEET_ID","mimeType":"text/csv"}' --output ./sheet.csv
+```
+
+## Copy / move / rename
+
+```bash
+# Copy
+gws drive files copy --params '{"fileId":"FILE_ID"}' \
+  --json '{"name":"Copy of report.pdf","parents":["FOLDER_ID"]}'
+
+# Move (update parents)
+gws drive files update --params '{
+  "fileId":"FILE_ID",
+  "addParents":"NEW_PARENT",
+  "removeParents":"OLD_PARENT"
+}' --json '{}'
+
+# Rename
+gws drive files update --params '{"fileId":"FILE_ID"}' --json '{"name":"New name"}'
+```
+
+## Share / permissions
+
+```bash
+# List permissions
+gws drive permissions list --params '{"fileId":"FILE_ID","fields":"permissions(id,type,role,emailAddress)"}'
+
+# Share with a user (reader/commenter/writer)
+gws drive permissions create --params '{"fileId":"FILE_ID","sendNotificationEmail":true}' \
+  --json '{"role":"writer","type":"user","emailAddress":"alice@x.com"}'
+
+# Share a whole domain
+gws drive permissions create --params '{"fileId":"FILE_ID"}' \
+  --json '{"role":"reader","type":"domain","domain":"the-shift.ai"}'
+
+# Anyone with the link
+gws drive permissions create --params '{"fileId":"FILE_ID"}' \
+  --json '{"role":"reader","type":"anyone"}'
+
+# Remove a permission
+gws drive permissions delete --params '{"fileId":"FILE_ID","permissionId":"PERM_ID"}'
+```
+
+Roles: `owner` · `organizer` (shared drives) · `fileOrganizer` · `writer` ·
+`commenter` · `reader`.
+
+## Trash / delete
+
+```bash
+# Trash
+gws drive files update --params '{"fileId":"FILE_ID"}' --json '{"trashed":true}'
+
+# Permanent delete (no undo)
+gws drive files delete --params '{"fileId":"FILE_ID"}'
+```
+
+Always prefer trash; use permanent delete only on explicit user request.
+
+## Shared drives
+
+```bash
+# List shared drives the user can access
+gws drive drives list --params '{"pageSize":50}'
+
+# Create a file in a shared drive
+gws drive files create --params '{"supportsAllDrives":true}' \
+  --json '{"name":"Doc","parents":["SHARED_DRIVE_ID"]}'
+```

--- a/claude-skills/skills/google-workspace/references/gmail.md
+++ b/claude-skills/skills/google-workspace/references/gmail.md
@@ -1,0 +1,152 @@
+# Gmail
+
+Prefer `gws gmail +send / +triage / +reply / +reply-all / +forward / +watch`
+for common tasks. Raw API for attachments, history watches, label
+management, settings, filters, and anything requiring full RFC 2822 control.
+
+## Search operator cheat sheet
+
+Pass any of these as `--query` to `+triage`, or as `q` inside `--params`
+for `gws gmail users messages list`.
+
+```
+from:alice@x.com            sender
+to:me                       recipient
+subject:"quarterly report"  subject phrase
+"invoice number"            body phrase (quoted)
+label:important             label name (lowercased, hyphens for spaces)
+has:attachment              has any attachment
+filename:pdf                attachment filename/extension
+is:unread  is:read  is:starred  is:important
+in:inbox   in:sent   in:trash   in:spam   in:anywhere
+category:primary|social|promotions|updates|forums
+newer_than:7d   older_than:3m     relative (s/m/h/d/w/m/y)
+after:2026/01/01  before:2026/02/01  absolute (YYYY/MM/DD)
+larger:5M   smaller:1M               size
+list:dev@x.com              mailing list
+-from:alice@x.com           negate (NOT)
+{from:a OR from:b}          OR group
+rfc822msgid:<id@host>       exact message-id
+```
+
+Combine freely: `from:boss@x.com is:unread newer_than:3d has:attachment`.
+
+## Raw listing
+
+```bash
+# List unread messages from the last week
+gws gmail users messages list --params '{
+  "userId":"me",
+  "q":"is:unread newer_than:7d",
+  "maxResults":25,
+  "fields":"messages(id,threadId)"
+}'
+
+# Paginate all
+gws gmail users messages list --params '{"userId":"me","q":"from:boss@x.com","maxResults":100}' \
+  --page-all --page-limit 5
+```
+
+## Fetch a full message
+
+```bash
+gws gmail users messages get --params '{"userId":"me","id":"MSG_ID","format":"full"}'
+
+# Plain text only (decodes MIME parts on the server)
+gws gmail users messages get --params '{"userId":"me","id":"MSG_ID","format":"full"}' \
+  | jq -r '.payload.parts[]? | select(.mimeType=="text/plain") | .body.data' \
+  | base64 --decode
+```
+
+`format` options: `minimal` · `full` · `raw` · `metadata`.
+
+## Threads
+
+```bash
+# List threads
+gws gmail users threads list --params '{"userId":"me","q":"label:important","maxResults":20}'
+
+# Get a thread with all messages
+gws gmail users threads get --params '{"userId":"me","id":"THREAD_ID","format":"full"}'
+```
+
+## Labels
+
+```bash
+# List labels
+gws gmail users labels list --params '{"userId":"me"}'
+
+# Create a label
+gws gmail users labels create --params '{"userId":"me"}' \
+  --json '{"name":"Follow-Up","labelListVisibility":"labelShow","messageListVisibility":"show"}'
+
+# Apply / remove labels
+gws gmail users messages modify --params '{"userId":"me","id":"MSG_ID"}' \
+  --json '{"addLabelIds":["Label_123"],"removeLabelIds":["UNREAD"]}'
+
+# Batch modify
+gws gmail users messages batchModify --params '{"userId":"me"}' \
+  --json '{"ids":["MSG1","MSG2"],"addLabelIds":["IMPORTANT"],"removeLabelIds":["UNREAD"]}'
+```
+
+## Send with attachment (raw path)
+
+`+send` cannot attach. Build an RFC 2822 message, base64-url-encode it,
+and POST:
+
+```bash
+# Build an RFC 2822 MIME with a single attachment (bash one-liner)
+BOUNDARY="boundary_$(date +%s)"
+{
+  printf 'From: me@x.com\r\n'
+  printf 'To: alice@x.com\r\n'
+  printf 'Subject: Report attached\r\n'
+  printf 'MIME-Version: 1.0\r\n'
+  printf 'Content-Type: multipart/mixed; boundary="%s"\r\n\r\n' "$BOUNDARY"
+  printf -- '--%s\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n' "$BOUNDARY"
+  printf 'See attached.\r\n'
+  printf -- '--%s\r\nContent-Type: application/pdf\r\nContent-Disposition: attachment; filename="report.pdf"\r\nContent-Transfer-Encoding: base64\r\n\r\n' "$BOUNDARY"
+  base64 < ./report.pdf
+  printf -- '\r\n--%s--\r\n' "$BOUNDARY"
+} > /tmp/msg.eml
+
+RAW=$(base64 < /tmp/msg.eml | tr -d '\n' | tr '+/' '-_' | tr -d '=')
+gws gmail users messages send --params '{"userId":"me"}' --json "{\"raw\":\"$RAW\"}"
+```
+
+## Drafts
+
+```bash
+# Create draft (same RAW encoding as send)
+gws gmail users drafts create --params '{"userId":"me"}' --json "{\"message\":{\"raw\":\"$RAW\"}}"
+
+# Send a saved draft
+gws gmail users drafts send --params '{"userId":"me"}' --json '{"id":"DRAFT_ID"}'
+```
+
+## History watch / push notifications
+
+```bash
+gws gmail users watch --params '{"userId":"me"}' \
+  --json '{"topicName":"projects/PROJECT/topics/TOPIC","labelIds":["INBOX"]}'
+gws gmail users stop  --params '{"userId":"me"}'
+```
+
+Push notifications go to Pub/Sub. For local polling use `gws gmail +watch`
+which streams NDJSON of new messages as they arrive.
+
+## Cheap patterns
+
+```bash
+# Unread count
+gws gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":1}' \
+  | jq '.resultSizeEstimate'
+
+# Archive a message
+gws gmail users messages modify --params '{"userId":"me","id":"MSG_ID"}' \
+  --json '{"removeLabelIds":["INBOX"]}'
+
+# Trash / delete
+gws gmail users messages trash  --params '{"userId":"me","id":"MSG_ID"}'
+gws gmail users messages delete --params '{"userId":"me","id":"MSG_ID"}'   # permanent, needs extra scope
+```

--- a/claude-skills/skills/google-workspace/references/helpers.md
+++ b/claude-skills/skills/google-workspace/references/helpers.md
@@ -1,0 +1,203 @@
+# `+` Helpers — full cheat sheet
+
+Helpers prefixed with `+` are curated shortcuts for the 90% of common
+tasks. Prefer them over raw API when a match exists — they handle
+encoding, formatting, and resolution the raw API would require you to do
+yourself.
+
+All helpers accept `--format json|table|yaml|csv` and `--dry-run`.
+
+## Gmail
+
+### `gws gmail +send` — send an email
+
+```
+--to <EMAILS>          (required) comma-separated
+--subject <SUBJECT>    (required)
+--body <TEXT>          (required) plain text, or HTML with --html
+--cc <EMAILS>          comma-separated
+--bcc <EMAILS>         comma-separated
+--html                 treat --body as HTML
+```
+
+```bash
+gws gmail +send --to alice@x.com --subject 'Hi' --body 'Hello Alice'
+gws gmail +send --to a@x.com --cc b@x.com --subject 'Report' --body '<b>done</b>' --html
+```
+
+No attachment support — use raw API (`gws gmail users messages send --json`)
+with a base64-encoded RFC 2822 `raw` field.
+
+### `gws gmail +triage` — unread inbox summary
+
+```
+--max <N>              default 20
+--query <QUERY>        default "is:unread"
+--labels               include label names
+```
+
+```bash
+gws gmail +triage --max 10
+gws gmail +triage --query 'from:boss@x.com newer_than:7d'
+gws gmail +triage --format json | jq '.[] | {from,subject,date}'
+```
+
+### `gws gmail +reply` / `+reply-all`
+
+Handles threading (In-Reply-To, References) automatically. Takes a message
+ID and a body.
+
+### `gws gmail +forward`
+
+Forwards a message to new recipients, preserves original content.
+
+### `gws gmail +watch` — streaming
+
+Watches for new emails and streams them as NDJSON. Good for pipelines.
+
+## Calendar
+
+### `gws calendar +insert` — create an event
+
+```
+--summary <TEXT>       (required)
+--start <TIME>         (required) RFC 3339, e.g. 2026-06-17T09:00:00-07:00
+--end <TIME>           (required)
+--calendar <ID>        default: primary
+--location <TEXT>
+--description <TEXT>
+--attendee <EMAIL>     repeatable (each --attendee adds one)
+```
+
+```bash
+gws calendar +insert --summary 'Standup' \
+  --start '2026-06-17T09:00:00-07:00' \
+  --end   '2026-06-17T09:30:00-07:00'
+
+gws calendar +insert --summary 'Review' \
+  --start '2026-06-17T14:00:00+02:00' --end '2026-06-17T15:00:00+02:00' \
+  --attendee alice@x.com --attendee bob@x.com --location 'Paris HQ'
+```
+
+Recurring events or Meet conference links → use raw `events insert` with
+`recurrence` / `conferenceData` + `conferenceDataVersion=1`.
+
+### `gws calendar +agenda` — upcoming events
+
+```
+--today
+--tomorrow
+--week
+--days <N>
+--calendar <NAME>      filter by calendar name or ID
+--timezone <TZ>        IANA tz, e.g. Europe/Paris
+```
+
+```bash
+gws calendar +agenda --today --format table
+gws calendar +agenda --week
+gws calendar +agenda --days 3 --timezone Europe/Paris
+```
+
+## Drive
+
+### `gws drive +upload` — upload a local file
+
+```
+<file>                 (positional) local path
+--parent <ID>          destination folder ID
+--name <NAME>          rename on upload
+```
+
+```bash
+gws drive +upload ./report.pdf
+gws drive +upload ./data.csv --parent FOLDER_ID --name 'Sales Data.csv'
+```
+
+Content type is auto-detected from extension. For non-standard types or
+resumable upload behavior use raw `files create` with `--upload` +
+`--upload-content-type`.
+
+## Sheets
+
+### `gws sheets +read` — read a range
+
+```
+--spreadsheet <ID>     (required)
+--range <RANGE>        (required) A1 notation
+```
+
+```bash
+gws sheets +read --spreadsheet ID --range 'Sheet1!A1:D10' --format csv
+gws sheets +read --spreadsheet ID --range Sheet1      # whole sheet
+```
+
+### `gws sheets +append` — append rows
+
+```
+--spreadsheet <ID>     (required)
+--values <CSV>         single-row shorthand
+--json-values <JSON>   array of arrays for multi-row
+```
+
+```bash
+gws sheets +append --spreadsheet ID --values 'Alice,100,true'
+gws sheets +append --spreadsheet ID --json-values '[["Alice",100,true],["Bob",200,false]]'
+```
+
+## Chat
+
+### `gws chat +send` — post a message
+
+```
+--space <NAME>         (required) e.g. spaces/AAAAxxxx
+--text <TEXT>          (required) plain text
+```
+
+```bash
+gws chat spaces list   # find the space name first
+gws chat +send --space spaces/AAAAxxxx --text 'Deploy done ✅'
+```
+
+For cards / threaded replies / formatted blocks → raw
+`spaces.messages.create` with `--json`.
+
+## Workflow — cross-service
+
+All read-only except `+email-to-task` and `+file-announce`.
+
+### `gws workflow +standup-report`
+
+Today's calendar agenda + open tasks, combined. Read-only.
+
+### `gws workflow +meeting-prep`
+
+Next upcoming event with attendees, description, linked docs. Read-only.
+
+```
+--calendar <ID>   default: primary
+```
+
+### `gws workflow +email-to-task` — write
+
+Reads a Gmail message and creates a Tasks entry (subject → title,
+snippet → notes). Confirm with the user first.
+
+```
+--message-id <ID>       (required)
+--tasklist <ID>         default: @default
+```
+
+### `gws workflow +weekly-digest`
+
+This week's agenda + unread email count. Read-only.
+
+### `gws workflow +file-announce` — write
+
+Posts a Chat message announcing a Drive file. Confirm with the user first.
+
+```
+--file-id <ID>    (required)
+--space <SPACE>   (required) e.g. spaces/ABC123
+--message <TEXT>  optional custom text
+```

--- a/claude-skills/skills/google-workspace/references/raw-api.md
+++ b/claude-skills/skills/google-workspace/references/raw-api.md
@@ -1,0 +1,151 @@
+# Raw API patterns
+
+When no `+helper` fits, use the generic pattern:
+
+```
+gws <service> <resource> [sub-resource] <method> [--params JSON] [--json BODY] [FLAGS]
+```
+
+- `--params <JSON>` — URL path + query parameters (always JSON, one object)
+- `--json <JSON>` — request body (for `POST` / `PUT` / `PATCH`)
+- `--upload <PATH>` — media upload (multipart)
+- `--upload-content-type <MIME>` — override auto-detect
+- `--output <PATH>` — write binary response to file (`--format` ignored)
+- `--format json|table|yaml|csv` — output shape
+- `--api-version <VER>` — override API version
+- `--dry-run` — build + validate locally, don't call Google
+- `--sanitize <TEMPLATE>` — Model Armor content sanitization
+
+## Always discover first
+
+Before writing a raw call, fetch the live schema — **do not guess
+parameter names**:
+
+```bash
+gws schema <service>.<resource>.<method>
+gws schema <service>.<resource>.<method> --resolve-refs   # inline $ref
+```
+
+Examples:
+
+```bash
+gws schema gmail.users.messages.list
+gws schema drive.files.create --resolve-refs
+gws schema sheets.spreadsheets.batchUpdate
+gws schema calendar.events.insert
+```
+
+The output is a Google Discovery Document fragment. Read
+`parameters` (for `--params`) and `request.$ref`/`request` (for `--json`).
+
+## Pagination
+
+```bash
+# Auto-paginate, emit one JSON object per page (NDJSON)
+gws drive files list --params '{"pageSize":100}' --page-all --page-limit 10 --page-delay 200
+
+# Collect all pages into a single array
+gws drive files list --params '{"pageSize":100}' --page-all | jq -s '[.[].files[]]'
+
+# Manual: use --params pageToken from the previous response
+gws drive files list --params '{"pageSize":100,"pageToken":"TOKEN_FROM_PREV"}'
+```
+
+Guard rails: `--page-limit N` caps pages (default 10), `--page-delay MS`
+slows between pages to respect quotas.
+
+## Field selection (smaller responses)
+
+Most list APIs accept `fields` to trim the response server-side:
+
+```bash
+gws drive files list --params '{"pageSize":20,"fields":"files(id,name,mimeType,modifiedTime)"}'
+gws gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":50,"fields":"messages(id,threadId)"}'
+```
+
+Per-service syntax differs — check `gws schema` → `parameters.fields`.
+
+## Uploads
+
+```bash
+# Simple upload (auto-detect MIME from extension)
+gws drive files create \
+  --json '{"name":"report.pdf","parents":["FOLDER_ID"]}' \
+  --upload ./report.pdf
+
+# Force content type
+gws drive files create \
+  --json '{"name":"blob.bin"}' \
+  --upload ./blob.bin --upload-content-type application/octet-stream
+```
+
+## Downloads
+
+```bash
+# Export a Google Doc as PDF to a file
+gws drive files export \
+  --params '{"fileId":"DOC_ID","mimeType":"application/pdf"}' \
+  --output ./doc.pdf
+
+# Get binary file
+gws drive files get --params '{"fileId":"FILE_ID","alt":"media"}' --output ./file.bin
+```
+
+## Exit codes
+
+```
+0   Success
+1   API error (Google returned an error response)
+2   Auth error (credentials missing / invalid)
+3   Validation (bad arguments or input)
+4   Discovery (could not fetch API schema)
+5   Internal (unexpected failure)
+```
+
+Pattern in scripts:
+
+```bash
+if ! out=$(gws gmail +send --to a@x.com --subject hi --body hi 2>&1); then
+  code=$?
+  case $code in
+    2) echo "auth — run: gws auth login" ;;
+    1) echo "api — $out" ;;
+    3) echo "validation — $out" ;;
+    *) echo "error $code — $out" ;;
+  esac
+  exit $code
+fi
+```
+
+## Model Armor sanitization (optional)
+
+If the user's responses need content sanitization (e.g. PII redaction on
+fetched email bodies), pass a Model Armor template:
+
+```bash
+gws gmail users messages get \
+  --params '{"userId":"me","id":"MSG_ID","format":"full"}' \
+  --sanitize projects/PROJECT/locations/LOCATION/templates/TEMPLATE
+```
+
+Env defaults: `GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE` and
+`GOOGLE_WORKSPACE_CLI_SANITIZE_MODE=warn|block`. Requires the
+`cloud-platform` OAuth scope (`gws auth login --full`).
+
+## Minimal service vocabulary
+
+```
+gmail:    users.{labels,messages,threads,drafts,settings,history,watch,stop}
+drive:    {files,permissions,comments,replies,revisions,drives,changes,about}
+sheets:   spreadsheets + spreadsheets.values + spreadsheets.sheets + .developerMetadata
+calendar: {events,calendars,calendarList,acl,freebusy,settings,colors,channels}
+slides:   presentations + presentations.pages
+tasks:    {tasklists,tasks}
+people:   {people,contactGroups,otherContacts}
+chat:     {spaces,spaces.members,spaces.messages,media,users,customEmojis}
+meet:     {spaces,conferenceRecords}
+forms:    forms + forms.responses + forms.watches
+keep:     {notes,media}
+```
+
+For exact resource paths, always check `gws <service> --help`.

--- a/claude-skills/skills/google-workspace/references/recipes.md
+++ b/claude-skills/skills/google-workspace/references/recipes.md
@@ -1,0 +1,160 @@
+# Recipes — cross-service workflows
+
+Multi-step patterns that chain `gws` commands. Each recipe is read-only
+unless marked **⚠ mutating**.
+
+## Find a doc by name, then share it — ⚠ mutating
+
+```bash
+# 1. Find
+FID=$(gws drive files list --params '{
+  "q":"name contains '\''Q2 plan'\''",
+  "fields":"files(id,name)",
+  "pageSize":5
+}' | jq -r '.files[0].id')
+
+# 2. Share as writer
+gws drive permissions create \
+  --params "{\"fileId\":\"$FID\",\"sendNotificationEmail\":true}" \
+  --json '{"role":"writer","type":"user","emailAddress":"alice@x.com"}'
+```
+
+Confirm with user before sharing — sends email notification.
+
+## Export a Doc as PDF and attach to an email — ⚠ mutating
+
+Requires the raw Gmail attachment flow (see references/gmail.md).
+
+```bash
+# 1. Export
+gws drive files export \
+  --params '{"fileId":"DOC_ID","mimeType":"application/pdf"}' \
+  --output /tmp/doc.pdf
+
+# 2. Build RFC 2822 with attachment → base64-url-encode → send
+# (see references/gmail.md "Send with attachment (raw path)")
+```
+
+## Inbox triage → Tasks
+
+Find actionable unread mail and promote each to a Google Task.
+
+```bash
+# 1. Unread messages with important label
+gws gmail users messages list --params '{
+  "userId":"me",
+  "q":"is:unread label:important newer_than:7d",
+  "maxResults":20
+}' --format json | jq -r '.messages[].id' | while read MID; do
+  # 2. Promote each to a task
+  gws workflow +email-to-task --message-id "$MID"
+done
+```
+
+Confirm with user before batch-running — creates N tasks.
+
+## "What's on my plate today?" — read only
+
+```bash
+gws workflow +standup-report --format table
+```
+
+Or, a richer custom version:
+
+```bash
+echo "── Calendar (today) ──"
+gws calendar +agenda --today --format table
+
+echo
+echo "── Inbox (unread) ──"
+gws gmail +triage --max 10 --format table
+
+echo
+echo "── Tasks ──"
+gws tasks tasks list --params '{"tasklist":"@default","showCompleted":false,"maxResults":20}' \
+  --format table
+```
+
+## Meeting prep — read only
+
+```bash
+gws workflow +meeting-prep --format table
+```
+
+Grabs next event, attendees, description, linked docs.
+
+Enhance by also fetching each attendee's recent email threads:
+
+```bash
+EVT=$(gws calendar events list --params '{
+  "calendarId":"primary",
+  "timeMin":"'"$(gws time now --format json 2>/dev/null | jq -r '.iso' || date -u +%FT%TZ)"'",
+  "maxResults":1,"singleEvents":true,"orderBy":"startTime"
+}' | jq '.items[0]')
+
+echo "$EVT" | jq -r '.attendees[]?.email' | while read EMAIL; do
+  echo "── Recent with $EMAIL ──"
+  gws gmail +triage --query "from:$EMAIL OR to:$EMAIL newer_than:14d" --max 5 --format table
+done
+```
+
+## Append a row to a sheet from a Gmail message — ⚠ mutating
+
+Useful for lightweight CRM / bug log / expense tracker patterns.
+
+```bash
+# 1. Pull subject + from from a message
+META=$(gws gmail users messages get \
+  --params '{"userId":"me","id":"MSG_ID","format":"metadata","metadataHeaders":["From","Subject","Date"]}')
+
+FROM=$(echo "$META" | jq -r '.payload.headers[] | select(.name=="From") | .value')
+SUBJ=$(echo "$META" | jq -r '.payload.headers[] | select(.name=="Subject") | .value')
+DATE=$(echo "$META" | jq -r '.payload.headers[] | select(.name=="Date") | .value')
+
+# 2. Append to tracking sheet
+gws sheets +append --spreadsheet SHEET_ID \
+  --json-values "[[\"$DATE\",\"$FROM\",\"$SUBJ\"]]"
+```
+
+## Weekly digest into a Chat space — ⚠ mutating
+
+```bash
+# 1. Build digest
+DIGEST=$(gws workflow +weekly-digest --format table)
+
+# 2. Post to a space (confirm with user first)
+gws chat +send --space spaces/AAAAxxxx --text "$DIGEST"
+```
+
+## Dry-run-then-execute pattern
+
+For any mutating command, show the user the `--dry-run` output first,
+confirm, then run for real:
+
+```bash
+# 1. Show what would happen
+gws calendar events insert \
+  --params '{"calendarId":"primary","conferenceDataVersion":1,"sendUpdates":"all"}' \
+  --json "$PAYLOAD" \
+  --dry-run
+
+# 2. On user confirm, drop --dry-run
+gws calendar events insert \
+  --params '{"calendarId":"primary","conferenceDataVersion":1,"sendUpdates":"all"}' \
+  --json "$PAYLOAD"
+```
+
+## Batch with `xargs` + `--page-all`
+
+```bash
+# Archive every unread promotional email
+gws gmail users messages list \
+  --params '{"userId":"me","q":"category:promotions is:unread","maxResults":100}' \
+  --page-all --page-limit 10 \
+  | jq -r '.messages[].id' \
+  | xargs -I {} gws gmail users messages modify \
+      --params '{"userId":"me","id":"{}"}' \
+      --json '{"removeLabelIds":["INBOX","UNREAD"]}'
+```
+
+Always confirm with the user before mass-mutating commands.

--- a/claude-skills/skills/google-workspace/references/sheets.md
+++ b/claude-skills/skills/google-workspace/references/sheets.md
@@ -1,0 +1,182 @@
+# Sheets
+
+Prefer `+read` and `+append` for simple cases. Raw API for bulk updates,
+formulas, formatting, and anything involving batchUpdate.
+
+## A1 notation (ranges)
+
+```
+Sheet1!A1             single cell
+Sheet1!A1:D10         rectangular range
+Sheet1!A:A            entire column
+Sheet1!2:2            entire row
+Sheet1                whole sheet
+'Sales Data'!A1:C10   sheet name with space — single quotes around name
+```
+
+Always JSON-escape in `--params`:
+
+```bash
+gws sheets spreadsheets values get \
+  --params '{"spreadsheetId":"ID","range":"'"'"'Sales Data'"'"'!A1:C10"}'
+```
+
+Shell escaping nightmare? Use the `+read` helper instead — it handles
+quoting for you.
+
+## Read
+
+```bash
+# Helper
+gws sheets +read --spreadsheet ID --range 'Sheet1!A1:D10' --format csv
+gws sheets +read --spreadsheet ID --range Sheet1                    # whole tab
+
+# Raw
+gws sheets spreadsheets values get --params '{"spreadsheetId":"ID","range":"Sheet1!A1:D10"}'
+
+# Multiple ranges in one call
+gws sheets spreadsheets values batchGet --params '{
+  "spreadsheetId":"ID",
+  "ranges":["Sheet1!A1:B10","Sheet2!C1:D5"]
+}'
+```
+
+Response shape: `values` is an array of rows; each row is an array of
+cells (as strings). Missing trailing cells are omitted.
+
+## Append rows
+
+```bash
+# Helper
+gws sheets +append --spreadsheet ID --values 'Alice,100,true'
+gws sheets +append --spreadsheet ID --json-values '[["Alice",100],["Bob",200]]'
+
+# Raw (finer control)
+gws sheets spreadsheets values append \
+  --params '{
+    "spreadsheetId":"ID",
+    "range":"Sheet1!A:C",
+    "valueInputOption":"USER_ENTERED",
+    "insertDataOption":"INSERT_ROWS"
+  }' \
+  --json '{"values":[["Alice",100,"=B1*2"]]}'
+```
+
+### `valueInputOption`
+
+- `RAW` — values stored as-is. `"=A1+1"` becomes the literal string.
+- `USER_ENTERED` — values parsed like typing in the UI: formulas, dates,
+  currency strings become real values. **Default for almost everything.**
+
+### `insertDataOption` (append only)
+
+- `OVERWRITE` (default) — writes over existing rows starting at the first
+  empty row.
+- `INSERT_ROWS` — inserts new rows, shifting existing rows down.
+
+## Update (overwrite specific range)
+
+```bash
+gws sheets spreadsheets values update \
+  --params '{
+    "spreadsheetId":"ID",
+    "range":"Sheet1!B2",
+    "valueInputOption":"USER_ENTERED"
+  }' \
+  --json '{"values":[["=SUM(A:A)"]]}'
+
+# Multiple ranges at once
+gws sheets spreadsheets values batchUpdate \
+  --params '{"spreadsheetId":"ID"}' \
+  --json '{
+    "valueInputOption":"USER_ENTERED",
+    "data":[
+      {"range":"Sheet1!A1","values":[["Header"]]},
+      {"range":"Sheet2!B2:C2","values":[["x","y"]]}
+    ]
+  }'
+```
+
+## Clear
+
+```bash
+gws sheets spreadsheets values clear --params '{"spreadsheetId":"ID","range":"Sheet1!A2:Z"}'
+```
+
+## Create a spreadsheet
+
+```bash
+gws sheets spreadsheets create --json '{
+  "properties":{"title":"Q2 2026 Tracker"},
+  "sheets":[{"properties":{"title":"Summary"}},{"properties":{"title":"Raw"}}]
+}'
+```
+
+Returns `{ "spreadsheetId": "...", "spreadsheetUrl": "..." }`.
+
+## Structural changes (batchUpdate)
+
+`spreadsheets.batchUpdate` takes an array of `requests`, one per change.
+Discover the request schema first:
+
+```bash
+gws schema sheets.spreadsheets.batchUpdate --resolve-refs | head -200
+```
+
+Common requests:
+
+```json
+// Add a sheet/tab
+{"addSheet":{"properties":{"title":"New tab","index":0}}}
+
+// Delete a sheet
+{"deleteSheet":{"sheetId":123456}}
+
+// Freeze first row
+{"updateSheetProperties":{
+  "properties":{"sheetId":0,"gridProperties":{"frozenRowCount":1}},
+  "fields":"gridProperties.frozenRowCount"
+}}
+
+// Bold the header row
+{"repeatCell":{
+  "range":{"sheetId":0,"startRowIndex":0,"endRowIndex":1},
+  "cell":{"userEnteredFormat":{"textFormat":{"bold":true}}},
+  "fields":"userEnteredFormat.textFormat.bold"
+}}
+
+// Auto-resize columns
+{"autoResizeDimensions":{
+  "dimensions":{"sheetId":0,"dimension":"COLUMNS","startIndex":0,"endIndex":5}
+}}
+```
+
+Apply:
+
+```bash
+gws sheets spreadsheets batchUpdate \
+  --params '{"spreadsheetId":"ID"}' \
+  --json '{"requests":[ ... ]}'
+```
+
+## Find sheetId (tab numeric ID)
+
+Structural `requests` need `sheetId`, not the tab name:
+
+```bash
+gws sheets spreadsheets get --params '{"spreadsheetId":"ID"}' \
+  | jq '.sheets[] | {title: .properties.title, sheetId: .properties.sheetId}'
+```
+
+## Export
+
+```bash
+# Via Drive export — single sheet only (first tab)
+gws drive files export --params '{"fileId":"ID","mimeType":"text/csv"}' --output ./data.csv
+
+# Full workbook as xlsx
+gws drive files export --params '{
+  "fileId":"ID",
+  "mimeType":"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+}' --output ./book.xlsx
+```

--- a/claude-skills/skills/google-workspace/scripts/auth-login.sh
+++ b/claude-skills/skills/google-workspace/scripts/auth-login.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# gws auth-login.sh — launch `gws auth login`, auto-open the OAuth URL in
+# Chrome (or the OS default browser), wait for the flow to complete, and
+# verify the token ends up valid.
+#
+# Accepts pass-through flags for `gws auth login`, e.g.:
+#   ./auth-login.sh
+#   ./auth-login.sh --services gmail,calendar,drive
+#   ./auth-login.sh --readonly
+#   ./auth-login.sh --full
+#   ./auth-login.sh --scopes https://www.googleapis.com/auth/drive.readonly
+#
+# Exits 0 if auth is valid after the flow, otherwise non-zero.
+
+set -euo pipefail
+
+warn() { printf "⚠ %s\n" "$*" >&2; }
+
+if ! command -v gws >/dev/null; then
+  echo "❌ gws not installed: npm install -g @googleworkspace/cli@latest" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null; then
+  echo "❌ jq not installed: brew install jq" >&2
+  exit 1
+fi
+
+LOG=$(mktemp -t gws-auth-login.XXXXXX)
+trap 'rm -f "$LOG"' EXIT
+
+# If the caller didn't specify a scope-shaping flag, default to `--full`.
+# That grants every available scope including cloud-platform + pubsub —
+# needed to avoid 403s on APIs that enforce `serviceusage.services.use`
+# (Drive, Tasks, Chat, People). Pass `--readonly`, `--services ...`, or
+# `--scopes ...` explicitly to override.
+HAS_SCOPE_FLAG=0
+for arg in "$@"; do
+  case "$arg" in
+    --full|--readonly|--services|-s|--scopes) HAS_SCOPE_FLAG=1; break ;;
+  esac
+done
+if [ "$HAS_SCOPE_FLAG" -eq 0 ]; then
+  set -- --full "$@"
+  echo "→ no scope flag given; defaulting to --full (all available scopes)"
+fi
+
+# Start `gws auth login` in the background, capturing stdout+stderr.
+# The process writes the OAuth URL, then blocks on the local callback server.
+gws auth login "$@" >"$LOG" 2>&1 &
+LOGIN_PID=$!
+
+# Poll the log for the URL for up to ~20s.
+URL=""
+for _ in $(seq 1 40); do
+  if ! kill -0 "$LOGIN_PID" 2>/dev/null; then
+    # login process already exited — probably an error
+    break
+  fi
+  URL=$(grep -Eom1 'https://accounts\.google\.com/[^[:space:]]+' "$LOG" 2>/dev/null || true)
+  [ -n "$URL" ] && break
+  sleep 0.5
+done
+
+if [ -z "$URL" ]; then
+  echo "❌ could not extract OAuth URL from gws auth login output:" >&2
+  cat "$LOG" >&2
+  kill "$LOGIN_PID" 2>/dev/null || true
+  wait "$LOGIN_PID" 2>/dev/null || true
+  exit 2
+fi
+
+# Open in Chrome (preferred), then fall back to OS-default browser.
+OS="$(uname -s)"
+OPENED=0
+case "$OS" in
+  Darwin)
+    if open -a "Google Chrome" "$URL" 2>/dev/null; then
+      OPENED=1
+    elif open "$URL" 2>/dev/null; then
+      OPENED=1
+    fi
+    ;;
+  Linux)
+    if command -v google-chrome >/dev/null && google-chrome "$URL" >/dev/null 2>&1 & then
+      OPENED=1
+    elif command -v chromium >/dev/null && chromium "$URL" >/dev/null 2>&1 & then
+      OPENED=1
+    elif command -v xdg-open >/dev/null && xdg-open "$URL" >/dev/null 2>&1; then
+      OPENED=1
+    fi
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    if start chrome "$URL" 2>/dev/null; then
+      OPENED=1
+    elif start "" "$URL" 2>/dev/null; then
+      OPENED=1
+    fi
+    ;;
+esac
+
+if [ "$OPENED" -eq 1 ]; then
+  echo "→ opened OAuth consent in your browser — complete the flow"
+else
+  echo "⚠ could not auto-open browser; paste this URL manually:"
+  echo ""
+  echo "  $URL"
+  echo ""
+fi
+
+# Wait for the gws auth login process to finish (success = OAuth callback hit).
+LOGIN_RC=0
+wait "$LOGIN_PID" || LOGIN_RC=$?
+
+# Double-check: the token is actually stored and valid.
+if ! gws auth status 2>/dev/null | jq -e '.token_valid == true and .encrypted_credentials_exists == true' >/dev/null; then
+  echo "⚠ gws auth still invalid after login (exit code: $LOGIN_RC)"
+  gws auth status 2>/dev/null | jq '{token_valid, has_refresh_token, token_error}' >&2
+  exit "${LOGIN_RC:-1}"
+fi
+
+# Verify scopes — Google's consent screen silently drops scopes the user
+# doesn't tick. Mint an access token and list what was actually granted so
+# the caller can see drift between requested and granted scopes.
+CID=$(gws auth export --unmasked 2>/dev/null | jq -r '.client_id // empty')
+CSECRET=$(gws auth export --unmasked 2>/dev/null | jq -r '.client_secret // empty')
+REFRESH=$(gws auth export --unmasked 2>/dev/null | jq -r '.refresh_token // empty')
+if [ -n "$CID" ] && [ -n "$CSECRET" ] && [ -n "$REFRESH" ] && command -v curl >/dev/null; then
+  ACCESS=$(curl -sX POST https://oauth2.googleapis.com/token \
+    -d "client_id=$CID" -d "client_secret=$CSECRET" \
+    -d "refresh_token=$REFRESH" -d "grant_type=refresh_token" \
+    | jq -r '.access_token // empty')
+  if [ -n "$ACCESS" ]; then
+    GRANTED=$(curl -s "https://oauth2.googleapis.com/tokeninfo?access_token=$ACCESS" \
+              | jq -r '.scope // empty' | tr ' ' '\n' | sort -u)
+    COUNT=$(printf '%s\n' "$GRANTED" | grep -c .)
+    echo "→ granted $COUNT scope(s)"
+
+    # Warn on notable omissions when the caller asked for --full
+    if printf "%s\n" "$@" | grep -q -- '--full'; then
+      MISSING=""
+      for needle in chat. contacts people directory forms keep meet; do
+        if ! printf "%s" "$GRANTED" | grep -q "$needle"; then
+          MISSING="$MISSING $needle"
+        fi
+      done
+      if [ -n "$MISSING" ]; then
+        warn "requested --full but consent dropped:$MISSING"
+        warn "Google's consent screen shows sensitive scopes as individual"
+        warn "checkboxes. Re-run and TICK EVERY BOX, or the scopes won't be"
+        warn "on your access token even though the OAuth URL requested them."
+      fi
+    fi
+  fi
+fi
+
+echo "✓ gws auth valid"
+exit 0

--- a/claude-skills/skills/google-workspace/scripts/fix-iam-403.sh
+++ b/claude-skills/skills/google-workspace/scripts/fix-iam-403.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# fix-iam-403.sh — grant the current gws user
+# `roles/serviceusage.serviceUsageConsumer` on the GCP project tied to the
+# OAuth client, so Drive / Tasks / Chat / People / Sheets / Slides APIs
+# stop returning 403 "Caller does not have required permission to use
+# project …".
+#
+# OAuth scopes don't help — this is a GCP IAM problem. Gmail & Calendar
+# work without the role because they skip the serviceusage.services.use
+# check; the rest enforce it.
+#
+# Usage:
+#   ./fix-iam-403.sh                       # auto-detect project + user
+#   GWS_PROJECT_ID=my-proj ./fix-iam-403.sh
+#   GWS_USER_EMAIL=me@x.com ./fix-iam-403.sh
+#   ./fix-iam-403.sh --enable-apis         # also `gcloud services enable`
+#                                          # the common workspace APIs
+
+set -euo pipefail
+
+info() { printf "→ %s\n" "$*"; }
+warn() { printf "⚠ %s\n" "$*" >&2; }
+die()  { printf "❌ %s\n" "$*" >&2; exit 1; }
+
+ENABLE_APIS=0
+for arg in "$@"; do
+  case "$arg" in
+    --enable-apis) ENABLE_APIS=1 ;;
+    -h|--help)
+      sed -n '1,25p' "$0"; exit 0 ;;
+  esac
+done
+
+command -v gws    >/dev/null || die "gws not installed"
+command -v gcloud >/dev/null || die "gcloud not installed — brew install google-cloud-sdk"
+command -v jq     >/dev/null || die "jq not installed — brew install jq"
+
+# Project: from $GWS_PROJECT_ID, else from gws auth status.
+PROJECT="${GWS_PROJECT_ID:-$(gws auth status 2>/dev/null | jq -r '.project_id // empty')}"
+[ -n "$PROJECT" ] || die "could not determine project_id; set GWS_PROJECT_ID=… and retry"
+
+# User email: every cheap lookup endpoint may itself 403 (that's what we're
+# fixing), so cascade through several options.
+EMAIL="${GWS_USER_EMAIL:-}"
+
+# 1. Gmail getProfile — works when the 403 wave spares this one endpoint
+if [ -z "$EMAIL" ]; then
+  EMAIL=$(gws gmail users getProfile --params '{"userId":"me"}' 2>/dev/null \
+          | jq -r '.emailAddress // empty' 2>/dev/null || true)
+fi
+
+# 2. Calendar — pick any event where an attendee has `self:true`
+if [ -z "$EMAIL" ]; then
+  EMAIL=$(gws calendar events list \
+          --params '{"calendarId":"primary","maxResults":25,"singleEvents":true,"orderBy":"startTime","timeMin":"1970-01-01T00:00:00Z"}' \
+          2>/dev/null \
+          | jq -r '.items[]?.attendees[]? | select(.self==true) | .email' 2>/dev/null \
+          | head -1 || true)
+fi
+
+# 3. gcloud's active account — only correct if it matches the gws user, but
+#    a useful default to propose.
+if [ -z "$EMAIL" ]; then
+  GCLOUD_ACCOUNT=$(gcloud config get-value account 2>/dev/null | grep -v '^$' || true)
+  if [ -n "$GCLOUD_ACCOUNT" ] && [ "$GCLOUD_ACCOUNT" != "(unset)" ]; then
+    EMAIL="$GCLOUD_ACCOUNT"
+    warn "using gcloud's active account as the gws user: $EMAIL"
+    warn "override with GWS_USER_EMAIL=… if that's wrong."
+  fi
+fi
+
+# 4. Interactive prompt — last resort
+if [ -z "$EMAIL" ] && [ -t 0 ]; then
+  printf "Enter the Workspace email of the gws user: "
+  read -r EMAIL
+fi
+
+[ -n "$EMAIL" ] || die "could not determine user email; retry with GWS_USER_EMAIL=you@example.com"
+
+info "project: $PROJECT"
+info "user:    $EMAIL"
+
+# Ensure gcloud is logged in (interactive — will open browser once).
+ACTIVE=$(gcloud config get-value account 2>/dev/null || true)
+if [ -z "$ACTIVE" ] || [ "$ACTIVE" = "(unset)" ]; then
+  info "gcloud not authenticated — running: gcloud auth login"
+  gcloud auth login
+  ACTIVE=$(gcloud config get-value account 2>/dev/null || true)
+fi
+
+if [ -n "$ACTIVE" ] && [ "$ACTIVE" != "$EMAIL" ]; then
+  warn "gcloud is logged in as $ACTIVE (≠ $EMAIL)"
+  warn "IAM grant will be applied as $ACTIVE; ensure that account owns $PROJECT."
+fi
+
+# Grant the role (idempotent — gcloud silently no-ops if already bound).
+info "granting roles/serviceusage.serviceUsageConsumer to user:$EMAIL on $PROJECT"
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member="user:$EMAIL" \
+  --role=roles/serviceusage.serviceUsageConsumer \
+  --condition=None \
+  --quiet >/dev/null
+
+# Optionally enable the common Workspace APIs on the project.
+if [ "$ENABLE_APIS" -eq 1 ]; then
+  info "enabling common Workspace APIs (idempotent)"
+  gcloud services enable \
+    drive.googleapis.com \
+    tasks.googleapis.com \
+    chat.googleapis.com \
+    people.googleapis.com \
+    sheets.googleapis.com \
+    slides.googleapis.com \
+    docs.googleapis.com \
+    forms.googleapis.com \
+    keep.googleapis.com \
+    meet.googleapis.com \
+    --project="$PROJECT" --quiet || warn "one or more APIs failed to enable"
+fi
+
+info "waiting 15s for IAM propagation…"
+sleep 15
+
+# Verify: a Drive call should no longer 403.
+if gws drive files list --params '{"pageSize":1,"fields":"files(id)"}' 2>/dev/null \
+   | jq -e 'has("files")' >/dev/null 2>&1; then
+  printf "✓ IAM elevated — Drive API now responds\n"
+  exit 0
+else
+  warn "still 403 — propagation can take a couple minutes, or the APIs"
+  warn "may need to be enabled. Retry:"
+  warn "  gws drive files list --params '{\"pageSize\":1}'"
+  warn "  or re-run with: bash $(basename "$0") --enable-apis"
+  exit 3
+fi


### PR DESCRIPTION
## Summary

- New shared skill `claude-skills/skills/google-workspace/` that wraps the official Google Workspace CLI (`gws` from [github.com/googleworkspace/cli](https://github.com/googleworkspace/cli)) across Gmail, Calendar, Drive, Sheets, Slides, Docs, Tasks, People, Chat, Meet, Forms, Keep, and the built-in `+workflow` helpers.
- Two push-button setup scripts: `scripts/auth-login.sh` (OAuth → auto-Chrome → verify + introspect granted scopes) and `scripts/fix-iam-403.sh` (gcloud-based GCP project IAM elevation + API enablement + Drive probe).
- Progressive-disclosure references per service (gmail / calendar / drive / sheets / helpers / raw-api / recipes) with a lean entry-point `SKILL.md` under 350 lines.

## Why the setup scripts

Fresh installs of `gws` hit three separate walls that OAuth alone can't fix:
1. The consent screen silently drops scopes that aren't registered on the GCP project.
2. Drive / Tasks / Chat / People enforce `serviceusage.services.use` which user tokens lack by default (Gmail + Calendar skip it, which is why half-works is common).
3. Chat API requires a registered Chat-app configuration on the project before any endpoint answers, even for read-only user-context calls.

The SKILL.md documents each gotcha with the exact console URL + `gcloud` command, and the two scripts automate the parts that are automatable.

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` → 7/7 pass (footer, catalog sync, canonical path)
- [x] `bash -n` on both helper scripts
- [x] End-to-end retest on a real Workspace account (gdumas@the-shift.ai) → 10/11 service probes green; the one remaining (Chat `spaces.list`) blocked only on the user running through the Chat-app registration form documented in SKILL.md
- [ ] Reviewer should verify the catalog row in `claude-skills/INSTALL.md` describes the skill accurately for their install flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)