### PR TITLE
feat(skills): add /github-compliance + finalize tick convention (#33)

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -38,6 +38,7 @@ No git clone, no script to run, no cron to set up.
 | `google-workspace` | Google Workspace CLI skill wrapping the official `gws` tool (github.com/googleworkspace/cli) across Gmail, Calendar, Drive, Sheets, Slides, Docs, Tasks, People, Chat, Meet, Forms, Keep, and the built-in `+workflow` helpers. Ships a preflight (binary/version/auth), an auto-Chrome OAuth helper (`scripts/auth-login.sh`), and an IAM-elevation helper (`scripts/fix-iam-403.sh`) that grants `serviceusage.serviceUsageConsumer` so Drive/Tasks/Chat/People stop 403'ing. Documents the GCP-project gotchas (consent-screen scope registration, Chat app registration) that `--full` alone can't solve. |
 | `ocr` | OCR toolkit that cascades local engines (Apple Vision, Tesseract) before reaching for the Mistral OCR API. Exposes `ocr.sh` as the orchestrator plus per-engine scripts. Any agent about to read an image or scanned PDF should call this skill first and read the resulting `.ocr.md` instead of sending the raw file to Claude. |
 | `browser` | Browser automation wrapping [`agent-browser`](https://www.npmjs.com/package/agent-browser) with persistent profile management, a Google login helper (`scripts/login-google.sh`), and a generic profile wrapper (`scripts/with-profile.sh`). Headed mode for first-time logins, headless for replay. Core verbs: open, click, fill, type, screenshot, snapshot (accessibility tree). |
+| `github-compliance` | GitHub organization compliance checker for `beyond-scale-group`. Audits that every non-archived private repo has the `board` team assigned with `admin` permission, and (with `--fix`) assigns missing teams. Exposes a `tick` action that lands the audit under `compliance/reports/YYYY-MM-DD-compliance.md` via `open-report-pr.sh` and stays silent unless a non-compliant repo is found. |
 | `po` | Product owner skill for the current GitHub repo. Covers plan adherence, backlog triage, milestone tracking, sprint planning, scope-creep detection, PR flow health, and stakeholder reporting. One paginated GraphQL snapshot feeds every capability; reports land under `po/reports/` with the raw snapshot in `po/history/<date>.json`. Heavy lifting in bash + jq (zero LLM cost), narration in the skill. |
 
 ## Available agents
@@ -155,16 +156,40 @@ For files under `claude-skills/agents/<name>.md`, replace
 `commands/<name>.md` with `agents/<name>.md` everywhere in the footer,
 and replace `~/.claude/commands/<name>.md` with `~/.claude/agents/<name>.md`.
 
-### Required `tick:` frontmatter on every agent
+### The `tick` convention (periodic agent and skill runs)
 
-Every file in `claude-skills/agents/` must declare a `tick:` field in its
-YAML frontmatter, describing what the agent's periodic run does. This is
-the BSG-wide convention for agents that produce recurring reports or
-checks — one verb across the catalog (`@<agent> tick`) so users don't
-have to memorize per-agent vocabulary. See the "The `tick` convention"
-section of the top-level [`CLAUDE.md`][claude-md] for the full spec
-(silent-by-default, idempotent, repo-scoped, human-initiated — no CI
-cron). The test in [`claude-skills/tests/test_skills.py`][tests]
+All BSG agents and reporting skills expose a single conventional verb
+for "do your periodic job now": `tick`. Users invoke it as
+`@<agent> tick` (for subagents) or `<skill> tick` / a routed slash
+command (for skills), typically driven by Claude Code's own
+[`/loop`][loop] or [`/schedule`][schedule] — never by GitHub Actions,
+Renovate, or any org-level cron. See the "The `tick` convention"
+section of the top-level [`CLAUDE.md`][claude-md] for the full
+rationale.
+
+Every `tick` implementation must satisfy three rules:
+
+1. **Idempotent and silent by default.** Write the dated output to the
+   repo (`po/reports/YYYY-MM-DD-*.md`,
+   `compliance/reports/YYYY-MM-DD-*.md`, etc.), land it through
+   [`open-report-pr.sh`][open-report-pr] so it ships via auto-merge PR,
+   and reply in chat with **one line** unless an explicit
+   silence-breaker fires. "All green" is not a chat message — it is a
+   committed file.
+2. **Explicit silence-breakers.** Each agent or reporting skill must
+   list, in its own body, the exact conditions that allow it to break
+   silence (drift score crossed a threshold, a non-compliant repo
+   appeared, a milestone went overdue, …). Thresholds live in the
+   agent's or skill's own file, not centrally — they are part of that
+   agent's product definition.
+3. **Repo-scoped.** `tick` runs inside one repo's working directory and
+   touches only that repo. Multi-repo sweeps are out of scope.
+
+#### For agents
+
+Every file in `claude-skills/agents/` must declare a `tick:` field in
+its YAML frontmatter, describing what the agent's periodic run does.
+The test in [`claude-skills/tests/test_skills.py`][tests]
 (`test_every_agent_declares_a_tick_action`) enforces that the field
 exists and is non-empty.
 
@@ -186,8 +211,20 @@ step-by-step + silence-breaker table in a dedicated "Tick action"
 section of the agent body, so the LLM has a single place to look when
 the user types `tick`.
 
+#### For reporting skills
+
+Skills under `claude-skills/skills/<name>/` that produce a periodic
+report or audit (today: `po`, `github-compliance`) document their
+`tick` as a top-level **"Tick action"** section in `SKILL.md`. There is
+no frontmatter test for skills — the section is the contract. Mirror
+the agent layout: numbered steps, a silence-breakers table, and a
+"Silence is a feature" reminder so the LLM does not pad the chat reply.
+
 [claude-md]: https://github.com/beyond-scale-group/bsg-stack/blob/main/CLAUDE.md
 [tests]: https://github.com/beyond-scale-group/bsg-stack/blob/main/claude-skills/tests/test_skills.py
+[open-report-pr]: https://github.com/beyond-scale-group/bsg-stack/blob/main/claude-skills/scripts/open-report-pr.sh
+[loop]: https://docs.claude.com/en/docs/claude-code/skills
+[schedule]: https://docs.claude.com/en/docs/claude-code/skills
 
 ---
 

--- a/claude-skills/skills/github-compliance/SKILL.md
+++ b/claude-skills/skills/github-compliance/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: github-compliance
+description: >
+  GitHub organization compliance checker for Beyond Scale Group. Ensures all
+  non-archived private repositories have the required teams assigned with the
+  correct permissions. Use this skill when the user asks to "check compliance",
+  "vérifier la conformité GitHub", "assigner les teams aux repos", "audit GitHub org",
+  "check team assignments", "fix repo permissions", "run compliance check", or
+  "github-compliance tick". Works with the `beyond-scale-group` org and the
+  `board` team by default.
+---
+
+# GitHub Compliance
+
+Vérifie et corrige l'assignation des teams GitHub sur tous les repos privés
+non-archivés de l'organisation.
+
+## Check (audit seul)
+
+```bash
+bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh
+```
+
+## Fix (audit + correction automatique)
+
+```bash
+bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh --fix
+```
+
+## Options
+
+| Flag | Défaut | Description |
+|---|---|---|
+| `--fix` | false | Corrige les repos non-conformes |
+| `--org` | `beyond-scale-group` | Organisation GitHub |
+| `--team` | `board` | Team à assigner |
+| `--permission` | `admin` | Permission (`pull`, `push`, `admin`) |
+
+## Exemples
+
+```bash
+# Audit only
+bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh
+
+# Fix with default settings
+bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh --fix
+
+# Custom org/team
+bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh --org my-org --team developers --permission push --fix
+```
+
+## Règles de conformité (Beyond Scale Group)
+
+- Tous les repos **privés** et **non-archivés** doivent avoir la team `board` avec permission `admin`
+- Les repos archivés sont ignorés
+- Le repo public (`prompt-eng-interactive-tutorial`) est ignoré
+
+## Tick action (periodic run)
+
+The user invokes `tick` (typically via `@github-compliance tick` from
+`/loop` or `/schedule`) when they want the compliance audit to run now and
+the result to be archived in the repo. It is **idempotent, repo-scoped,
+and silent by default** — when every repo is compliant, the chat reply
+is one line; the full audit lives in the committed report.
+
+This `tick` follows the BSG-wide convention documented in the top-level
+[`CLAUDE.md`][claude-md] under "The `tick` convention" — silent-by-default,
+human-initiated (no CI cron), repo-scoped (the audit targets one GitHub
+org but the report lands in the current repo's `compliance/reports/`).
+
+[claude-md]: https://github.com/beyond-scale-group/bsg-stack/blob/main/CLAUDE.md
+
+### Steps
+
+1. **Run the audit in capture mode** (no `--fix`) and write the raw output
+   to a dated report file:
+
+   ```bash
+   mkdir -p compliance/reports
+   bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh \
+     > compliance/reports/$(date +%F)-compliance.md
+   ```
+
+2. **Land the report via the shared helper** — never commit to `main`
+   directly. The helper opens an auto-merge PR (or falls back to a direct
+   squash merge if branch protection is not configured):
+
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     compliance/reports/$(date +%F)-compliance.md \
+     --agent github-compliance
+   ```
+
+3. **Evaluate the silence-breaker** by parsing the report:
+
+   ```bash
+   non_compliant=$(grep -c '^    ' compliance/reports/$(date +%F)-compliance.md \
+     | head -1 || echo 0)
+   ```
+
+   Or, more robustly, re-run the audit script and count the
+   `Non-compliant (N repos)` line. The script exits 0 in both compliant
+   and non-compliant states, so you must inspect its output rather than
+   relying on the exit code.
+
+4. **Reply.** If every repo is compliant, a single line — e.g.
+   `Tick: all repos compliant, report at <PR url>` — is the whole reply.
+   If any repo is non-compliant, list the offending repos and the PR url
+   so the user can decide whether to re-run with `--fix`.
+
+### Silence-breakers (what counts as "needs human attention")
+
+Break silence if **any** of these hold for the audit you just produced:
+
+| Signal                                  | Source                                                  | Threshold |
+| --------------------------------------- | ------------------------------------------------------- | --------- |
+| Any non-compliant repo                  | `check_compliance.sh` → `Non-compliant (N repos)` line  | `N > 0`   |
+| Audit script failed to enumerate repos  | `gh api orgs/$ORG/repos` returned an error              | Any error |
+| New repo appeared since the last tick   | Diff `compliance/reports/` between latest and previous  | First tick after a new repo lands — flag once so the user can confirm intent, then silent |
+
+The "new repo" case is a one-shot: surface it once so the user notices a
+fresh repo joined the org, then keep quiet on subsequent ticks (the
+report itself still lists every repo each run).
+
+### Silence is a feature
+
+Do **not** pad the reply with "everything is compliant" narrative or
+next-step suggestions when nothing fired. One-line acknowledgements only.
+The committed report PR is the full audit trail — the chat line is just
+a receipt. Auto-fixing (`--fix`) is **never** part of `tick` — `tick`
+audits and reports; the user explicitly opts in to remediation.
+
+## Références
+
+- Voir `references/org_structure.md` pour la structure complète de l'organisation
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/github-compliance/SKILL.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/skills/github-compliance/SKILL.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/skills/github-compliance/SKILL.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/github-compliance/references/org_structure.md
+++ b/claude-skills/skills/github-compliance/references/org_structure.md
@@ -1,0 +1,29 @@
+# Beyond Scale Group — GitHub Org Structure
+
+## Organisation
+
+- **GitHub org:** `beyond-scale-group`
+- **URL:** https://github.com/beyond-scale-group
+
+## Teams
+
+| Team | Slug | Permission | Usage |
+|---|---|---|---|
+| board | `board` | admin | Accès admin à tous les repos privés actifs |
+| outside_collaborator | `outside_collaborator` | pull | Collaborateurs externes |
+
+## Règle de conformité
+
+Tout repo **privé** et **non-archivé** doit être assigné à la team `board`
+avec permission `admin`.
+
+## Repo public (ignoré)
+
+`prompt-eng-interactive-tutorial`
+
+## Maintenance
+
+The list of active and archived repos is intentionally not duplicated
+here — it changes as the org evolves. Run
+`bash ~/.claude/skills/github-compliance/scripts/check_compliance.sh` to
+get the current snapshot from the GitHub API directly.

--- a/claude-skills/skills/github-compliance/scripts/check_compliance.sh
+++ b/claude-skills/skills/github-compliance/scripts/check_compliance.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# GitHub Org Compliance Checker & Fixer
+# Usage: ./check_compliance.sh [--fix] [--org beyond-scale-group] [--team board]
+
+ORG="${ORG:-beyond-scale-group}"
+TEAM="${TEAM:-board}"
+PERMISSION="${PERMISSION:-admin}"
+FIX=false
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --fix) FIX=true ;;
+    --org) ORG="$2"; shift ;;
+    --team) TEAM="$2"; shift ;;
+    --permission) PERMISSION="$2"; shift ;;
+  esac
+  shift
+done
+
+echo "=== GitHub Compliance Check ==="
+echo "Org: $ORG | Team: $TEAM | Permission: $PERMISSION"
+echo ""
+
+# Get all non-archived private repos
+ALL_REPOS=$(gh api "orgs/$ORG/repos" --paginate --jq '[.[] | select(.private == true and .archived == false) | .name] | .[]' 2>&1)
+
+# Get repos already assigned to the team
+TEAM_REPOS=$(gh api "orgs/$ORG/teams/$TEAM/repos" --paginate --jq '[.[].name] | .[]' 2>&1)
+
+MISSING=()
+COMPLIANT=()
+
+while IFS= read -r repo; do
+  if echo "$TEAM_REPOS" | grep -qx "$repo"; then
+    COMPLIANT+=("$repo")
+  else
+    MISSING+=("$repo")
+  fi
+done <<< "$ALL_REPOS"
+
+echo "✓ Compliant (${#COMPLIANT[@]} repos):"
+for r in "${COMPLIANT[@]}"; do echo "    $r"; done
+
+echo ""
+echo "✗ Non-compliant (${#MISSING[@]} repos):"
+for r in "${MISSING[@]}"; do echo "    $r"; done
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+  echo ""
+  echo "✓ All repos are compliant."
+  exit 0
+fi
+
+if [ "$FIX" = true ]; then
+  echo ""
+  echo "=== Fixing non-compliant repos ==="
+  for repo in "${MISSING[@]}"; do
+    result=$(gh api --method PUT "orgs/$ORG/teams/$TEAM/repos/$ORG/$repo" -f permission="$PERMISSION" 2>&1)
+    if [ $? -eq 0 ]; then
+      echo "  ✓ $repo"
+    else
+      echo "  ✗ $repo — $result"
+    fi
+  done
+  echo ""
+  echo "Done."
+else
+  echo ""
+  echo "Run with --fix to assign team '$TEAM' to missing repos."
+fi


### PR DESCRIPTION
## Summary

Closes #33 — implements the `tick` convention across the BSG catalog by
shipping the missing `github-compliance` skill and splitting the
convention docs to cover both agents and reporting skills.

- New `claude-skills/skills/github-compliance/` with SKILL.md, an
  audit/fix script, and an org-structure reference. Audits that every
  non-archived private repo in \`beyond-scale-group\` has the \`board\`
  team with \`admin\` permission.
- SKILL.md defines the skill's \`tick\` action — capture-mode audit
  written under \`compliance/reports/YYYY-MM-DD-compliance.md\`, landed
  via \`open-report-pr.sh\`, silent by default with explicit
  silence-breakers (non-compliant repo, enumeration error, new repo
  first-seen).
- INSTALL.md reworks the \`tick\` section: common rules at the top,
  then agent-specific (\`tick:\` frontmatter + existing test) and
  skill-specific (Tick action section in SKILL.md) sub-sections. Adds
  the github-compliance row to the skills catalog.

All 7 claude-skills tests pass.

## Test plan

- [ ] \`python3 claude-skills/tests/test_skills.py\` — green
- [ ] \`bash claude-skills/skills/github-compliance/scripts/check_compliance.sh\`
      runs against \`beyond-scale-group\` from a developer machine
- [ ] \`--fix\` flag applies missing team assignments as expected
- [ ] Invoking the skill via \`/github-compliance tick\` emits a silent
      reply when every repo is compliant and a flagged reply otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)