### PR TITLE
feat(google-workspace): +onboard / +doctor scripts and explicit-scope auth

### DIFF
--- a/claude-skills/skills/google-workspace/SKILL.md
+++ b/claude-skills/skills/google-workspace/SKILL.md
@@ -30,6 +30,45 @@ This CLI evolves fast — **never assume memorized flags**, verify with
 For Admin SDK (user provisioning on `the-shift.ai`), use the separate
 `workspace-admin` skill — `gws` doesn't cover Admin APIs.
 
+## First-time setup → `scripts/onboard.sh`
+
+If the user has never run `gws` on this machine — no binary, no OAuth
+client, no consent-screen scopes registered, no Chat app — point them at
+the orchestrator:
+
+```bash
+bash scripts/onboard.sh
+```
+
+It walks 7 idempotent steps (prereqs → enable APIs → OAuth client →
+consent-screen scopes → Chat app → login → smoke tests). Steps that
+require GCP Console interaction print the exact URL + checklist and
+pause. Re-run a single step with `--step <name>` (`prereqs`, `apis`,
+`oauth`, `scopes`, `chat-app`, `login`, `smoke`).
+
+⚠ **GCP Console always demands passkey re-authentication**, even with a
+saved browser session. Plan to authenticate once and run the manual
+steps back-to-back so the session covers them all.
+
+Browser automation for the GCP Console steps will land via a future
+`/browser` skill (tracked in beyond-scale-group/bsg-stack#39); until then,
+those steps are manual.
+
+## Daily health check → `scripts/doctor.sh`
+
+For sessions where `gws` is already configured, the doctor is the
+fast read-only check:
+
+```bash
+bash scripts/doctor.sh           # full report
+bash scripts/doctor.sh --quiet   # exit codes only, silent on green
+```
+
+Exits `0` (healthy), `1` (warnings — e.g. outdated version), or `2` (auth
+or service failing). Auto-repairs missing scopes by re-running
+`auth-login.sh` and re-checking — only escalates to manual if the scope
+is missing from the consent-screen registration.
+
 ## Preflight (run first, every session)
 
 Before issuing any `gws` command, run these three checks once per session.
@@ -65,20 +104,27 @@ If any check fails, surface it to the user **before** attempting the task:
   it in Google Chrome (or the OS default browser as fallback), waits
   for the callback, and verifies `token_valid == true` before exiting.
 
-  **Defaults to `--full`** (all available scopes including
-  `cloud-platform` + `pubsub`). Gives you the widest API surface in one
-  consent flow. You can narrow later if needed.
+  **Defaults to a curated 15-scope list** covering every Workspace API
+  the skill exercises (Drive, Sheets, Gmail, Calendar, Docs, Slides,
+  Tasks, Chat, Contacts, Directory, Forms, Meet, OpenID). Picking
+  scopes explicitly — instead of `--full` — surfaces the silent drops
+  Google performs when a scope isn't registered on the consent screen.
 
-  ⚠ `--full` does **not** fix `403 Caller does not have required
-  permission to use project …` errors on Drive/Tasks/Chat/People — those
-  are **GCP IAM** problems, not OAuth-scope problems. See the
-  "403 on Drive/Tasks/Chat/People" section below.
+  ⚠ Even the curated list does **not** fix:
+    - `403 Caller does not have required permission to use project …`
+      → that's a **GCP IAM** problem; see the "403 on Drive/Tasks/Chat/People"
+      section below.
+    - `404 Google Chat app not found` on `gws chat *`
+      → Chat needs the GCP project to have a registered Chat app
+      configuration; see the "Chat API" section below or run
+      `bash scripts/onboard.sh --step chat-app`.
 
-  Override when you want narrower scopes:
+  Override when you want narrower or wider scopes:
   ```
   bash scripts/auth-login.sh --readonly
   bash scripts/auth-login.sh --services gmail,calendar,drive
   bash scripts/auth-login.sh --scopes https://www.googleapis.com/auth/drive.readonly
+  bash scripts/auth-login.sh --full   # everything gws knows about
   ```
   **Always prefer this helper over bare `gws auth login`** — it saves
   the user a copy/paste step, opens Chrome, and confirms success.
@@ -121,10 +167,12 @@ mention any drift to the user.
 ## Decision tree
 
 ```
-Common task?     → use a +helper (prefer)        §Helpers
-Raw API call?    → gws <svc> <res> <method>      §Raw API
-Cross-service?   → gws workflow +<name>          §Workflow
-Unknown schema?  → gws schema <svc.res.method>   references/raw-api.md
+First-time setup?  → bash scripts/onboard.sh    §First-time setup
+Health check?      → bash scripts/doctor.sh     §Daily health check
+Common task?       → use a +helper (prefer)     §Helpers
+Raw API call?      → gws <svc> <res> <method>   §Raw API
+Cross-service?     → gws workflow +<name>       §Workflow
+Unknown schema?    → gws schema <svc.res.method> references/raw-api.md
 ```
 
 Default to `+helpers` before raw API calls. They handle tedious encoding
@@ -348,6 +396,12 @@ Find the current project with `gws auth status | jq .project_id`.
 - **Version drift** — if a flag shown here errors out, the installed `gws`
   may be ahead of this skill. Run `gws <svc> --help` and prefer the live
   output.
+- **GCP Console passkey re-auth** — `console.cloud.google.com` always
+  demands passkey verification, even with a saved Google session. When
+  walking a user through manual GCP Console steps (OAuth client,
+  consent-screen scopes, Chat app), batch them into one session so they
+  authenticate once. `scripts/onboard.sh` is structured to do exactly
+  that.
 
 ---
 

--- a/claude-skills/skills/google-workspace/scripts/auth-login.sh
+++ b/claude-skills/skills/google-workspace/scripts/auth-login.sh
@@ -28,11 +28,35 @@ fi
 LOG=$(mktemp -t gws-auth-login.XXXXXX)
 trap 'rm -f "$LOG"' EXIT
 
-# If the caller didn't specify a scope-shaping flag, default to `--full`.
-# That grants every available scope including cloud-platform + pubsub —
-# needed to avoid 403s on APIs that enforce `serviceusage.services.use`
-# (Drive, Tasks, Chat, People). Pass `--readonly`, `--services ...`, or
-# `--scopes ...` explicitly to override.
+# Curated scope list covering every Workspace API the skill exercises.
+# Kept in sync with scripts/onboard.sh (single source of truth).
+#
+# Why not `--full`? gws's `--full` silently drops sensitive scopes
+# (chat.spaces, contacts, directory.readonly, forms.body,
+# meetings.space.created) that aren't pre-registered on the project's
+# OAuth consent screen. Passing the explicit list surfaces the drop:
+# Google still won't grant unregistered scopes, but at least the
+# request matches the user's intent.
+GWS_DEFAULT_SCOPES="\
+https://www.googleapis.com/auth/drive,\
+https://www.googleapis.com/auth/spreadsheets,\
+https://www.googleapis.com/auth/gmail.modify,\
+https://www.googleapis.com/auth/calendar,\
+https://www.googleapis.com/auth/documents,\
+https://www.googleapis.com/auth/presentations,\
+https://www.googleapis.com/auth/tasks,\
+https://www.googleapis.com/auth/chat.spaces,\
+https://www.googleapis.com/auth/contacts,\
+https://www.googleapis.com/auth/directory.readonly,\
+https://www.googleapis.com/auth/forms.body,\
+https://www.googleapis.com/auth/meetings.space.created,\
+openid,\
+https://www.googleapis.com/auth/userinfo.email,\
+https://www.googleapis.com/auth/userinfo.profile"
+
+# If the caller didn't specify a scope-shaping flag, request our explicit
+# 15-scope list. Pass `--full`, `--readonly`, `--services …`, or
+# `--scopes …` to override.
 HAS_SCOPE_FLAG=0
 for arg in "$@"; do
   case "$arg" in
@@ -40,8 +64,8 @@ for arg in "$@"; do
   esac
 done
 if [ "$HAS_SCOPE_FLAG" -eq 0 ]; then
-  set -- --full "$@"
-  echo "→ no scope flag given; defaulting to --full (all available scopes)"
+  set -- --scopes "$GWS_DEFAULT_SCOPES" "$@"
+  echo "→ no scope flag given; requesting the curated 15-scope BSG default"
 fi
 
 # Start `gws auth login` in the background, capturing stdout+stderr.
@@ -135,8 +159,16 @@ if [ -n "$CID" ] && [ -n "$CSECRET" ] && [ -n "$REFRESH" ] && command -v curl >/
     COUNT=$(printf '%s\n' "$GRANTED" | grep -c .)
     echo "→ granted $COUNT scope(s)"
 
-    # Warn on notable omissions when the caller asked for --full
+    # Warn on notable omissions when the caller asked for --full or our
+    # curated default list. Drops here usually mean the scope isn't
+    # registered on the project's OAuth consent screen.
+    REQUESTED_BROAD=0
     if printf "%s\n" "$@" | grep -q -- '--full'; then
+      REQUESTED_BROAD=1
+    elif printf "%s\n" "$@" | grep -q -- "$GWS_DEFAULT_SCOPES"; then
+      REQUESTED_BROAD=1
+    fi
+    if [ "$REQUESTED_BROAD" -eq 1 ]; then
       MISSING=""
       for needle in chat. contacts people directory forms keep meet; do
         if ! printf "%s" "$GRANTED" | grep -q "$needle"; then
@@ -144,10 +176,11 @@ if [ -n "$CID" ] && [ -n "$CSECRET" ] && [ -n "$REFRESH" ] && command -v curl >/
         fi
       done
       if [ -n "$MISSING" ]; then
-        warn "requested --full but consent dropped:$MISSING"
+        warn "consent dropped:$MISSING"
         warn "Google's consent screen shows sensitive scopes as individual"
-        warn "checkboxes. Re-run and TICK EVERY BOX, or the scopes won't be"
-        warn "on your access token even though the OAuth URL requested them."
+        warn "checkboxes. Either (a) re-run and TICK EVERY BOX, or (b) add"
+        warn "the missing scopes on the OAuth consent screen first:"
+        warn "  bash scripts/onboard.sh --step scopes"
       fi
     fi
   fi

--- a/claude-skills/skills/google-workspace/scripts/doctor.sh
+++ b/claude-skills/skills/google-workspace/scripts/doctor.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# doctor.sh — daily health check for `gws`, with auto-repair of missing
+# scopes. Run before a Workspace-heavy session, or wire into a PreToolUse
+# hook to surface drift early.
+#
+#   bash scripts/doctor.sh             # full check
+#   bash scripts/doctor.sh --quiet     # exit codes only, no output if green
+#   bash scripts/doctor.sh --no-repair # skip auto-relogin even on missing scopes
+#
+# Exit codes (suitable for hook gating):
+#   0  all green
+#   1  warnings only (e.g. outdated gws version)
+#   2  one or more services failing or auth invalid
+#
+# Distinct from scripts/onboard.sh — that's the one-shot zero-to-working
+# bootstrap. doctor is the recurring "is everything still wired up?" check.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+QUIET=0
+REPAIR=1
+for arg in "$@"; do
+  case "$arg" in
+    --quiet)     QUIET=1 ;;
+    --no-repair) REPAIR=0 ;;
+    -h|--help) sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  esac
+done
+
+# Buffered output so --quiet can suppress everything when exit == 0.
+BUF=$(mktemp -t gws-doctor.XXXXXX)
+trap 'rm -f "$BUF"' EXIT
+say()  { printf "%s\n" "$*" >>"$BUF"; }
+ok()   { say "  ✓ $*"; }
+warn() { say "  ⚠ $*"; }
+bad()  { say "  ✗ $*"; }
+hdr()  { say ""; say "[$1] $2"; }
+
+EXIT_CODE=0
+bump() { [ "$1" -gt "$EXIT_CODE" ] && EXIT_CODE=$1 || true; }
+
+# Same scope list as scripts/auth-login.sh and scripts/onboard.sh.
+EXPECTED_SCOPES=(
+  https://www.googleapis.com/auth/drive
+  https://www.googleapis.com/auth/spreadsheets
+  https://www.googleapis.com/auth/gmail.modify
+  https://www.googleapis.com/auth/calendar
+  https://www.googleapis.com/auth/documents
+  https://www.googleapis.com/auth/presentations
+  https://www.googleapis.com/auth/tasks
+  https://www.googleapis.com/auth/chat.spaces
+  https://www.googleapis.com/auth/contacts
+  https://www.googleapis.com/auth/directory.readonly
+  https://www.googleapis.com/auth/forms.body
+  https://www.googleapis.com/auth/meetings.space.created
+  openid
+  https://www.googleapis.com/auth/userinfo.email
+  https://www.googleapis.com/auth/userinfo.profile
+)
+EXPECTED_COUNT=${#EXPECTED_SCOPES[@]}
+
+#==============================================================================
+# [1/4] Binary & version
+#==============================================================================
+hdr "1/4" "Binary & version"
+
+if ! command -v gws >/dev/null; then
+  bad "gws not installed"
+  bad "  → npm install -g @googleworkspace/cli@latest"
+  bump 2
+else
+  INSTALLED=$(gws --version 2>/dev/null | head -1 | awk '{print $2}')
+  ok "gws $INSTALLED"
+  LATEST=$(npm view @googleworkspace/cli version 2>/dev/null || true)
+  if [ -n "$LATEST" ] && [ "$INSTALLED" != "$LATEST" ]; then
+    warn "$LATEST available — npm install -g @googleworkspace/cli@latest"
+    bump 1
+  fi
+fi
+
+if ! command -v jq >/dev/null; then
+  bad "jq not installed — brew install jq"
+  bump 2
+fi
+
+#==============================================================================
+# [2/4] Auth & token
+#==============================================================================
+hdr "2/4" "Auth & token"
+
+if [ "$EXIT_CODE" -ge 2 ]; then
+  warn "skipping (binary/jq missing)"
+else
+  STATUS=$(gws auth status 2>/dev/null || echo '{}')
+  TOKEN_VALID=$(echo "$STATUS" | jq -r '.token_valid // false')
+  PROJECT=$(echo "$STATUS" | jq -r '.project_id // empty')
+
+  if [ "$TOKEN_VALID" != "true" ]; then
+    bad "token_valid = false"
+    bad "  → bash scripts/auth-login.sh"
+    bump 2
+  else
+    ok "token_valid = true"
+    [ -n "$PROJECT" ] && ok "project   = $PROJECT"
+
+    EMAIL=$(gws gmail users getProfile --params '{"userId":"me"}' 2>/dev/null \
+            | jq -r '.emailAddress // empty')
+    [ -n "$EMAIL" ] && ok "user      = $EMAIL"
+  fi
+fi
+
+#==============================================================================
+# [3/4] Scope audit
+#==============================================================================
+hdr "3/4" "Scope audit"
+
+mint_access_token() {
+  local cid csecret refresh
+  cid=$(gws auth export --unmasked 2>/dev/null | jq -r '.client_id // empty')
+  csecret=$(gws auth export --unmasked 2>/dev/null | jq -r '.client_secret // empty')
+  refresh=$(gws auth export --unmasked 2>/dev/null | jq -r '.refresh_token // empty')
+  [ -n "$cid" ] && [ -n "$csecret" ] && [ -n "$refresh" ] || return 1
+  curl -sX POST https://oauth2.googleapis.com/token \
+    -d "client_id=$cid" -d "client_secret=$csecret" \
+    -d "refresh_token=$refresh" -d "grant_type=refresh_token" \
+    | jq -r '.access_token // empty'
+}
+
+audit_scopes() {
+  local access granted missing s
+  access=$(mint_access_token) || return 1
+  [ -n "$access" ] || return 1
+  granted=$(curl -s "https://oauth2.googleapis.com/tokeninfo?access_token=$access" \
+            | jq -r '.scope // empty' | tr ' ' '\n' | sort -u)
+  GRANTED_COUNT=$(printf '%s\n' "$granted" | grep -c .)
+  MISSING_LIST=()
+  for s in "${EXPECTED_SCOPES[@]}"; do
+    if ! printf "%s\n" "$granted" | grep -Fxq "$s"; then
+      MISSING_LIST+=("$s")
+    fi
+  done
+}
+
+if [ "$EXIT_CODE" -ge 2 ]; then
+  warn "skipping (auth invalid)"
+else
+  GRANTED_COUNT=0
+  MISSING_LIST=()
+  if audit_scopes; then
+    ok "Expected: $EXPECTED_COUNT scopes"
+    ok "Granted : $GRANTED_COUNT"
+    if [ "${#MISSING_LIST[@]}" -gt 0 ]; then
+      warn "Missing : ${#MISSING_LIST[@]} scope(s)"
+      for s in "${MISSING_LIST[@]}"; do
+        warn "    - ${s##*/}"
+      done
+      if [ "$REPAIR" -eq 1 ]; then
+        say "  → re-running auth-login.sh to request the full scope list…"
+        # Run and append output to BUF so --quiet still suppresses on green.
+        bash "$SCRIPT_DIR/auth-login.sh" >>"$BUF" 2>&1 || true
+        if audit_scopes && [ "${#MISSING_LIST[@]}" -eq 0 ]; then
+          ok "re-auth complete — $GRANTED_COUNT/$EXPECTED_COUNT scopes granted"
+        else
+          warn "still missing ${#MISSING_LIST[@]} scope(s) — likely not registered"
+          warn "on the OAuth consent screen. Fix:"
+          warn "  bash scripts/onboard.sh --step scopes"
+          bump 2
+        fi
+      else
+        bump 1
+      fi
+    fi
+  else
+    warn "could not mint access token to audit scopes (skipping)"
+    bump 1
+  fi
+fi
+
+#==============================================================================
+# [4/4] Service smoke tests
+#==============================================================================
+hdr "4/4" "Service smoke tests"
+
+if [ "$EXIT_CODE" -ge 2 ]; then
+  warn "skipping (auth or scope problem above)"
+else
+  smoke() {
+    local name="$1"; local fix="$2"; shift 2
+    if "$@" >/dev/null 2>&1; then
+      ok "$name"
+    else
+      bad "$name"
+      [ -n "$fix" ] && bad "    Fix: $fix"
+      bump 2
+    fi
+  }
+
+  smoke "Gmail    (messages.list)"  ""                                          gws gmail users messages list --params '{"userId":"me","maxResults":1}'
+  smoke "Calendar (events.list)"    ""                                          gws calendar events list --params '{"calendarId":"primary","maxResults":1}'
+  smoke "Drive    (files.list)"     "bash scripts/fix-iam-403.sh"               gws drive files list --params '{"pageSize":1}'
+  smoke "Tasks    (tasklists.list)" "bash scripts/fix-iam-403.sh"               gws tasks tasklists list --params '{"maxResults":1}'
+  smoke "Chat     (spaces.list)"    "bash scripts/onboard.sh --step chat-app"   gws chat spaces list --params '{"pageSize":1}'
+  smoke "Contacts (listDirectory)"  "bash scripts/onboard.sh --step scopes"     gws people people listDirectoryPeople --params '{"readMask":"emailAddresses","sources":"DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE","pageSize":1}'
+fi
+
+#==============================================================================
+# Output
+#==============================================================================
+if [ "$QUIET" -eq 1 ] && [ "$EXIT_CODE" -eq 0 ]; then
+  : # silent on green
+else
+  cat "$BUF"
+  echo
+  case "$EXIT_CODE" in
+    0) echo "✓ healthy" ;;
+    1) echo "⚠ warnings — see above" ;;
+    2) echo "✗ failures — see above" ;;
+  esac
+fi
+
+exit "$EXIT_CODE"

--- a/claude-skills/skills/google-workspace/scripts/onboard.sh
+++ b/claude-skills/skills/google-workspace/scripts/onboard.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# onboard.sh — zero-to-working `gws` setup, in one orchestrated flow.
+#
+# Solves the friction stack discovered in beyond-scale-group/bsg-stack#38:
+# missing prereqs, OAuth client to be created by hand, scopes silently
+# dropped because they aren't registered on the consent screen, and the
+# Chat API requiring a separate app registration.
+#
+# Each step is idempotent. Re-run the whole script or jump to a single
+# step:
+#
+#   bash scripts/onboard.sh                    # full flow
+#   bash scripts/onboard.sh --step prereqs     # just the binary checks
+#   bash scripts/onboard.sh --step apis        # just `gcloud services enable`
+#   bash scripts/onboard.sh --step oauth       # OAuth client creation guide
+#   bash scripts/onboard.sh --step scopes      # consent-screen scope guide
+#   bash scripts/onboard.sh --step chat-app    # Chat app registration guide
+#   bash scripts/onboard.sh --step login       # `gws auth login` with our scopes
+#   bash scripts/onboard.sh --step smoke       # service smoke tests
+#
+# Steps that need GCP Console interaction print the exact URL + checklist
+# and pause. Browser automation is intentionally NOT bundled here — see
+# beyond-scale-group/bsg-stack#39 for the planned `/browser` skill that
+# will wrap agent-browser with persistent login state. Once that lands,
+# this script will gain an `--auto` mode that drives the GCP Console
+# steps without manual interaction.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+step()  { printf "\n\033[1;34m▸ %s\033[0m\n" "$*"; }
+info()  { printf "  %s\n" "$*"; }
+ok()    { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn()  { printf "  \033[33m⚠\033[0m %s\n" "$*" >&2; }
+die()   { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+pause() {
+  if [ ! -t 0 ]; then
+    info "(non-interactive — skipping prompt)"
+    return 0
+  fi
+  printf "\n  Press ENTER when done, or Ctrl-C to abort: "
+  read -r _ || true
+}
+
+# Single source of truth for the curated 15-scope default. Mirrored in
+# scripts/auth-login.sh — keep them in sync.
+SCOPES=(
+  https://www.googleapis.com/auth/drive
+  https://www.googleapis.com/auth/spreadsheets
+  https://www.googleapis.com/auth/gmail.modify
+  https://www.googleapis.com/auth/calendar
+  https://www.googleapis.com/auth/documents
+  https://www.googleapis.com/auth/presentations
+  https://www.googleapis.com/auth/tasks
+  https://www.googleapis.com/auth/chat.spaces
+  https://www.googleapis.com/auth/contacts
+  https://www.googleapis.com/auth/directory.readonly
+  https://www.googleapis.com/auth/forms.body
+  https://www.googleapis.com/auth/meetings.space.created
+  openid
+  https://www.googleapis.com/auth/userinfo.email
+  https://www.googleapis.com/auth/userinfo.profile
+)
+
+# APIs that must be enabled on the GCP project. People + Forms + Chat +
+# Meet are the ones whose absence makes the corresponding scopes
+# disappear from the consent-screen picker.
+APIS=(
+  drive.googleapis.com
+  sheets.googleapis.com
+  gmail.googleapis.com
+  calendar-json.googleapis.com
+  docs.googleapis.com
+  slides.googleapis.com
+  tasks.googleapis.com
+  chat.googleapis.com
+  people.googleapis.com
+  forms.googleapis.com
+  meet.googleapis.com
+)
+
+#==============================================================================
+# Step implementations
+#==============================================================================
+
+step_prereqs() {
+  step "Step 1/7 — Prerequisites"
+
+  if ! command -v node >/dev/null; then
+    die "node not installed — install Node.js first (https://nodejs.org)"
+  fi
+  ok "node $(node --version)"
+
+  if ! command -v npm >/dev/null; then
+    die "npm not installed (should ship with Node.js)"
+  fi
+  ok "npm $(npm --version)"
+
+  if ! command -v gws >/dev/null; then
+    info "gws not installed — installing globally now"
+    npm install -g @googleworkspace/cli@latest
+  fi
+  ok "gws $(gws --version | head -1 | awk '{print $2}')"
+
+  if ! command -v jq >/dev/null; then
+    die "jq not installed — brew install jq"
+  fi
+  ok "jq $(jq --version)"
+
+  if ! command -v gcloud >/dev/null; then
+    warn "gcloud not installed — required for Step 2 (enabling APIs) and"
+    warn "Step 7 (smoke tests via Chat API). Install with:"
+    warn "  brew install --cask google-cloud-sdk"
+    warn "Skipping prereq gate — re-run later if you want."
+  else
+    ok "gcloud $(gcloud --version 2>/dev/null | head -1 | awk '{print $4}')"
+  fi
+}
+
+resolve_project() {
+  if [ -n "${GWS_PROJECT_ID:-}" ]; then
+    PROJECT="$GWS_PROJECT_ID"
+    return
+  fi
+  PROJECT=$(gws auth status 2>/dev/null | jq -r '.project_id // empty')
+  if [ -z "$PROJECT" ] && command -v gcloud >/dev/null; then
+    PROJECT=$(gcloud config get-value project 2>/dev/null | grep -v '^$' || true)
+    [ "$PROJECT" = "(unset)" ] && PROJECT=""
+  fi
+  if [ -z "$PROJECT" ] && [ -t 0 ]; then
+    printf "  Enter your GCP project ID: "
+    read -r PROJECT
+  fi
+  [ -n "$PROJECT" ] || die "no GCP project — set GWS_PROJECT_ID or pass one interactively"
+}
+
+step_apis() {
+  step "Step 2/7 — Enable Workspace APIs on the GCP project"
+
+  command -v gcloud >/dev/null || die "gcloud required for this step"
+
+  resolve_project
+  info "project: $PROJECT"
+
+  # gcloud needs to be logged in.
+  ACTIVE=$(gcloud config get-value account 2>/dev/null || true)
+  if [ -z "$ACTIVE" ] || [ "$ACTIVE" = "(unset)" ]; then
+    info "gcloud not authenticated — running: gcloud auth login"
+    gcloud auth login
+  fi
+
+  info "enabling ${#APIS[@]} APIs on $PROJECT (idempotent)…"
+  gcloud services enable "${APIS[@]}" --project="$PROJECT" --quiet
+  ok "all APIs enabled"
+}
+
+step_oauth() {
+  step "Step 3/7 — Create OAuth client (manual, GCP Console)"
+
+  CLIENT_PATH="${GOOGLE_WORKSPACE_CLI_CONFIG_DIR:-$HOME/.config/gws}/client_secret.json"
+
+  if [ -f "$CLIENT_PATH" ]; then
+    ok "OAuth client already in place at $CLIENT_PATH"
+    info "Re-run with --force-oauth to redo this step."
+    [ "${FORCE_OAUTH:-0}" = "1" ] || return 0
+  fi
+
+  resolve_project
+  cat <<EOF
+
+  gws cannot auto-create the OAuth client — Google requires manual setup
+  in the GCP Console. Open this URL:
+
+      https://console.cloud.google.com/apis/credentials?project=$PROJECT
+
+  Then:
+
+    1. Click "Create Credentials" → "OAuth client ID"
+    2. Application type: "Desktop app"
+    3. Name: "gws CLI"  (any name works)
+    4. Click "Create"
+    5. Download the JSON
+    6. Save it to: $CLIENT_PATH
+
+  ⚠ GCP Console always demands passkey re-authentication, even with a
+    saved browser session. Plan to authenticate once for the whole
+    onboard run.
+
+EOF
+  pause
+
+  if [ ! -f "$CLIENT_PATH" ]; then
+    warn "client_secret.json still missing at $CLIENT_PATH"
+    warn "Drop the downloaded JSON there and re-run: bash scripts/onboard.sh --step oauth"
+    return 1
+  fi
+  ok "client_secret.json detected"
+}
+
+step_scopes() {
+  step "Step 4/7 — Register scopes on the OAuth consent screen (manual)"
+
+  resolve_project
+  cat <<EOF
+
+  Google's consent screen silently drops any scope that isn't registered
+  on the project's OAuth consent screen. APIs (Step 2) must be enabled
+  first or these scopes won't appear in the picker.
+
+  Open this URL:
+
+      https://console.cloud.google.com/apis/credentials/consent?project=$PROJECT
+
+  Then:
+
+    1. Click "Edit App"
+    2. Click through to "Scopes"
+    3. Click "Add or Remove Scopes"
+    4. In the "Manually add scopes" field at the bottom, paste each line
+       below (one at a time, or comma-separated if the form accepts it):
+
+EOF
+  for s in "${SCOPES[@]}"; do
+    printf "         %s\n" "$s"
+  done
+  cat <<EOF
+
+    5. Click "Add to Table" → tick every newly added scope → "Update"
+    6. "Save and Continue" through the rest of the wizard
+
+EOF
+  pause
+  ok "scope registration acknowledged (verified at Step 6)"
+}
+
+step_chat_app() {
+  step "Step 5/7 — Register Chat app (manual, GCP Console)"
+
+  resolve_project
+  cat <<EOF
+
+  The Chat API requires a registered "Chat app configuration" before any
+  endpoint will respond — even read-only user-context calls. Without
+  this, every chat.* call returns 404 "Google Chat app not found".
+
+  Open this URL:
+
+      https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat?project=$PROJECT
+
+  Then:
+
+    1. App name        : gws CLI (or any name)
+    2. Avatar URL      : https://developers.google.com/chat/images/quickstart-app-avatar.png
+    3. Description     : User-context CLI access via gws
+    4. Functionality   : tick "Receive 1:1 messages" + "Join spaces and group conversations"
+    5. Connection      : "App URL" — placeholder OK (user-context CLI never receives webhooks)
+                         e.g. https://example.com/chat
+    6. Visibility      : "Make this Chat app available to specific people…"
+                         Add your own email
+    7. Click "Save"
+
+EOF
+  pause
+  ok "Chat app registration acknowledged (verified at Step 7)"
+}
+
+step_login() {
+  step "Step 6/7 — OAuth login with the curated 15-scope list"
+
+  bash "$SCRIPT_DIR/auth-login.sh"
+
+  STATUS=$(gws auth status 2>/dev/null)
+  if ! echo "$STATUS" | jq -e '.token_valid == true' >/dev/null; then
+    die "auth still invalid after login — check the OAuth client and try again"
+  fi
+
+  # Cross-check the granted scope count against our 15 explicit scopes.
+  CID=$(gws auth export --unmasked 2>/dev/null | jq -r '.client_id // empty')
+  CSECRET=$(gws auth export --unmasked 2>/dev/null | jq -r '.client_secret // empty')
+  REFRESH=$(gws auth export --unmasked 2>/dev/null | jq -r '.refresh_token // empty')
+  if [ -n "$CID" ] && [ -n "$CSECRET" ] && [ -n "$REFRESH" ]; then
+    ACCESS=$(curl -sX POST https://oauth2.googleapis.com/token \
+      -d "client_id=$CID" -d "client_secret=$CSECRET" \
+      -d "refresh_token=$REFRESH" -d "grant_type=refresh_token" \
+      | jq -r '.access_token // empty')
+    if [ -n "$ACCESS" ]; then
+      GRANTED=$(curl -s "https://oauth2.googleapis.com/tokeninfo?access_token=$ACCESS" \
+                | jq -r '.scope // empty' | tr ' ' '\n' | sort -u)
+      COUNT=$(printf '%s\n' "$GRANTED" | grep -c .)
+      ok "granted $COUNT scope(s) (expected ${#SCOPES[@]})"
+      if [ "$COUNT" -lt "${#SCOPES[@]}" ]; then
+        warn "Some scopes were dropped — likely missing from the consent"
+        warn "screen registration. Re-run Step 4: bash scripts/onboard.sh --step scopes"
+      fi
+    fi
+  fi
+}
+
+step_smoke() {
+  step "Step 7/7 — Service smoke tests"
+
+  PASS=0; FAIL=0
+  smoke() {
+    local name="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+      ok "$name"
+      PASS=$((PASS+1))
+    else
+      warn "$name FAILED"
+      FAIL=$((FAIL+1))
+    fi
+  }
+
+  smoke "Gmail    (messages.list)"  gws gmail users messages list --params '{"userId":"me","maxResults":1}'
+  smoke "Calendar (events.list)"    gws calendar events list --params '{"calendarId":"primary","maxResults":1}'
+  smoke "Drive    (files.list)"     gws drive files list --params '{"pageSize":1}'
+  smoke "Sheets   (api reachable)"  bash -c "gws sheets --help"
+  smoke "Tasks    (tasklists.list)" gws tasks tasklists list --params '{"maxResults":1}'
+  smoke "Chat     (spaces.list)"    gws chat spaces list --params '{"pageSize":1}'
+  smoke "People   (contactGroups)"  gws people contactGroups list --params '{"pageSize":1}'
+  smoke "Forms    (api reachable)"  bash -c "gws forms --help"
+
+  echo
+  if [ "$FAIL" -eq 0 ]; then
+    ok "all $PASS smoke tests passed — gws is ready"
+  else
+    warn "$FAIL of $((PASS+FAIL)) smoke tests failed"
+    warn "Common fixes:"
+    warn "  • 403 IAM      → bash scripts/fix-iam-403.sh --enable-apis"
+    warn "  • 404 Chat app → bash scripts/onboard.sh --step chat-app"
+    warn "  • Missing scope → bash scripts/onboard.sh --step scopes && --step login"
+    return 1
+  fi
+}
+
+#==============================================================================
+# CLI
+#==============================================================================
+
+usage() {
+  sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+STEP="all"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --step) STEP="$2"; shift 2 ;;
+    --force-oauth) FORCE_OAUTH=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown flag: $1 (try --help)" ;;
+  esac
+done
+
+case "$STEP" in
+  all)
+    step_prereqs
+    step_apis
+    step_oauth
+    step_scopes
+    step_chat_app
+    step_login
+    step_smoke
+    echo
+    ok "Onboarding complete."
+    ;;
+  prereqs)   step_prereqs ;;
+  apis)      step_apis ;;
+  oauth)     step_oauth ;;
+  scopes)    step_scopes ;;
+  chat-app)  step_chat_app ;;
+  login)     step_login ;;
+  smoke)     step_smoke ;;
+  *) die "unknown step: $STEP (valid: prereqs, apis, oauth, scopes, chat-app, login, smoke, all)" ;;
+esac


### PR DESCRIPTION
Closes #38. Spawns follow-up #39 (browser skill) for the deferred GCP-Console automation.

## Summary

- **`scripts/onboard.sh`** — 7-step idempotent orchestrator (prereqs → enable APIs → OAuth client → consent-screen scopes → Chat app → login → smoke tests). Re-runnable per step via `--step <name>`. GCP-Console steps print the exact URL + checklist and pause; no browser automation yet (deferred to #39).
- **`scripts/doctor.sh`** — read-only daily health check (binary/version, auth, scope audit, service smoke tests). Exit codes `0` healthy / `1` warnings / `2` failures so it can gate a PreToolUse hook. Auto-repairs missing scopes by re-running `auth-login.sh`.
- **`scripts/auth-login.sh`** — defaults to a curated 15-scope list instead of `--full`. `--full` silently drops `chat.spaces`, `contacts`, `directory.readonly`, `forms.body`, `meetings.space.created`; passing scopes explicitly surfaces the drop. The post-login warning now triggers on either `--full` or the curated default.
- **`SKILL.md`** — adds `+onboard` / `+doctor` to the decision tree, documents the GCP Console passkey caveat, and cross-links Chat app registration from the auth-error block.

## Why no browser automation in this PR

The original ticket asked for `agent-browser` automation of the OAuth client / consent-screen / Chat-app forms. GCP Console DOM selectors break frequently and login state is annoying to persist, so we extracted that into a dedicated `/browser` skill (#39). Once #39 ships, `onboard.sh` will gain `--auto` and the manual checklists become the fallback.

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — 7/7 pass (footer + INSTALL.md catalog invariants intact).
- [x] `bash -n` syntax check on all three scripts.
- [x] `scripts/onboard.sh --step prereqs` exits clean on a configured machine.
- [x] `scripts/doctor.sh --quiet` exits 0 on a configured machine.
- [ ] Full `scripts/onboard.sh` run from a clean machine — needs human (planned follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)