### PR TITLE
docs(agents): add PRDs for 7 new company agents

### DIFF
--- a/claude-skills/prds/001-security.md
+++ b/claude-skills/prds/001-security.md
@@ -1,0 +1,193 @@
+# PRD-001: Security Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P0 — Phase 1
+
+---
+
+## 1. Problem Statement
+
+BSG repositories have no automated, recurring security posture assessment.
+Dependency vulnerabilities accumulate silently, secrets occasionally slip into
+committed code, and OWASP compliance is checked ad-hoc (if at all). Developers
+discover security issues reactively — after a breach scare, a failed audit, or
+a customer report — rather than through a systematic, repo-scoped review cadence.
+
+## 2. Goal
+
+Provide a Claude Code subagent that, on every `tick`, produces a dated security
+audit report covering dependency vulnerabilities, secret detection, and
+configuration hardening — and stays silent when the posture is clean.
+
+## 3. Non-Goals
+
+- **Runtime security monitoring** (WAF, IDS, SIEM). This agent audits source
+  code and configuration at rest, not live traffic.
+- **Penetration testing or exploit generation.** The agent flags risks; it does
+  not attempt exploitation.
+- **Fixing vulnerabilities automatically.** The agent reports; the developer (or
+  another agent) remediates. The agent may suggest fixes in its narrative but
+  must not commit code changes.
+- **CI/CD pipeline integration.** Per BSG convention, no GitHub Actions or cron
+  jobs. The agent runs on-demand via `@security tick`.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| S1 | Developer | Run `@security tick` and get a one-line receipt if everything is clean | I don't waste time reading "all good" reports |
+| S2 | Developer | Get alerted when a critical CVE lands in my dependency tree | I can prioritize the upgrade before it's exploited |
+| S3 | Tech lead | See a dated trail of security audits in `security/reports/` | I can demonstrate compliance to stakeholders |
+| S4 | Developer | Run `@security secrets` to scan for leaked credentials | I can catch accidental commits before they reach production |
+| S5 | Developer | Run `@security deps` to see just the dependency vulnerability summary | I can focus on one dimension without the full audit |
+| S6 | Developer | Run `@security checklist` for an OWASP top-10 gap analysis | I can verify a feature against the standard before shipping |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: security
+description: >
+  Security posture auditor for the current GitHub repository. Scans for
+  dependency vulnerabilities, committed secrets, and OWASP top-10 gaps.
+  Use when the user asks for "security audit", "vulnerability scan",
+  "secret scan", "OWASP check", "dependency vulnerabilities", "security
+  posture", "are we secure", "audit de sécurité", or "analyse des
+  vulnérabilités".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [security-report]
+color: red
+output: pr
+tick: >
+  Run the full security audit (deps + secrets + config), land it as
+  security/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
+  silent in chat unless a silence-breaker fires.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "security audit", "full scan", "posture check" | Run all scripts, produce full report |
+| "dependency scan", "CVEs", "vulnerabilities" | `security-report` -> `references/deps.md` |
+| "secret scan", "leaked credentials", "tokens in code" | `security-report` -> `references/secrets.md` |
+| "OWASP", "checklist", "top 10" | `security-report` -> `references/owasp.md` |
+| "security headers", "CSP", "CORS", "HSTS" | `security-report` -> `references/headers.md` |
+| "fix vulnerability X", "upgrade package Y" | Decline; hand back to main agent |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather a security snapshot (`/tmp/security-snap.json`):
+   - `npm audit --json` / `pip-audit --format=json` (language-detected)
+   - `gh api /repos/{owner}/{repo}/vulnerability-alerts`
+   - Secret pattern grep results
+   - Config file inventory (CSP headers, `.env.example` vs `.env`, etc.)
+
+2. Run individual reporters against the snapshot:
+   - `deps.sh --snapshot /tmp/security-snap.json` — dependency CVEs
+   - `secrets.sh --snapshot /tmp/security-snap.json` — secret patterns
+   - `headers.sh --snapshot /tmp/security-snap.json` — config hardening
+
+3. `generate-report.sh` composes the full report:
+   ```
+   security/reports/2026-04-20-audit.md
+   ```
+
+4. Land via `open-report-pr.sh`:
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     security/reports/$(date +%F)-audit.md \
+     --agent security
+   ```
+
+5. Evaluate silence-breakers. Reply with one-line receipt if none fire.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Critical/high CVE in dependencies | `deps.sh` -> `severity: critical\|high` | Any |
+| Secret pattern detected in tracked files | `secrets.sh` -> `findings[]` | Non-empty |
+| Missing security headers in config | `headers.sh` -> `missing[]` | Any critical header (CSP, HSTS) |
+| Known-vulnerable dependency with no fix available | `deps.sh` -> `noFix[]` | Any critical |
+| `.env` or credentials file tracked by git | `secrets.sh` -> `trackedEnvFiles[]` | Non-empty |
+
+## 6. Skill Structure
+
+```
+skills/security-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── deps.md                 # Dependency vulnerability analysis guide
+│   ├── secrets.md              # Secret scanning guide
+│   ├── owasp.md                # OWASP top-10 checklist guide
+│   └── headers.md              # Security headers/config guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector (language-aware)
+    ├── deps.sh                 # Dependency vulnerability reporter
+    ├── secrets.sh              # Secret pattern scanner
+    ├── headers.sh              # Config/headers auditor
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# Security Audit — 2026-04-20
+
+## Dependency Vulnerabilities
+| Package | Severity | CVE | Fix available |
+|---------|----------|-----|---------------|
+| …       | critical | …   | Yes — v2.3.1  |
+
+**Summary:** 2 critical, 1 high, 4 moderate
+
+## Secret Scan
+- 0 secrets detected in tracked files
+- .env is in .gitignore: YES
+
+## Configuration Hardening
+| Header/Config | Status |
+|---------------|--------|
+| CSP            | Present |
+| HSTS           | Missing |
+
+## OWASP Top-10 Quick Check
+| Category | Status | Notes |
+|----------|--------|-------|
+| A01 Broken Access Control | … | … |
+```
+
+## 8. Dependencies
+
+- `npm` or `pip` (language-detected per repo)
+- `gh` CLI (authenticated)
+- `jq` for JSON processing
+- `grep` with PCRE support for secret patterns
+- Optional: `pip-audit`, `npm audit` (bundled with their package managers)
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Time from CVE publication to developer notification | < 24h (with daily tick) |
+| False positive rate on secret scanning | < 10% |
+| Report generation time | < 30s for repos with < 500 dependencies |
+| Adoption across BSG repos | 100% within 4 weeks of launch |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `npm audit` / `pip-audit` not installed | `collect.sh` detects available tools, skips gracefully, flags in report |
+| Secret scanner false positives (test fixtures, examples) | Respect `.securityignore` file for exclusion patterns |
+| Large repos slow to scan | `collect.sh` caps file count, uses `.gitignore`-aware search |
+| Different repos use different languages | `collect.sh` auto-detects from lockfiles (package-lock.json, Pipfile.lock, go.sum, Cargo.lock) |

--- a/claude-skills/prds/002-qa.md
+++ b/claude-skills/prds/002-qa.md
@@ -1,0 +1,204 @@
+# PRD-002: QA Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P0 — Phase 1
+
+---
+
+## 1. Problem Statement
+
+Test coverage, regression risk, and flaky tests are tracked inconsistently
+across BSG repositories. Developers merge features without knowing which
+high-churn files lack coverage, CI failures are dismissed as "flaky" without
+investigation, and coverage trends are invisible unless someone manually pulls
+reports. There is no systematic, recurring quality gate that surfaces
+regression risk before it becomes a production incident.
+
+## 2. Goal
+
+Provide a Claude Code subagent that, on every `tick`, produces a dated QA
+report covering test coverage trends, regression risk scoring (high-churn +
+low-coverage files), and flaky test detection — landing it via auto-merge PR
+and staying silent when quality metrics are stable.
+
+## 3. Non-Goals
+
+- **Writing tests.** The agent identifies gaps; the developer writes the tests.
+  The agent may suggest test strategies in its narrative but must not commit
+  test code.
+- **Running the full test suite.** The agent reads existing coverage reports and
+  CI logs; it does not execute `npm test` or `pytest` itself (too slow, too
+  side-effectful for a reporting agent).
+- **Replacing CI.** The agent complements CI by providing trend analysis and
+  risk scoring that CI pipelines don't natively offer.
+- **E2E or integration test orchestration.** Scope is limited to unit/integration
+  coverage and CI log analysis.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| Q1 | Developer | Run `@qa tick` and get a one-line receipt if coverage is stable | I don't waste time on healthy repos |
+| Q2 | Developer | See which files changed most in the last 30 days but have < 50% coverage | I know where the next regression will come from |
+| Q3 | Tech lead | Track coverage trends over time in `qa/reports/` | I can show the team we're improving (or not) |
+| Q4 | Developer | Run `@qa flaky` to see which tests failed intermittently in recent CI | I can prioritize stabilization work |
+| Q5 | Developer | Run `@qa coverage` for the latest coverage summary | I get a quick snapshot without digging through CI artifacts |
+| Q6 | Developer | Run `@qa risk` for the regression risk heatmap | I can decide what to test manually before a release |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: qa
+description: >
+  Quality assurance auditor for the current GitHub repository. Tracks test
+  coverage trends, identifies regression risk hotspots (high-churn + low-
+  coverage files), and detects flaky tests from CI logs. Use when the user
+  asks for "test coverage", "regression risk", "flaky tests", "quality
+  report", "QA audit", "coverage trends", "what needs testing", "rapport
+  qualité", or "couverture de tests".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [qa-report]
+color: green
+output: pr
+tick: >
+  Run the full QA audit (coverage + risk + flaky), land it as
+  qa/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay silent
+  in chat unless a silence-breaker fires.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "QA audit", "full quality report", "test health" | Run all scripts, produce full report |
+| "coverage", "test coverage", "what's covered" | `qa-report` -> `references/coverage.md` |
+| "regression risk", "hotspots", "what needs testing" | `qa-report` -> `references/risk.md` |
+| "flaky tests", "intermittent failures", "CI flakes" | `qa-report` -> `references/flaky.md` |
+| "test plan for feature X" | `qa-report` -> `references/test-plan.md` |
+| "write tests for X", "fix flaky test Y" | Decline; hand back to main agent |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather a QA snapshot (`/tmp/qa-snap.json`):
+   - Parse latest coverage report (lcov, coverage.json, .coverage — auto-detected)
+   - `git log --numstat --since="30 days ago"` for churn data
+   - Fetch recent CI workflow runs via `gh run list --json` + `gh run view --log-failed`
+   - Historical coverage from `qa/history/` if present
+
+2. Run individual reporters against the snapshot:
+   - `coverage.sh --snapshot /tmp/qa-snap.json` — current coverage + delta
+   - `risk.sh --snapshot /tmp/qa-snap.json` — churn x coverage heatmap
+   - `flaky.sh --snapshot /tmp/qa-snap.json` — intermittent CI failures
+
+3. `generate-report.sh` composes the full report:
+   ```
+   qa/reports/2026-04-20-audit.md
+   ```
+
+4. Archive snapshot for trend tracking:
+   ```
+   qa/history/2026-04-20.json
+   ```
+
+5. Land via `open-report-pr.sh`:
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     qa/reports/$(date +%F)-audit.md \
+     --agent qa
+   ```
+
+6. Evaluate silence-breakers. Reply with one-line receipt if none fire.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Coverage drop | `coverage.sh` -> `delta` | > 5% decrease from previous snapshot |
+| High-risk file (high churn, zero coverage) | `risk.sh` -> `criticalFiles[]` | Any file with > 10 commits + 0% coverage |
+| New flaky test | `flaky.sh` -> `newFlakes[]` | Any test not previously flagged |
+| Coverage report missing | `collect.sh` -> `coverageFound: false` | First tick only — then silent |
+| Test suite not found | `collect.sh` -> `testSuiteFound: false` | Always (repo has no tests at all) |
+
+## 6. Skill Structure
+
+```
+skills/qa-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── coverage.md             # Coverage analysis guide
+│   ├── risk.md                 # Regression risk scoring methodology
+│   ├── flaky.md                # Flaky test detection guide
+│   └── test-plan.md            # Test plan generation guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector (coverage + churn + CI logs)
+    ├── coverage.sh             # Coverage reporter (current + trend)
+    ├── risk.sh                 # Regression risk heatmap (churn x coverage)
+    ├── flaky.sh                # Flaky test detector (CI log parser)
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# QA Audit — 2026-04-20
+
+## Coverage Summary
+| Metric | Current | Previous | Delta |
+|--------|---------|----------|-------|
+| Line coverage | 72.3% | 74.1% | -1.8% |
+| Branch coverage | 58.1% | 59.0% | -0.9% |
+| Files with 0% | 12 | 10 | +2 |
+
+## Regression Risk Heatmap
+| File | Commits (30d) | Coverage | Risk |
+|------|---------------|----------|------|
+| src/payments/checkout.ts | 23 | 12% | CRITICAL |
+| src/auth/session.ts | 15 | 0% | CRITICAL |
+| src/api/routes.ts | 11 | 45% | HIGH |
+
+## Flaky Tests (last 14 days)
+| Test | Pass rate | Runs | First seen |
+|------|-----------|------|------------|
+| test_webhook_retry | 6/10 | CI #401-#410 | 2026-04-14 |
+
+## Untested Areas
+- `src/payments/` — 3 files, 0% coverage, 41 commits in 30d
+- `src/notifications/` — 2 files, 0% coverage, new directory
+```
+
+## 8. Dependencies
+
+- `jq` for JSON processing
+- `gh` CLI (authenticated) for CI log fetching
+- `git` for churn analysis
+- Coverage report in any of: `lcov.info`, `coverage/coverage-summary.json`,
+  `.coverage` (Python), `coverage.xml` (JaCoCo/Cobertura)
+- No additional package installs required
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Regression risk files identified before incident | > 80% of production bugs trace to flagged files |
+| Coverage trend visibility | Teams can see 30-day trend within 1 tick |
+| Flaky test detection latency | Flagged within 1 tick of first intermittent failure |
+| Report generation time | < 20s for repos with < 1000 files |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| No coverage report exists in repo | `collect.sh` detects absence, flags in report, suggests CI configuration |
+| Coverage format varies across repos | Auto-detect from common filenames (lcov.info, coverage-summary.json, .coverage) |
+| CI logs too large to parse | `flaky.sh` fetches only failed runs from last 14 days, caps at 50 runs |
+| Churn analysis slow on large repos | `collect.sh` limits to last 30 days, excludes generated files via `.gitignore` |
+| Different test frameworks | Language-agnostic — reads coverage output, not test framework config |

--- a/claude-skills/prds/003-tech-lead.md
+++ b/claude-skills/prds/003-tech-lead.md
@@ -1,0 +1,205 @@
+# PRD-003: Tech Lead Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P1 — Phase 2
+
+---
+
+## 1. Problem Statement
+
+Technical debt, architecture decisions, and dependency health are managed
+informally across BSG repositories. Architecture decisions are made in Slack
+threads and forgotten. Dependency upgrades lag months behind, accumulating risk.
+Tech debt is acknowledged in TODO comments but never triaged, prioritized, or
+tracked against business impact. There is no single view that tells a tech lead
+"here is the health of this codebase, and here is what needs attention."
+
+## 2. Goal
+
+Provide a Claude Code subagent that acts as a virtual CTO/senior developer,
+maintaining architecture decision records, tracking dependency health, measuring
+code quality signals, and surfacing tech debt — giving the tech lead an
+actionable, data-driven view of codebase health on every `tick`.
+
+## 3. Non-Goals
+
+- **Making architecture decisions.** The agent records decisions and flags when
+  they're missing; it does not choose between PostgreSQL and MongoDB.
+- **Refactoring code.** The agent identifies debt; the developer remediates.
+- **Replacing code review.** The agent provides static analysis signals, not
+  PR-level review feedback.
+- **Performance profiling.** Runtime performance is out of scope; this agent
+  works on source code and metadata at rest.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| T1 | Tech lead | Run `@tech-lead tick` and see architecture health at a glance | I can decide where to invest engineering time |
+| T2 | Developer | Run `@tech-lead deps` to see outdated and vulnerable dependencies | I can plan upgrade sprints |
+| T3 | Tech lead | Maintain ADRs in `adr/` with an auto-generated index | New team members can understand past decisions |
+| T4 | Developer | Run `@tech-lead debt` to see the tech debt backlog | I can attach debt items to sprint planning |
+| T5 | Tech lead | Track code quality metrics over time | I can demonstrate improvement (or justify investment) |
+| T6 | Developer | Run `@tech-lead complexity` to find the most complex files | I know what to break apart next |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: tech-lead
+description: >
+  Senior developer / CTO agent for the current GitHub repository. Maintains
+  architecture decision records, tracks dependency health, measures code
+  quality signals (complexity, duplication, TODO density), and surfaces tech
+  debt. Use when the user asks for "architecture review", "dependency health",
+  "tech debt", "code quality", "ADR", "complexity analysis", "dette technique",
+  "santé du code", or "revue d'architecture".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [tech-report]
+color: blue
+output: chat
+tick: >
+  Run the full architecture health check (deps + quality + debt), produce
+  a summary in chat with key findings. Land detailed report as
+  tech/reports/YYYY-MM-DD-health.md for the record. Stay silent if all
+  metrics are stable.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "architecture health", "tech health", "full review" | Run all scripts, produce full report |
+| "dependencies", "outdated", "upgrades needed" | `tech-report` -> `references/deps.md` |
+| "tech debt", "TODOs", "debt backlog" | `tech-report` -> `references/debt.md` |
+| "complexity", "big files", "code smell" | `tech-report` -> `references/quality.md` |
+| "ADR", "architecture decision", "why did we choose X" | `tech-report` -> `references/adr.md` |
+| "refactor X", "upgrade dependency Y" | Decline; hand back to main agent |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather a tech health snapshot (`/tmp/tech-snap.json`):
+   - `npm outdated --json` / `pip list --outdated --format=json`
+   - `gh api /repos/{owner}/{repo}/dependabot/alerts` (if enabled)
+   - File size and line count analysis (`wc -l` on source files)
+   - TODO/FIXME/HACK grep with file and line context
+   - Circular dependency detection (language-aware)
+   - ADR inventory from `adr/` or `docs/adr/`
+
+2. Run individual reporters:
+   - `deps.sh --snapshot /tmp/tech-snap.json` — outdated + major version gaps
+   - `quality.sh --snapshot /tmp/tech-snap.json` — file size outliers, complexity
+   - `debt.sh --snapshot /tmp/tech-snap.json` — TODO inventory + age analysis
+   - `adr.sh --snapshot /tmp/tech-snap.json` — ADR index + gap detection
+
+3. `generate-report.sh` composes the full report:
+   ```
+   tech/reports/2026-04-20-health.md
+   ```
+
+4. Evaluate silence-breakers. If any fire, present the 3-bullet summary in
+   chat. Otherwise, one-line receipt.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Dependency with major version lag | `deps.sh` -> `majorBehind[]` | Any dependency > 2 major versions behind |
+| Circular dependency detected | `quality.sh` -> `circularDeps[]` | Non-empty |
+| File exceeding complexity threshold | `quality.sh` -> `oversizedFiles[]` | Any file > 500 lines or > 20 functions |
+| TODO/FIXME older than 90 days | `debt.sh` -> `staleTodos[]` | > 5 items |
+| Architecture decision without ADR | `adr.sh` -> `undocumentedDecisions[]` | Non-empty (heuristic: new framework/library added without ADR) |
+| Tech debt score regression | `debt.sh` -> `debtScore` vs previous | > 10% increase |
+
+## 6. Skill Structure
+
+```
+skills/tech-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── deps.md                 # Dependency health analysis guide
+│   ├── debt.md                 # Tech debt tracking methodology
+│   ├── quality.md              # Code quality metrics guide
+│   └── adr.md                  # ADR management guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector
+    ├── deps.sh                 # Dependency health reporter
+    ├── quality.sh              # Code quality metrics (size, complexity, duplication)
+    ├── debt.sh                 # Tech debt inventory (TODOs, age, scoring)
+    ├── adr.sh                  # ADR index generator + gap detector
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# Tech Health — 2026-04-20
+
+## Dependency Health
+| Package | Current | Latest | Gap | Risk |
+|---------|---------|--------|-----|------|
+| react | 17.0.2 | 19.1.0 | 2 major | HIGH |
+| express | 4.18.2 | 4.21.0 | minor | LOW |
+
+**Summary:** 3 major-behind, 12 minor-behind, 45 up-to-date
+
+## Code Quality
+| Metric | Value | Trend |
+|--------|-------|-------|
+| Files > 500 lines | 4 | +1 |
+| Avg file length | 142 lines | stable |
+| Circular deps | 0 | stable |
+
+### Largest Files
+| File | Lines | Functions |
+|------|-------|-----------|
+| src/legacy/processor.ts | 823 | 34 |
+
+## Tech Debt Inventory
+| Category | Count | Oldest |
+|----------|-------|--------|
+| TODO | 23 | 2025-08-12 |
+| FIXME | 7 | 2025-11-03 |
+| HACK | 2 | 2026-01-15 |
+
+**Debt score:** 32 (previous: 28, delta: +4)
+
+## Architecture Decision Records
+- 3 ADRs documented in `adr/`
+- 1 gap detected: new ORM introduced without ADR
+```
+
+## 8. Dependencies
+
+- `npm` or `pip` (language-detected per repo)
+- `gh` CLI (authenticated)
+- `jq` for JSON processing
+- `git` for blame/age analysis on TODOs
+- `wc`, `grep` (standard Unix tools)
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Major-version dependency lag detection | 100% of deps > 2 major behind flagged |
+| TODO/FIXME staleness visibility | All items > 90 days surfaced |
+| ADR coverage for major decisions | Teams create ADRs for flagged gaps within 2 weeks |
+| Report generation time | < 15s for repos with < 1000 files |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Language detection ambiguity (polyglot repos) | `collect.sh` scans for all known lockfiles, reports per-ecosystem |
+| Circular dependency detection is language-specific | Start with JS/TS (import analysis), add Python later |
+| TODO age requires git blame (slow on large repos) | Cache blame results, only re-blame changed files |
+| ADR gap detection is heuristic | Conservative: only flag when a new top-level dependency appears in package.json/requirements.txt |
+| `output: chat` means no PR trail for reports | Reports still written to `tech/reports/` and committed; `chat` just means tick results go to chat not PR |

--- a/claude-skills/prds/004-seo.md
+++ b/claude-skills/prds/004-seo.md
@@ -1,0 +1,220 @@
+# PRD-004: SEO Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P1 — Phase 3
+
+---
+
+## 1. Problem Statement
+
+SEO issues are discovered late — after pages are indexed poorly, after traffic
+drops, after a competitor outranks us. Technical SEO (meta tags, structured
+data, sitemaps, canonical URLs) is treated as an afterthought during development.
+Content gaps between what users search for and what the site covers are invisible
+without manual keyword research. Internal linking is ad-hoc, creating orphan
+pages that search engines undervalue.
+
+There is no automated, repo-level SEO audit that runs alongside development and
+catches issues before they reach production.
+
+## 2. Goal
+
+Provide a Claude Code subagent that audits technical SEO, content coverage, and
+internal linking directly from source code and templates — producing a dated
+report on every `tick` and surfacing issues before they affect search rankings.
+
+## 3. Non-Goals
+
+- **Live crawling of production URLs.** The agent analyzes source files in the
+  repo (HTML templates, static pages, config files). It does not fetch from
+  production servers.
+- **Keyword research.** The agent checks coverage against a maintained keyword
+  list (`seo/KEYWORDS.md`); it does not discover new keywords via external APIs.
+- **Google Search Console integration.** No API calls to GSC or other analytics
+  platforms. Data comes from the repo.
+- **Content writing.** The agent identifies gaps and missing metadata; it does
+  not write page copy.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| E1 | Developer | Run `@seo tick` and see a receipt if everything is clean | I know SEO is on track without manual checking |
+| E2 | Developer | Get alerted when a new page has no meta description | I fix it before the page is indexed |
+| E3 | Marketing lead | See which target keywords have no matching content | I can plan content creation sprints |
+| E4 | Developer | Run `@seo links` to see the internal link graph | I can identify orphan pages and fix navigation |
+| E5 | Developer | Run `@seo meta` to audit all pages' meta tags | I get a quick inventory of title/description coverage |
+| E6 | Tech lead | Track SEO health over time in `seo/reports/` | I can correlate code changes with SEO improvements |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: seo
+description: >
+  SEO auditor for the current GitHub repository. Analyzes source files for
+  technical SEO issues: missing meta tags, broken internal links, structured
+  data gaps, sitemap completeness, and content coverage against target
+  keywords. Use when the user asks for "SEO audit", "meta tags", "sitemap
+  check", "internal links", "content gaps", "structured data", "audit SEO",
+  "référencement", or "optimisation moteurs de recherche".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [seo-report]
+color: orange
+output: pr
+tick: >
+  Run the full SEO audit (meta + links + content + sitemap), land it as
+  seo/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay silent
+  in chat unless a silence-breaker fires.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "SEO audit", "full scan", "technical SEO" | Run all scripts, produce full report |
+| "meta tags", "titles", "descriptions" | `seo-report` -> `references/meta.md` |
+| "internal links", "orphan pages", "link graph" | `seo-report` -> `references/links.md` |
+| "content gaps", "keywords", "missing pages" | `seo-report` -> `references/content.md` |
+| "sitemap", "robots.txt", "canonical" | `seo-report` -> `references/technical.md` |
+| "structured data", "schema.org", "JSON-LD" | `seo-report` -> `references/structured-data.md` |
+| "write meta for page X", "create content for keyword Y" | Decline; hand back to main agent |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather an SEO snapshot (`/tmp/seo-snap.json`):
+   - Glob for HTML/template files (`*.html`, `*.tsx`, `*.vue`, `*.svelte`, etc.)
+   - Extract `<title>`, `<meta name="description">`, `<link rel="canonical">`,
+     Open Graph tags, JSON-LD blocks
+   - Parse `sitemap.xml` / `sitemap.txt` if present
+   - Parse `robots.txt` if present
+   - Build internal link graph from `<a href>` in templates
+   - Load `seo/KEYWORDS.md` if present
+
+2. Run individual reporters:
+   - `meta.sh --snapshot /tmp/seo-snap.json` — meta tag inventory + gaps
+   - `links.sh --snapshot /tmp/seo-snap.json` — internal link graph + orphans
+   - `content.sh --snapshot /tmp/seo-snap.json` — keyword coverage analysis
+   - `technical.sh --snapshot /tmp/seo-snap.json` — sitemap, robots, canonical
+
+3. `generate-report.sh` composes the full report:
+   ```
+   seo/reports/2026-04-20-audit.md
+   ```
+
+4. Land via `open-report-pr.sh`:
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     seo/reports/$(date +%F)-audit.md \
+     --agent seo
+   ```
+
+5. Evaluate silence-breakers. Reply with one-line receipt if none fire.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Page missing meta description | `meta.sh` -> `missingDescription[]` | Any |
+| Page missing title tag | `meta.sh` -> `missingTitle[]` | Any |
+| Orphan page (no inbound links) | `links.sh` -> `orphanPages[]` | Any |
+| Broken internal link (target not found) | `links.sh` -> `brokenLinks[]` | Any |
+| Target keyword with no content | `content.sh` -> `uncoveredKeywords[]` | Any (only if KEYWORDS.md exists) |
+| Missing sitemap.xml | `technical.sh` -> `sitemapFound: false` | Always |
+| Missing robots.txt | `technical.sh` -> `robotsFound: false` | Always |
+| Page not in sitemap | `technical.sh` -> `pagesNotInSitemap[]` | > 3 pages |
+
+## 6. Skill Structure
+
+```
+skills/seo-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── meta.md                 # Meta tag auditing guide
+│   ├── links.md                # Internal link analysis guide
+│   ├── content.md              # Content gap analysis guide
+│   ├── technical.md            # Sitemap/robots/canonical guide
+│   └── structured-data.md      # Schema.org / JSON-LD guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector (template parser)
+    ├── meta.sh                 # Meta tag inventory + gap reporter
+    ├── links.sh                # Internal link graph builder + orphan detector
+    ├── content.sh              # Keyword coverage analyzer
+    ├── technical.sh            # Sitemap/robots/canonical auditor
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# SEO Audit — 2026-04-20
+
+## Meta Tag Coverage
+| Page | Title | Description | Canonical | OG Tags |
+|------|-------|-------------|-----------|---------|
+| /pricing | YES | NO | YES | Partial |
+| /blog/new-feature | YES | YES | NO | YES |
+
+**Summary:** 42 pages scanned, 3 missing descriptions, 1 missing title
+
+## Internal Link Health
+| Metric | Value |
+|--------|-------|
+| Total pages | 42 |
+| Orphan pages (0 inbound links) | 2 |
+| Broken links | 1 |
+| Avg inbound links per page | 3.4 |
+
+### Orphan Pages
+- `/docs/advanced-config` — 0 inbound links
+- `/legal/dpa` — 0 inbound links
+
+## Content Coverage
+| Target Keyword | Matching Page | Status |
+|----------------|---------------|--------|
+| "API authentication" | /docs/auth | COVERED |
+| "pricing plans" | — | GAP |
+| "migration guide" | /docs/migrate | COVERED |
+
+## Technical SEO
+| Check | Status |
+|-------|--------|
+| sitemap.xml | Present (42 URLs) |
+| robots.txt | Present |
+| Canonical tags | 38/42 pages |
+| JSON-LD structured data | 5 pages |
+```
+
+## 8. Dependencies
+
+- `jq` for JSON processing
+- `grep` with PCRE support for HTML parsing
+- Standard Unix tools (`find`, `wc`, `sort`)
+- No external APIs or packages required
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Missing meta tags detected before indexing | > 95% caught in dev |
+| Orphan page detection accuracy | 100% (repo-scoped, deterministic) |
+| Content gap identification | All KEYWORDS.md entries checked per tick |
+| Report generation time | < 10s for repos with < 200 pages |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Template syntax varies (JSX, Vue, Svelte, Jinja) | `collect.sh` uses regex patterns that work across template formats; add framework-specific extractors as needed |
+| Dynamic meta tags (set via JS at runtime) | Flag pages with no static meta as "dynamic — verify manually" |
+| Large sites with hundreds of pages | `collect.sh` caps analysis, samples if needed |
+| `seo/KEYWORDS.md` doesn't exist | Content gap analysis skipped gracefully; flagged as suggestion in report |
+| Single-page apps (SPA) with client-side routing | Detect SPA pattern, note in report that server-side rendering is needed for SEO |

--- a/claude-skills/prds/005-marketing.md
+++ b/claude-skills/prds/005-marketing.md
@@ -1,0 +1,195 @@
+# PRD-005: Marketing Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P1 — Phase 3
+
+---
+
+## 1. Problem Statement
+
+Marketing and product development operate on parallel timelines that frequently
+drift apart. Features ship without marketing awareness, landing pages describe
+capabilities that don't exist yet, and content calendars slip without anyone
+noticing. There is no automated mechanism to detect the gap between "what the
+product does" and "what the marketing says it does" — this misalignment erodes
+trust with users and wastes marketing effort on outdated messaging.
+
+## 2. Goal
+
+Provide a Claude Code subagent that maintains a content calendar, audits the
+alignment between shipped features and marketed features, and generates campaign
+briefs from product milestones — surfacing drift before it reaches customers.
+
+## 3. Non-Goals
+
+- **Executing marketing campaigns.** The agent plans and audits; it does not
+  send emails, post to social media, or manage ad spend.
+- **Copywriting.** The agent generates campaign briefs and flags copy drift;
+  it does not write final marketing copy.
+- **Analytics integration.** No Google Analytics, HubSpot, or attribution
+  tracking. Data comes from the repo (milestones, READMEs, landing pages,
+  changelogs).
+- **Design work.** No image generation, layout design, or brand asset creation.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| M1 | Marketing lead | Run `@marketing tick` and see if any campaigns are overdue | I can reprioritize before deadlines pass |
+| M2 | Product manager | See which shipped features have no marketing coverage | I can request campaign briefs for unannounced features |
+| M3 | Marketing lead | Maintain a content calendar in `marketing/CALENDAR.md` | The whole team sees what's planned and when |
+| M4 | Developer | Run `@marketing alignment` to check feature-marketing parity | I know if the landing page matches current capabilities |
+| M5 | Marketing lead | Get campaign briefs auto-generated from milestone closures | I have a starting point for every feature launch |
+| M6 | Marketing lead | Track marketing health over time in `marketing/reports/` | I can demonstrate coverage improvements |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: marketing
+description: >
+  Marketing auditor for the current GitHub repository. Maintains the content
+  calendar, audits alignment between shipped features and marketing copy,
+  and generates campaign briefs from product milestones. Use when the user
+  asks for "marketing audit", "content calendar", "campaign brief",
+  "feature alignment", "what's marketed", "landing page check",
+  "calendrier marketing", "brief de campagne", or "alignement produit-marketing".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [marketing-report]
+color: pink
+output: pr
+tick: >
+  Audit the content calendar for overdue items, check feature-marketing
+  alignment, land the report as marketing/reports/YYYY-MM-DD-audit.md
+  via open-report-pr.sh, and stay silent unless a silence-breaker fires.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "marketing audit", "full marketing check" | Run all scripts, produce full report |
+| "content calendar", "what's planned", "overdue content" | `marketing-report` -> `references/calendar.md` |
+| "feature alignment", "shipped vs marketed" | `marketing-report` -> `references/alignment.md` |
+| "campaign brief", "brief for milestone X" | `marketing-report` -> `references/brief.md` |
+| "landing page audit", "messaging check" | `marketing-report` -> `references/messaging.md` |
+| "write copy for X", "design campaign Y" | Decline; hand back to main agent |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather a marketing snapshot (`/tmp/mkt-snap.json`):
+   - Parse `marketing/CALENDAR.md` for scheduled items and their dates
+   - `gh release list --json` for recent releases
+   - `gh api /repos/{owner}/{repo}/milestones` for closed/upcoming milestones
+   - Scan landing pages / README / docs for feature claims
+   - Scan changelog / release notes for shipped features
+
+2. Run individual reporters:
+   - `calendar.sh --snapshot /tmp/mkt-snap.json` — overdue items, upcoming deadlines
+   - `alignment.sh --snapshot /tmp/mkt-snap.json` — shipped-vs-marketed matrix
+   - `brief.sh --snapshot /tmp/mkt-snap.json` — auto-generate briefs for unannounced releases
+
+3. `generate-report.sh` composes the full report:
+   ```
+   marketing/reports/2026-04-20-audit.md
+   ```
+
+4. Land via `open-report-pr.sh`:
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     marketing/reports/$(date +%F)-audit.md \
+     --agent marketing
+   ```
+
+5. Evaluate silence-breakers. Reply with one-line receipt if none fire.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Overdue calendar item | `calendar.sh` -> `overdueItems[]` | Any item past its scheduled date |
+| Shipped feature with no marketing | `alignment.sh` -> `unmarketed[]` | Any release/milestone closed without matching content |
+| Marketed feature not yet shipped | `alignment.sh` -> `unshipped[]` | Any landing page claim with no matching release |
+| Calendar missing or empty | `calendar.sh` -> `calendarFound: false` | First tick only — suggest bootstrapping |
+| Campaign brief not picked up | `brief.sh` -> `staleBriefs[]` | Brief generated > 14 days ago with no follow-up |
+
+## 6. Skill Structure
+
+```
+skills/marketing-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── calendar.md             # Content calendar management guide
+│   ├── alignment.md            # Feature-marketing alignment methodology
+│   ├── brief.md                # Campaign brief generation guide
+│   └── messaging.md            # Landing page / messaging audit guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector (calendar + releases + pages)
+    ├── calendar.sh             # Content calendar auditor
+    ├── alignment.sh            # Shipped-vs-marketed parity checker
+    ├── brief.sh                # Campaign brief generator
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# Marketing Audit — 2026-04-20
+
+## Content Calendar
+| Item | Scheduled | Status |
+|------|-----------|--------|
+| Blog: API v2 launch | 2026-04-15 | OVERDUE |
+| Newsletter: Q2 update | 2026-04-30 | On track |
+| Case study: Acme Corp | 2026-05-10 | On track |
+
+**Summary:** 1 overdue, 2 on track, 0 completed this period
+
+## Feature-Marketing Alignment
+| Feature | Shipped | Marketed | Status |
+|---------|---------|----------|--------|
+| OAuth2 login | v2.3.0 (Apr 10) | Landing page | ALIGNED |
+| Webhook retry | v2.4.0 (Apr 18) | — | GAP |
+| "AI assistant" | — | Landing page | PREMATURE |
+
+## Campaign Briefs (Auto-generated)
+### Webhook Retry (v2.4.0)
+- **What:** Automatic webhook retry with exponential backoff
+- **Who:** Developers integrating via webhooks
+- **Angle:** Reliability — never miss a webhook again
+- **Assets needed:** Blog post, changelog entry, docs update
+```
+
+## 8. Dependencies
+
+- `gh` CLI (authenticated) for releases and milestones
+- `jq` for JSON processing
+- `grep` for content scanning
+- `date` for calendar date comparison
+- Maintained `marketing/CALENDAR.md` (bootstrapped on first tick if absent)
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Feature-marketing alignment gap detection | 100% of shipped features without marketing flagged |
+| Calendar overdue detection | Flagged within 1 tick of overdue date |
+| Campaign brief generation latency | Brief available within 1 tick of release |
+| Marketing audit adoption | Active in all customer-facing repos within 6 weeks |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| No `marketing/CALENDAR.md` exists | First tick bootstraps a template; subsequent ticks skip calendar check gracefully |
+| Feature detection is heuristic (based on releases/milestones) | Conservative: only flag releases tagged as minor/major, ignore patches |
+| Landing page copy changes without repo update | Agent works on repo source; out-of-repo copy (CMS, Webflow) is out of scope — document this limitation |
+| "Marketed" detection via keyword matching is imprecise | Use feature names from milestone titles as search terms; allow `.marketingignore` for false positives |

--- a/claude-skills/prds/006-storytelling.md
+++ b/claude-skills/prds/006-storytelling.md
@@ -1,0 +1,240 @@
+# PRD-006: Storytelling Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P2 — Phase 4
+
+---
+
+## 1. Problem Statement
+
+Companies communicate through dozens of touchpoints — README files, landing
+pages, docs, changelogs, blog posts, investor decks, onboarding flows — but
+the narrative across these assets drifts over time. The founding story gets
+rewritten inconsistently, the value proposition shifts without alignment, and
+the brand voice varies from formal in docs to casual in blog posts to robotic
+in changelogs. Without a single source of truth for "who we are and how we
+talk," every new piece of content is a coin flip on brand consistency.
+
+## 2. Goal
+
+Provide a Claude Code subagent that maintains a narrative bible
+(`brand/NARRATIVE.md`), audits brand voice consistency across repo assets, and
+generates talking points from product events — ensuring every public-facing
+word sounds like it comes from the same company.
+
+## 3. Non-Goals
+
+- **Visual brand identity.** Logos, color palettes, typography are out of scope.
+  This agent covers words, not design.
+- **Content creation.** The agent audits consistency and generates talking
+  points as starting material; it does not write final blog posts or landing
+  page copy.
+- **Social media management.** No posting, scheduling, or engagement tracking.
+- **External content monitoring.** The agent works on repo files only — press
+  mentions, partner sites, and social media are out of scope.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| N1 | Founder | Maintain a narrative bible that defines our story, voice, and positioning | Every team member communicates consistently |
+| N2 | Marketing lead | Run `@storytelling tick` and see if any asset drifts from the narrative | I can catch tone/messaging inconsistencies before they go live |
+| N3 | Developer | Get talking points when a major release ships | I can write a changelog entry that matches our voice |
+| N4 | Content writer | Run `@storytelling voice` to check a draft against brand guidelines | I know if my copy matches the established tone |
+| N5 | Founder | See the narrative bible evolve alongside the product | The story stays current as the product matures |
+| N6 | Marketing lead | Track narrative health over time in `brand/reports/` | I can demonstrate brand consistency improvements |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: storytelling
+description: >
+  Brand narrative auditor for the current GitHub repository. Maintains the
+  narrative bible (brand/NARRATIVE.md), audits voice consistency across
+  public-facing assets, and generates talking points from product events.
+  Use when the user asks for "brand audit", "narrative check", "voice
+  consistency", "talking points", "brand story", "tone of voice",
+  "narrative bible", "cohérence de marque", "ton éditorial", or
+  "storytelling".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [storytelling-report]
+color: violet
+output: pr
+tick: >
+  Audit public-facing repo assets against brand/NARRATIVE.md, land the
+  report as brand/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and
+  stay silent unless a silence-breaker fires.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "brand audit", "narrative check", "voice consistency" | Run all scripts, produce full report |
+| "narrative bible", "who are we", "brand story" | `storytelling-report` -> `references/narrative.md` |
+| "voice check", "tone audit", "does this sound right" | `storytelling-report` -> `references/voice.md` |
+| "talking points", "release narrative", "how to announce" | `storytelling-report` -> `references/talking-points.md` |
+| "positioning", "value proposition", "differentiators" | `storytelling-report` -> `references/positioning.md` |
+| "write copy for X", "rewrite this page" | Decline; hand back to main agent |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather a brand snapshot (`/tmp/brand-snap.json`):
+   - Load `brand/NARRATIVE.md` (voice guidelines, positioning, key messages)
+   - Scan public-facing files: README.md, docs/, landing pages, CHANGELOG,
+     blog posts, onboarding copy
+   - Extract key phrases, tone markers, value propositions from each asset
+   - `gh release list --json` for recent releases (talking point triggers)
+
+2. Run individual reporters:
+   - `voice.sh --snapshot /tmp/brand-snap.json` — tone consistency scoring
+     per asset (formal/casual/technical scale, jargon density, sentence length)
+   - `alignment.sh --snapshot /tmp/brand-snap.json` — key message presence in
+     each asset vs. narrative bible
+   - `talking-points.sh --snapshot /tmp/brand-snap.json` — generate points
+     for unnarrated releases
+
+3. `generate-report.sh` composes the full report:
+   ```
+   brand/reports/2026-04-20-audit.md
+   ```
+
+4. Land via `open-report-pr.sh`:
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     brand/reports/$(date +%F)-audit.md \
+     --agent storytelling
+   ```
+
+5. Evaluate silence-breakers. Reply with one-line receipt if none fire.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Asset voice drift | `voice.sh` -> `driftScore` | Any asset > 2 standard deviations from narrative bible tone |
+| Key message missing from README | `alignment.sh` -> `missingMessages[]` | Any core message absent from primary README |
+| Outdated positioning (product evolved past narrative) | `alignment.sh` -> `stalePositioning[]` | Narrative bible references features removed > 30 days ago |
+| Release without talking points | `talking-points.sh` -> `unnarratedReleases[]` | Any minor/major release without generated points |
+| Narrative bible missing | `collect.sh` -> `narrativeFound: false` | First tick only — suggest bootstrapping |
+
+### 5.5 Narrative Bible Schema
+
+The agent expects (and can bootstrap) `brand/NARRATIVE.md` with this structure:
+
+```markdown
+# Brand Narrative Bible
+
+## Our Story
+[Origin story — why this company exists, the problem that sparked it]
+
+## Mission
+[One sentence: what we do and for whom]
+
+## Vision
+[One sentence: the world we're building toward]
+
+## Value Proposition
+[2-3 bullet points: why choose us over alternatives]
+
+## Voice Guidelines
+- **Tone:** [e.g., confident but not arrogant, technical but accessible]
+- **Vocabulary:** [preferred terms, banned terms]
+- **Sentence style:** [e.g., short and direct, avoid passive voice]
+
+## Key Messages
+1. [Core message that must appear in all primary assets]
+2. [Secondary message for technical audiences]
+3. [Differentiator message vs. competitors]
+
+## Positioning
+- **Category:** [what market category we compete in]
+- **Target audience:** [who we serve]
+- **Differentiators:** [what makes us unique]
+```
+
+## 6. Skill Structure
+
+```
+skills/storytelling-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── narrative.md            # Narrative bible management guide
+│   ├── voice.md                # Voice consistency analysis guide
+│   ├── talking-points.md       # Talking point generation guide
+│   └── positioning.md          # Positioning audit guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector (narrative + assets)
+    ├── voice.sh                # Tone/voice consistency scorer
+    ├── alignment.sh            # Key message alignment checker
+    ├── talking-points.sh       # Talking point generator for releases
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# Brand Audit — 2026-04-20
+
+## Voice Consistency
+| Asset | Tone Score | Jargon | Avg Sentence | Drift |
+|-------|-----------|--------|-------------|-------|
+| README.md | 7.2 (confident) | Low | 14 words | OK |
+| docs/getting-started.md | 5.1 (neutral) | High | 22 words | DRIFT |
+| CHANGELOG.md | 3.0 (robotic) | Medium | 8 words | DRIFT |
+
+**Bible tone target:** 7.0 (confident, accessible)
+
+## Key Message Alignment
+| Message | README | Docs | Landing | Blog |
+|---------|--------|------|---------|------|
+| "Ship faster with confidence" | YES | YES | YES | NO |
+| "Enterprise-grade security" | YES | NO | YES | YES |
+| "Developer-first API" | YES | YES | NO | YES |
+
+## Unnarrated Releases
+| Release | Date | Talking Points |
+|---------|------|----------------|
+| v2.4.0 | Apr 18 | MISSING — [auto-generated draft below] |
+
+### Draft Talking Points: v2.4.0
+- **Headline:** Webhook reliability, solved
+- **Detail:** Automatic retry with exponential backoff means…
+- **Voice note:** Lead with user benefit, not technical mechanism
+```
+
+## 8. Dependencies
+
+- `jq` for JSON processing
+- `gh` CLI for release data
+- `wc`, `grep`, `awk` for text analysis (sentence length, word frequency)
+- No external NLP APIs — tone scoring uses heuristic rules (word lists,
+  sentence length, passive voice detection)
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Voice drift detection | Flagged within 1 tick of divergent asset |
+| Key message coverage | 100% of core messages present in README and landing page |
+| Talking point latency | Points generated within 1 tick of release |
+| Narrative bible adoption | Bootstrapped in all customer-facing repos within 8 weeks |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Tone scoring without NLP is imprecise | Use validated heuristics (Flesch readability, passive voice ratio, jargon word lists); flag "review suggested" instead of definitive "wrong" |
+| Narrative bible doesn't exist | First tick offers to bootstrap from README + existing copy; template included in skill |
+| Too many assets to audit in large repos | `collect.sh` focuses on primary assets (README, docs index, landing page); secondary assets audited on request |
+| Voice guidelines are subjective | Agent reports metrics and deviations; human decides if drift is intentional |
+| Multilingual repos | Audit one language at a time; default to the language of NARRATIVE.md |

--- a/claude-skills/prds/007-pr-comms.md
+++ b/claude-skills/prds/007-pr-comms.md
@@ -1,0 +1,223 @@
+# PRD-007: PR/Comms Agent
+
+**Status:** Draft
+**Author:** Guillaume Badin
+**Date:** 2026-04-20
+**Priority:** P2 — Phase 4
+
+---
+
+## 1. Problem Statement
+
+Newsworthy product events — major releases, milestone completions, partnership
+integrations, security fixes — happen continuously but rarely get translated
+into external communications in a timely manner. Press releases are written
+reactively (or not at all), press kits go stale, and the window of relevance
+closes before marketing or comms can act. There is no systematic mechanism to
+detect PR-worthy events from the development workflow and prepare communication
+materials proactively.
+
+## 2. Goal
+
+Provide a Claude Code subagent that monitors the repository for PR-worthy
+events (releases, milestone closures, major merges), drafts press angles and
+announcement copy, and maintains a press kit — so the comms team always has
+a starting point ready when news breaks.
+
+## 3. Non-Goals
+
+- **Media outreach.** The agent drafts materials; it does not contact
+  journalists, send press releases, or manage media lists.
+- **Social media posting.** No publishing to Twitter, LinkedIn, or other
+  platforms.
+- **Crisis communications.** Security incidents and PR crises require human
+  judgment; the agent may flag the event but does not draft crisis responses.
+- **Investor relations.** Earnings, fundraising, and board materials are out
+  of scope.
+- **Final copy approval.** The agent produces drafts; a human reviews and
+  approves before any external publication.
+
+## 4. User Stories
+
+| # | As a… | I want to… | So that… |
+|---|-------|-----------|----------|
+| P1 | Comms lead | Run `@pr-comms tick` and see if any product event needs a press angle | I can prepare announcements proactively |
+| P2 | Comms lead | Get draft press releases when a major version ships | I have a starting point within minutes of release |
+| P3 | Founder | Maintain a press kit in `comms/press-kit/` | Journalists always have up-to-date company materials |
+| P4 | Marketing lead | Run `@pr-comms events` to see the PR event timeline | I can plan campaigns around upcoming announcements |
+| P5 | Comms lead | Track announcement history in `comms/reports/` | I can see what's been communicated and what hasn't |
+| P6 | Comms lead | Run `@pr-comms draft` for a specific release | I get a structured press release draft immediately |
+
+## 5. Agent Design
+
+### 5.1 Frontmatter
+
+```yaml
+---
+name: pr-comms
+description: >
+  Public relations and communications agent for the current GitHub repository.
+  Monitors for PR-worthy events (releases, milestones, major merges), drafts
+  press releases and announcement copy, and maintains the press kit. Use when
+  the user asks for "press release", "announcement draft", "PR events",
+  "press kit", "communication plan", "newsworthy", "communiqué de presse",
+  "annonce produit", or "kit presse".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [pr-comms-report]
+color: cyan
+output: pr
+tick: >
+  Scan for PR-worthy events since last tick, draft press angles for
+  unannounced events, land the report as comms/reports/YYYY-MM-DD-events.md
+  via open-report-pr.sh, and stay silent unless a silence-breaker fires.
+---
+```
+
+### 5.2 Routing Table
+
+| User intent | Action |
+|---|---|
+| "PR audit", "communication check", "what's newsworthy" | Run all scripts, produce full report |
+| "press release", "draft announcement", "announce release X" | `pr-comms-report` -> `references/press-release.md` |
+| "press kit", "media materials", "company boilerplate" | `pr-comms-report` -> `references/press-kit.md` |
+| "PR events", "event timeline", "what happened" | `pr-comms-report` -> `references/events.md` |
+| "communication plan", "announcement schedule" | `pr-comms-report` -> `references/plan.md` |
+| "send press release", "contact journalist" | Decline; out of scope |
+
+### 5.3 Tick Action
+
+**Steps:**
+
+1. Run `collect.sh` to gather a comms snapshot (`/tmp/comms-snap.json`):
+   - `gh release list --json` — all releases with dates, tags, bodies
+   - `gh api /repos/{owner}/{repo}/milestones?state=closed` — recently closed
+   - Scan `comms/press-kit/` for existing materials and their freshness
+   - Load `comms/ANNOUNCED.md` (log of already-communicated events) if present
+   - Parse contributor stats for "team growth" angle detection
+
+2. Run individual reporters:
+   - `events.sh --snapshot /tmp/comms-snap.json` — classify events by
+     newsworthiness (major release, milestone, security fix, community milestone)
+   - `press-kit.sh --snapshot /tmp/comms-snap.json` — audit press kit freshness
+   - `draft.sh --snapshot /tmp/comms-snap.json` — generate press release
+     drafts for unannounced events
+
+3. `generate-report.sh` composes the full report:
+   ```
+   comms/reports/2026-04-20-events.md
+   ```
+
+4. Land via `open-report-pr.sh`:
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     comms/reports/$(date +%F)-events.md \
+     --agent pr-comms
+   ```
+
+5. Evaluate silence-breakers. Reply with one-line receipt if none fire.
+
+### 5.4 Silence-Breakers
+
+| Signal | Source | Threshold |
+|---|---|---|
+| Major release without announcement | `events.sh` -> `unannouncedMajor[]` | Any major/minor release not in ANNOUNCED.md |
+| Milestone closed without comms | `events.sh` -> `unannouncedMilestone[]` | Any milestone closure |
+| Press kit stale | `press-kit.sh` -> `staleAssets[]` | Any asset > 90 days old |
+| Security advisory published | `events.sh` -> `securityAdvisories[]` | Any (flag for human judgment — do not draft) |
+| Community milestone (100th PR, Nth contributor) | `events.sh` -> `communityMilestones[]` | Pre-defined thresholds (100, 500, 1000) |
+
+### 5.5 Press Kit Schema
+
+The agent maintains `comms/press-kit/` with this structure:
+
+```
+comms/
+├── press-kit/
+│   ├── boilerplate.md          # Company description (short, medium, long)
+│   ├── fact-sheet.md           # Key facts and figures
+│   ├── leadership.md           # Founder/team bios and quotes
+│   ├── milestones.md           # Company timeline / key events
+│   └── faq.md                  # Frequently asked questions for press
+├── ANNOUNCED.md                # Log of communicated events (prevents re-drafting)
+└── reports/                    # Dated audit reports
+```
+
+## 6. Skill Structure
+
+```
+skills/pr-comms-report/
+├── SKILL.md                    # Intent routing + hard rules
+├── references/
+│   ├── press-release.md        # Press release drafting guide (structure, tone)
+│   ├── press-kit.md            # Press kit management guide
+│   ├── events.md               # Event classification methodology
+│   └── plan.md                 # Communication planning guide
+└── scripts/
+    ├── collect.sh              # Snapshot collector (releases + milestones + kit)
+    ├── events.sh               # Event classifier (newsworthiness scoring)
+    ├── press-kit.sh            # Press kit freshness auditor
+    ├── draft.sh                # Press release draft generator
+    └── generate-report.sh      # Full report composer
+```
+
+## 7. Report Format
+
+```markdown
+# PR/Comms Events — 2026-04-20
+
+## Newsworthy Events (Last 30 Days)
+| Event | Date | Type | Announced | Priority |
+|-------|------|------|-----------|----------|
+| v2.4.0 release | Apr 18 | Major release | NO | HIGH |
+| Milestone "API v2" closed | Apr 15 | Milestone | NO | HIGH |
+| 50th contributor | Apr 12 | Community | NO | MEDIUM |
+| v2.3.1 patch | Apr 10 | Patch | — | LOW (skip) |
+
+## Draft Press Releases
+
+### v2.4.0 — Webhook Reliability Update
+**Headline:** [Company] Launches Automatic Webhook Retry, Eliminating
+Failed Deliveries for API Integrators
+
+**Lead:** [Company], the developer-first API platform, today announced
+version 2.4.0 featuring automatic webhook retry with exponential backoff…
+
+**Quote:** "[Suggested founder quote placeholder]"
+
+**Boilerplate:** [From press-kit/boilerplate.md]
+
+## Press Kit Health
+| Asset | Last Updated | Status |
+|-------|-------------|--------|
+| boilerplate.md | 2026-03-01 | OK |
+| fact-sheet.md | 2025-12-15 | STALE (127 days) |
+| leadership.md | 2026-02-20 | OK |
+```
+
+## 8. Dependencies
+
+- `gh` CLI (authenticated) for releases, milestones, contributors
+- `jq` for JSON processing
+- `date` for freshness calculations
+- `git log` for contributor milestones
+- No external APIs or services
+
+## 9. Success Metrics
+
+| Metric | Target |
+|---|---|
+| Major releases with draft press angle available | 100% within 1 tick |
+| Press kit freshness | All assets updated within 90 days |
+| Event detection accuracy | 100% of major/minor releases detected |
+| Draft-to-publish turnaround | Comms team publishes within 48h of draft |
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Press release drafts are generic | Templates include placeholders for human-authored quotes, customer stories; agent flags what needs human input |
+| Security events require careful handling | Agent flags security advisories but does NOT draft press responses; explicit note: "requires human judgment" |
+| `ANNOUNCED.md` not maintained | Agent can infer announced status from press-kit commit history; ANNOUNCED.md is preferred but optional |
+| Events in private repos shouldn't be public | Agent adds "CONFIDENTIAL — review before publishing" header; human decides what to release |
+| Newsworthiness scoring is subjective | Conservative defaults: major/minor releases always flagged; patches only if security-related |


### PR DESCRIPTION
## Summary

- Add 7 Product Requirements Documents for the full BSG agent catalog covering all company phases: security, QA, tech lead, SEO, marketing, storytelling, and PR/comms
- Each PRD follows BSG conventions: frontmatter with `output`/`tick`, routing tables, silence-breakers, scripts-before-LLM principle, and `open-report-pr.sh` integration
- Phased rollout: P0 (security + QA), P1 (tech-lead, SEO, marketing), P2 (storytelling, PR/comms)
- GitHub issues created for each agent: #44, #45, #46, #47, #48, #49, #50

## Agents

| PRD | Agent | Phase | Output | Issue |
|-----|-------|-------|--------|-------|
| 001 | `security` | P0 | `pr` | #44 |
| 002 | `qa` | P0 | `pr` | #45 |
| 003 | `tech-lead` | P1 | `chat` | #46 |
| 004 | `seo` | P1 | `pr` | #47 |
| 005 | `marketing` | P1 | `pr` | #48 |
| 006 | `storytelling` | P2 | `pr` | #49 |
| 007 | `pr-comms` | P2 | `pr` | #50 |

## Testing

- Not run (documentation-only change, no code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
