### PR TITLE
feat(agents): implement @security agent + /security-report skill (#44)

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -40,12 +40,14 @@ No git clone, no script to run, no cron to set up.
 | `browser` | Browser automation wrapping [`agent-browser`](https://www.npmjs.com/package/agent-browser) with persistent profile management, a Google login helper (`scripts/login-google.sh`), and a generic profile wrapper (`scripts/with-profile.sh`). Headed mode for first-time logins, headless for replay. Core verbs: open, click, fill, type, screenshot, snapshot (accessibility tree). |
 | `github-compliance` | GitHub organization compliance checker for `beyond-scale-group`. Audits that every non-archived private repo has the `board` team assigned with `admin` permission, and (with `--fix`) assigns missing teams. Exposes a `tick` action that lands the audit under `compliance/reports/YYYY-MM-DD-compliance.md` via `open-report-pr.sh` and stays silent unless a non-compliant repo is found. |
 | `po` | Product owner skill for the current GitHub repo. Covers plan adherence, backlog triage, milestone tracking, sprint planning, scope-creep detection, PR flow health, and stakeholder reporting. One paginated GraphQL snapshot feeds every capability; reports land under `po/reports/` with the raw snapshot in `po/history/<date>.json`. Heavy lifting in bash + jq (zero LLM cost), narration in the skill. |
+| `security-report` | Security audit toolkit for the current repo. Auto-detects the package ecosystem (npm/pip/go/cargo), runs vulnerability scanners, cross-checks with Dependabot alerts, scans tracked files for secret patterns (AWS keys, GitHub tokens, private keys), and audits HTTP security headers on web-serving repos. Exposes a `tick` action that lands the audit under `security/reports/YYYY-MM-DD-audit.md` via `open-report-pr.sh` and stays silent unless a critical/high CVE, secret finding, missing critical header, or tracked `.env` is detected. |
 
 ## Available agents
 
 | Name | Description |
 |------|-------------|
 | `po-manager` | Product owner / project manager orchestrator subagent. Delegated to for plan adherence, backlog triage, milestone progress, sprint health, stale ticket detection, standup summaries. Uses the `po` skill and `daily-standup` for meeting parsing. Does not implement features. |
+| `security` | Security posture auditor subagent. Delegated to for "security audit", "vulnerability scan", "secret scan", "OWASP check", "are we secure". Uses the `security-report` skill for deps / secrets / headers / OWASP heuristics. Reports only — does not remediate, upgrade packages, or edit source. |
 
 ## Settings merged into `~/.claude/settings.json`
 

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -1,0 +1,111 @@
+---
+name: security
+description: >
+  Security posture auditor for the current GitHub repository. Scans for
+  dependency vulnerabilities, committed secrets, and OWASP top-10 gaps.
+  Use when the user asks for "security audit", "vulnerability scan",
+  "secret scan", "OWASP check", "dependency vulnerabilities", "security
+  posture", "are we secure", "audit de sécurité", or "analyse des
+  vulnérabilités".
+tools: Read, Glob, Grep, Bash, Write
+model: sonnet
+skills: [security-report]
+color: red
+output: pr
+tick: >
+  Run the full security audit (deps + secrets + config), land it as
+  security/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
+  silent in chat unless a silence-breaker fires (critical/high CVE, secret
+  found, missing critical header, tracked `.env`).
+---
+
+You are the **Security Agent** for this repository. Your job: produce a
+clear, accurate security audit — and nothing else. You do not remediate
+vulnerabilities, you do not upgrade packages, you do not edit source code.
+If the user asks for a fix, hand the request back to the main agent with a
+summary of the finding.
+
+## Operating principles
+
+1. **Facts over narrative.** Every finding must come from a script in the
+   `security-report` skill or from a tool the skill wraps (`npm audit`,
+   `pip-audit`, `gh api /vulnerability-alerts`, pattern grep). Never
+   invent CVE IDs, severities, or package names.
+2. **Scripts before LLM reasoning.** If the skill has a script for what
+   you need, run it instead of pattern-matching the repo yourself. The
+   scripts are faster, deterministic, and free of token cost.
+3. **Files persist, chat is ephemeral.** Write the audit to
+   `security/reports/YYYY-MM-DD-audit.md` and land it via
+   `open-report-pr.sh`. In the chat, reply with the PR URL plus a
+   one-line verdict — never paste the full audit.
+4. **Silence is a feature.** When no silence-breaker fires, the chat
+   reply is a single line. The committed report is the full trail.
+5. **Confirm before any externally-visible action.** Posting a comment,
+   opening an issue, or labeling a PR based on a finding — always
+   confirm with the user first.
+6. **Never remediate.** Even when the fix is obvious (`npm update foo`),
+   report the finding and stop. Remediation is a separate, explicit ask.
+
+## Routing
+
+| User intent                                                     | What to do                                       |
+| --------------------------------------------------------------- | ------------------------------------------------ |
+| "security audit", "full scan", "posture check", "are we secure" | `security-report` → full audit via `generate-report.sh` |
+| "dependency scan", "CVEs", "vulnerabilities"                    | `security-report` → `references/deps.md`         |
+| "secret scan", "leaked credentials", "tokens in code"           | `security-report` → `references/secrets.md`      |
+| "OWASP", "checklist", "top 10"                                  | `security-report` → `references/owasp.md`        |
+| "security headers", "CSP", "CORS", "HSTS"                       | `security-report` → `references/headers.md`      |
+| "fix vulnerability X", "upgrade package Y"                      | Decline politely; this is out of scope.          |
+
+## Report file naming
+
+```
+security/reports/2026-04-20-audit.md      # full tick
+security/reports/2026-04-20-deps.md       # deps-only slice
+security/reports/2026-04-20-secrets.md    # secrets-only slice
+```
+
+Use today's date. After writing and landing the PR, print the PR URL
+plus a one-line verdict — do **not** dump the full report inline.
+
+## Tick action
+
+`@security tick` is the single conventional verb for "run the periodic
+audit now." It must be **idempotent**, **silent by default**, and
+**repo-scoped** — see `claude-skills/skills/security-report/SKILL.md`
+→ "Tick action" for the full procedure (collect snapshot → reporters →
+compose report → land via `open-report-pr.sh` → evaluate
+silence-breakers).
+
+### Silence-breakers
+
+Break silence if **any** of these hold for the audit you just produced:
+
+| Signal                                 | Source                                       | Threshold              |
+| -------------------------------------- | -------------------------------------------- | ---------------------- |
+| Critical / high CVE in dependencies    | `deps.sh` → `severity: critical\|high`       | Any                    |
+| Secret pattern in tracked files        | `secrets.sh` → `findings[]`                  | Non-empty              |
+| Missing critical security header       | `headers.sh` → `missing[]` (CSP, HSTS)       | Any critical           |
+| Known-vulnerable dep with no fix       | `deps.sh` → `noFix[]`                        | Any critical           |
+| `.env` or credentials tracked by git   | `secrets.sh` → `trackedEnvFiles[]`           | Non-empty              |
+| Collector failed (tool missing, etc.)  | `collect.sh` exit code                       | Non-zero               |
+
+Thresholds live here (in the agent's product definition), not in the
+skill's scripts. The scripts emit raw counts; the agent decides what
+counts as "needs attention."
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/agents/security.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/agents/security.md`
+is overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this agent, do **not**
+edit the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/agents/security.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/security-report/SKILL.md
+++ b/claude-skills/skills/security-report/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: security-report
+description: >
+  Security audit toolkit for the current GitHub repository. Produces a
+  dated report covering dependency vulnerabilities (npm/pip/cargo/go),
+  secret patterns in tracked files, security headers / config hardening,
+  and an OWASP top-10 quick check. Use when the user asks to "scan for
+  vulnerabilities", "check for leaked secrets", "run a security audit",
+  "OWASP check", "CVE scan", or "are there known vulns". Heavy lifting
+  happens in bash + jq scripts; the LLM narrates the findings.
+---
+
+# Security Report
+
+The security-audit skill for the **current repository**. Shipped as the
+implementation layer behind the `@security` subagent — run directly when
+you just need the raw data, or let `@security` orchestrate it for a
+silent-by-default tick.
+
+## Intent routing
+
+| If the user asks about...                                        | Read this reference       |
+| ---------------------------------------------------------------- | ------------------------- |
+| Dependency vulnerabilities, CVEs, outdated packages              | `references/deps.md`      |
+| Leaked secrets, committed `.env`, tokens in source               | `references/secrets.md`   |
+| OWASP top-10, broken access control, injection, misconfig        | `references/owasp.md`     |
+| Security headers (CSP, HSTS, CORS), cookie flags, HTTPS config   | `references/headers.md`   |
+
+For a **full audit** (every dimension), run `generate-report.sh` — it
+collects once, runs every reporter, and composes a single markdown file
+under `security/reports/`.
+
+## Hard rules
+
+1. **Never invent findings.** Every CVE, severity, package name, or
+   secret pattern must come from a script's JSON output — not from
+   recognition or memory.
+2. **Always write the final report to `security/reports/YYYY-MM-DD-*.md`**
+   so the audit trail is dated and version-controllable.
+3. **Run scripts from the repo root.** They auto-detect the package
+   ecosystem via lockfiles (package-lock.json, Pipfile.lock, go.sum,
+   Cargo.lock).
+4. **Do not fix anything.** Reporting only. If a script has a `--fix`
+   flag (it doesn't today), never pass it from a `tick`.
+5. **Respect `.securityignore`** when scanning for secrets. Test
+   fixtures and intentional sample credentials belong there.
+6. **Confirm before posting** to GitHub (issue comment, labels, etc.).
+   Default is local-only.
+
+## Available scripts
+
+All scripts live in `scripts/` and emit JSON on stdout (except
+`generate-report.sh`, which emits markdown). `collect.sh` is the single
+cross-tool fetch; every other reporter is a pure jq / grep transform of
+that snapshot — pass it with `--snapshot <path>`, pipe it in, or let
+the script auto-collect a fresh one.
+
+| Script                | Purpose                                                                 |
+| --------------------- | ----------------------------------------------------------------------- |
+| `collect.sh`          | Auto-detect package ecosystem, run `npm audit` / `pip-audit` / `gh api /vulnerability-alerts`, gather tracked-file list for secret scan. One snapshot → `/tmp/security-snap.json`. |
+| `deps.sh`             | Transform snapshot → dependency vulnerability table with severity, fix-available, and `noFix[]` summary. |
+| `secrets.sh`          | Scan tracked files for secret patterns (AWS keys, GitHub tokens, generic `AKIA`/`sk-`/`ghp_` prefixes, private keys). Respects `.securityignore`. |
+| `headers.sh`          | Inspect config files (nginx, Express, Flask, …) for required security headers (CSP, HSTS, X-Frame-Options). |
+| `generate-report.sh`  | Collects once, runs every reporter, composes the full markdown audit. |
+
+**Invocation patterns:**
+
+```bash
+# One-shot: full audit
+bash scripts/generate-report.sh > security/reports/$(date +%F)-audit.md
+
+# Reuse one snapshot across multiple reporters
+bash scripts/collect.sh > /tmp/security-snap.json
+bash scripts/deps.sh    --snapshot /tmp/security-snap.json
+bash scripts/secrets.sh --snapshot /tmp/security-snap.json
+bash scripts/headers.sh --snapshot /tmp/security-snap.json
+
+# Deps only, fail-closed on critical CVEs (for a local guard, not CI)
+bash scripts/deps.sh | jq -e '.summary.critical == 0'
+```
+
+## Output convention
+
+Reports go to `security/reports/`. Filename pattern:
+
+```
+security/reports/2026-04-20-audit.md      # full audit from tick
+security/reports/2026-04-20-deps.md       # deps-only slice
+security/reports/2026-04-20-secrets.md    # secrets-only slice
+```
+
+Use today's date. After writing, print the file path and a one-line
+verdict — do **not** dump the full report inline.
+
+## Tick action
+
+Users invoke `tick` (typically via `@security tick` from `/loop` or
+`/schedule`) when they want the security audit to run now and the
+result to be archived in the repo. It is **idempotent, repo-scoped,
+and silent by default**.
+
+This `tick` follows the BSG-wide convention documented in the top-level
+[`CLAUDE.md`][claude-md] under "The `tick` convention" — silent-by-default,
+human-initiated (no CI cron), repo-scoped (audits the current repo's
+tree, writes to the current repo's `security/reports/`).
+
+[claude-md]: https://github.com/beyond-scale-group/bsg-stack/blob/main/CLAUDE.md
+
+### Steps
+
+1. **Generate the full audit** — one invocation composes every reporter:
+
+   ```bash
+   mkdir -p security/reports
+   bash ~/.claude/skills/security-report/scripts/generate-report.sh \
+     > security/reports/$(date +%F)-audit.md
+   ```
+
+2. **Land the report via the shared helper** — never commit to `main`
+   directly. The helper opens an auto-merge PR (or falls back to a
+   direct squash merge if branch protection is not configured):
+
+   ```bash
+   bash ~/.claude/scripts/open-report-pr.sh \
+     security/reports/$(date +%F)-audit.md \
+     --agent security
+   ```
+
+3. **Evaluate silence-breakers** by parsing the snapshot JSON (not the
+   rendered markdown — more robust). The `@security` agent owns the
+   thresholds; this skill emits raw counts.
+
+4. **Reply.** If no silence-breaker fires, a single line — e.g.
+   `Tick: security posture clean, report at <PR url>` — is the whole
+   reply. If a silence-breaker fires, summarize which ones (count
+   critical CVEs, count secret findings, etc.) and link the PR.
+
+### Silence is a feature
+
+Do **not** pad the reply with "no issues found" narrative, next-step
+suggestions, or reassurance when nothing fired. One-line receipts
+only. The committed report PR is the full audit trail — the chat line
+is just a receipt. Remediation (package upgrades, secret rotation,
+header fixes) is **never** part of `tick` — the user explicitly opts
+in to each remediation.
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/skills/security-report/SKILL.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/skills/security-report/SKILL.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/skills/security-report/SKILL.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/skills/security-report/references/deps.md
+++ b/claude-skills/skills/security-report/references/deps.md
@@ -1,0 +1,87 @@
+# Dependency Vulnerability Analysis
+
+How to run and interpret the dependency scan.
+
+## Scope
+
+Covers every ecosystem the collector detects via lockfiles:
+
+| Lockfile              | Tool used              | Ecosystem |
+| --------------------- | ---------------------- | --------- |
+| `package-lock.json`   | `npm audit --json`     | Node.js   |
+| `yarn.lock`           | `npm audit --json` (fallback) | Node.js |
+| `pnpm-lock.yaml`      | `npm audit --json` (fallback) | Node.js |
+| `Pipfile.lock`        | `pip-audit --format=json` | Python |
+| `poetry.lock`         | `pip-audit --format=json` | Python |
+| `go.sum`              | `gh api .../vulnerability-alerts` (GHSA) | Go |
+| `Cargo.lock`          | `gh api .../vulnerability-alerts` (GHSA) | Rust |
+
+GitHub Dependabot's Security Alerts API (`gh api /repos/{owner}/{repo}/vulnerability-alerts`)
+is queried unconditionally as a cross-ecosystem safety net — it works
+even when no local tool is installed.
+
+## How to run
+
+```bash
+# From a fresh snapshot
+bash scripts/deps.sh
+
+# Against an existing snapshot
+bash scripts/deps.sh --snapshot /tmp/security-snap.json
+
+# Only critical severity
+bash scripts/deps.sh | jq '.findings[] | select(.severity == "critical")'
+```
+
+## Output schema
+
+```json
+{
+  "summary": {
+    "total": 7,
+    "critical": 2,
+    "high": 1,
+    "moderate": 4,
+    "low": 0
+  },
+  "findings": [
+    {
+      "package": "lodash",
+      "version": "4.17.19",
+      "severity": "critical",
+      "cve": "CVE-2021-23337",
+      "fixedIn": "4.17.21",
+      "source": "npm audit"
+    }
+  ],
+  "noFix": [
+    { "package": "foo", "severity": "high", "cve": "..." }
+  ]
+}
+```
+
+## How to interpret
+
+- **`summary.critical > 0`** → silence-breaker fires. Reply with the
+  package list and recommended upgrade; do **not** perform the upgrade.
+- **`noFix[]` non-empty** → there are known-vulnerable deps with no
+  upstream patch yet. Surface them once per tick, then keep quiet
+  until the list changes (the agent, not the script, debounces).
+- **`summary.total == 0`** → clean. One-line receipt.
+
+## Common false positives
+
+- **Dev-only packages with CVEs in transitive build tools.** Still
+  reported, but the severity is usually informational. Let the user
+  decide.
+- **Vulnerabilities in lockfile-only versions that were pinned
+  intentionally.** Respect `.securityignore` entries of the form
+  `deps: <package>@<version> # reason`.
+
+## What NOT to do
+
+- Don't auto-upgrade. Reporting only.
+- Don't open upstream issues from the tick — the user decides whether
+  to escalate.
+- Don't cite CVEs that aren't in the tool output, even if you "know"
+  they exist.

--- a/claude-skills/skills/security-report/references/headers.md
+++ b/claude-skills/skills/security-report/references/headers.md
@@ -1,0 +1,75 @@
+# Security Headers & Config Hardening
+
+How to audit HTTP security headers and related config for web-serving
+repos.
+
+## Scope
+
+The check only runs when the repo looks like it serves HTTP — detected
+via any of:
+
+- `nginx.conf` / `**/nginx/*.conf`
+- `apache2.conf` / `httpd.conf` / `.htaccess`
+- `app.js` / `server.js` / `main.ts` importing `express`, `fastify`, `koa`, `hono`
+- `wsgi.py` / `asgi.py` / Django `settings.py` / Flask `app.py`
+- `Caddyfile`
+- `vercel.json` / `netlify.toml` (headers stanza)
+- Clever Cloud `clevercloud.json` with a `http` section
+
+Non-HTTP repos (libraries, CLI tools) return `{"applicable": false}`
+and the agent skips this section in the report.
+
+## Required headers
+
+Default enforcement list (codified in `scripts/headers.sh`):
+
+| Header                         | Severity   | Notes                                          |
+| ------------------------------ | ---------- | ---------------------------------------------- |
+| `Content-Security-Policy`      | critical   | Fail if absent or set to `*` / `unsafe-inline` unconditionally |
+| `Strict-Transport-Security`    | critical   | Fail if absent on HTTPS-serving configs; `max-age` ≥ 31536000 |
+| `X-Content-Type-Options`       | high       | Must be `nosniff`                              |
+| `X-Frame-Options`              | high       | Must be `DENY` or `SAMEORIGIN` (unless CSP `frame-ancestors` present) |
+| `Referrer-Policy`              | moderate   | Must be set to a non-`unsafe-url` value        |
+| `Permissions-Policy`           | moderate   | Must restrict geolocation/camera/microphone by default |
+
+## How to run
+
+```bash
+bash scripts/headers.sh                          # fresh
+bash scripts/headers.sh --snapshot /tmp/*.json   # snapshot reuse
+```
+
+## Output schema
+
+```json
+{
+  "applicable": true,
+  "serverKind": "express",
+  "found": ["X-Content-Type-Options", "X-Frame-Options"],
+  "missing": [
+    { "header": "Content-Security-Policy", "severity": "critical" },
+    { "header": "Strict-Transport-Security", "severity": "critical" }
+  ],
+  "weak": [
+    { "header": "Permissions-Policy", "severity": "moderate",
+      "reason": "allows microphone by default" }
+  ]
+}
+```
+
+## How to interpret
+
+- **`missing[]` contains any critical header** → silence-breaker.
+- **`weak[]` non-empty** → surface in the report; not a silence-breaker.
+- **`applicable == false`** → skip the section entirely. Do not
+  fabricate "N/A" entries for a CLI-only repo.
+
+## What NOT to do
+
+- Don't auto-write a CSP. Generating a correct CSP requires knowing
+  every inline script and third-party origin the site loads — out
+  of scope for the audit.
+- Don't trust reverse-proxy-only headers without verifying the
+  upstream config is reachable. If the repo only contains app code,
+  note that headers may be set at the proxy layer (`serverKind:
+  "unknown"` is legitimate).

--- a/claude-skills/skills/security-report/references/owasp.md
+++ b/claude-skills/skills/security-report/references/owasp.md
@@ -1,0 +1,60 @@
+# OWASP Top-10 Quick Check
+
+A lightweight pass across the OWASP Top-10 categories (2021 edition),
+intended as a gap-analysis surface, not a full audit.
+
+## Scope and philosophy
+
+The quick check is **signal, not certification.** Each category is
+evaluated against 1–3 cheap heuristics the LLM can apply by reading
+the repo. Detailed category analysis (fuzzing, DAST, full threat
+modeling) is out of scope for this skill.
+
+Categories with no actionable heuristic for a repo-at-rest audit (e.g.
+A10 Server-Side Request Forgery, which needs runtime instrumentation)
+are marked `n/a` rather than fabricated.
+
+## Checklist
+
+| ID  | Category                                    | Heuristic                                                                 |
+| --- | ------------------------------------------- | ------------------------------------------------------------------------- |
+| A01 | Broken Access Control                       | Auth middleware wired on every router branch? `@auth_required` coverage? |
+| A02 | Cryptographic Failures                      | TLS enforced (HSTS)? Any MD5 / SHA1 / DES / ECB in source?                |
+| A03 | Injection                                   | Parameterized queries / ORM? `eval`, `exec`, `os.system`, template-string SQL? |
+| A04 | Insecure Design                             | Threat model documented? Rate limits on auth endpoints?                   |
+| A05 | Security Misconfiguration                   | Verbose errors in prod? Default creds in config? Debug flags?             |
+| A06 | Vulnerable & Outdated Components            | Covered by `deps.sh` — reference the count here, don't re-scan.           |
+| A07 | Identification & Authentication Failures    | Password policy? MFA? Session timeout? Login throttling?                  |
+| A08 | Software & Data Integrity Failures          | CI runs only pinned Actions? Lockfile committed? SRI on CDN scripts?      |
+| A09 | Security Logging & Monitoring Failures      | Auth events logged? Log injection sanitization?                           |
+| A10 | Server-Side Request Forgery                 | URL allow-list for outbound fetches? (often `n/a` at rest)                |
+
+## How to run
+
+There is no dedicated `owasp.sh` script — the check is LLM-driven on
+top of `generate-report.sh`'s aggregated snapshot plus a targeted
+Read/Grep pass. The result lands in the `## OWASP Top-10` section of
+the composed audit report.
+
+## How to interpret
+
+Each category emits one of:
+
+- **`pass`** — heuristic found no issue
+- **`warn`** — heuristic found a smell; show the file(s)
+- **`fail`** — heuristic found a concrete finding; silence-breaker at
+  the agent's discretion
+- **`n/a`** — heuristic not applicable to this repo (e.g. no auth
+  surface, no web frontend)
+
+The silence-breakers in `agents/security.md` do **not** currently
+include OWASP `fail` counts — the heuristics are too coarse for
+automatic alerting. Surface them in the report; the user decides.
+
+## What NOT to do
+
+- Don't claim a category passes if the heuristic wasn't applicable —
+  use `n/a` instead. False confidence is worse than silence.
+- Don't invent CVE IDs for A06. Defer to `deps.sh`.
+- Don't promote `warn` to `fail` without a concrete file + line — the
+  LLM must cite evidence.

--- a/claude-skills/skills/security-report/references/secrets.md
+++ b/claude-skills/skills/security-report/references/secrets.md
@@ -1,0 +1,101 @@
+# Secret Scanning
+
+How to find secrets that shouldn't be in the repo.
+
+## Scope
+
+Scans **tracked files only** (`git ls-files`) — untracked and gitignored
+files are out of scope. If a secret is in `.env` but `.env` is gitignored,
+that's fine; if `.env` is tracked, that's a silence-breaker.
+
+## Patterns
+
+Default regex catalog (defined in `scripts/secrets.sh`):
+
+| Pattern                                   | Kind                      |
+| ----------------------------------------- | ------------------------- |
+| `AKIA[0-9A-Z]{16}`                        | AWS Access Key ID         |
+| `aws_secret_access_key\s*=\s*[A-Za-z0-9/+=]{40}` | AWS Secret Access Key |
+| `ghp_[A-Za-z0-9]{36}`                     | GitHub personal token     |
+| `ghs_[A-Za-z0-9]{36}`                     | GitHub server token       |
+| `sk-[A-Za-z0-9]{20,}`                     | OpenAI / Anthropic        |
+| `xoxb-[0-9A-Za-z-]+`                      | Slack bot token           |
+| `-----BEGIN (RSA|OPENSSH|EC) PRIVATE KEY-----` | Private key            |
+| `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` | JWT (informational) |
+
+JWT matches are informational by default — often legitimate test
+fixtures. The silence-breaker only fires on actual credentials.
+
+## Tracked env files
+
+Independently of regex patterns, `secrets.sh` lists any tracked file
+whose basename starts with `.env` (e.g. `.env`, `.env.local`,
+`.env.production`). A tracked `.env.example` with placeholder values
+is OK only if it explicitly contains no real secret patterns — the
+regex scan still runs across it.
+
+## How to run
+
+```bash
+bash scripts/secrets.sh                          # fresh scan
+bash scripts/secrets.sh --snapshot /tmp/*.json   # use existing snapshot
+```
+
+## Output schema
+
+```json
+{
+  "summary": {
+    "findings": 1,
+    "trackedEnvFiles": 0,
+    "scannedFiles": 428
+  },
+  "findings": [
+    {
+      "file": "src/config.js",
+      "line": 17,
+      "kind": "AWS Access Key ID",
+      "match": "AKIAIOSFODNN7EXAMPLE"
+    }
+  ],
+  "trackedEnvFiles": []
+}
+```
+
+Matches are returned with enough context for a reviewer to decide, but
+the raw match is truncated or redacted in the public report —
+`scripts/secrets.sh --redact` masks the middle of every match.
+
+## `.securityignore`
+
+A `.gitignore`-style file at the repo root. Each line is either a
+glob (to skip the file entirely) or a `pattern:` directive for
+fine-grained exclusion.
+
+```
+# Skip the whole file
+tests/fixtures/fake-aws-keys.txt
+
+# Skip a specific pattern in one file
+pattern: AKIAIOSFODNN7EXAMPLE in docs/examples/aws-readme.md
+```
+
+The pattern-directive form catches test vectors that are genuinely
+fake but otherwise match a regex.
+
+## How to interpret
+
+- **`findings[]` non-empty** → silence-breaker. Show each finding's
+  file + line; let the user confirm whether it's real or a fixture.
+- **`trackedEnvFiles[]` non-empty** → always a silence-breaker, even
+  if the file has no regex matches. Tracked `.env` is an architectural
+  smell.
+- **`scannedFiles == 0`** → scan was skipped or misconfigured.
+  Investigate.
+
+## What NOT to do
+
+- Don't rotate credentials as part of the tick.
+- Don't commit a redacted copy to the report if the raw secret was
+  already pushed — the audit trail links to the PR where it leaked.
+  Rotation and git-history cleanup are separate explicit asks.

--- a/claude-skills/skills/security-report/scripts/collect.sh
+++ b/claude-skills/skills/security-report/scripts/collect.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# collect.sh — one cross-ecosystem snapshot for the security-report skill.
+#
+# Auto-detects the package ecosystem (npm / pip / go / cargo), runs the
+# available vulnerability tool, cross-checks with GitHub's Dependabot
+# alerts, gathers tracked-file list for secret scanning, and inventories
+# detectable HTTP-server config files. Emits a single JSON document on
+# stdout that every reporter (deps.sh, secrets.sh, headers.sh) consumes
+# with `--snapshot <path>`.
+#
+# Exits 0 on success, non-zero if the repo can't be located.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------- helpers
+
+emit_jsonl_file() {
+  # Read a possibly-missing JSON file, emit {} if missing/empty.
+  local path=$1
+  if [[ -s "$path" ]]; then
+    cat "$path"
+  else
+    echo "{}"
+  fi
+}
+
+json_null_if_empty() {
+  local value=$1
+  if [[ -z "$value" ]]; then
+    echo "null"
+  else
+    printf '%s' "$value" | jq -Rs .
+  fi
+}
+
+# ---------------------------------------------------------- ecosystems
+
+ECOSYSTEMS=()
+[[ -f package-lock.json || -f yarn.lock || -f pnpm-lock.yaml ]] && ECOSYSTEMS+=("node")
+[[ -f Pipfile.lock || -f poetry.lock || -f requirements.txt ]]   && ECOSYSTEMS+=("python")
+[[ -f go.sum || -f go.mod ]]                                     && ECOSYSTEMS+=("go")
+[[ -f Cargo.lock ]]                                              && ECOSYSTEMS+=("rust")
+
+NPM_AUDIT_JSON='{}'
+if [[ " ${ECOSYSTEMS[*]} " == *" node "* ]] && command -v npm >/dev/null 2>&1; then
+  NPM_AUDIT_JSON=$(npm audit --json 2>/dev/null || echo '{}')
+fi
+
+PIP_AUDIT_JSON='{}'
+if [[ " ${ECOSYSTEMS[*]} " == *" python "* ]] && command -v pip-audit >/dev/null 2>&1; then
+  PIP_AUDIT_JSON=$(pip-audit --format=json 2>/dev/null || echo '{}')
+fi
+
+# --------------------------------------------------------- gh dependabot
+
+GHSA_JSON='[]'
+if command -v gh >/dev/null 2>&1; then
+  # Endpoint requires vulnerability-alerts to be enabled. Non-zero
+  # exit just means "nothing to report" from our POV.
+  GHSA_JSON=$(gh api /repos/{owner}/{repo}/dependabot/alerts --paginate 2>/dev/null || echo '[]')
+fi
+
+# ----------------------------------------------------------- tracked files
+
+TRACKED_FILES_JSON=$(git ls-files 2>/dev/null | jq -Rn '[inputs]' || echo '[]')
+
+# Files whose basename starts with .env — candidate leaked env files.
+TRACKED_ENV_FILES_JSON=$(git ls-files 2>/dev/null \
+  | awk -F/ '{base=$NF} base ~ /^\.env(\..+)?$/ {print}' \
+  | jq -Rn '[inputs]' || echo '[]')
+
+# .securityignore content (raw) for downstream reporters.
+SECURITYIGNORE_JSON='""'
+if [[ -f .securityignore ]]; then
+  SECURITYIGNORE_JSON=$(jq -Rs . < .securityignore)
+fi
+
+# ---------------------------------------------------------- server kind
+
+SERVER_KIND="unknown"
+SERVER_APPLICABLE="false"
+if [[ -f nginx.conf ]] || find . -maxdepth 3 -type f \( -name 'nginx.conf' -o -path '*/nginx/*.conf' \) 2>/dev/null | grep -q . ; then
+  SERVER_KIND="nginx"; SERVER_APPLICABLE="true"
+elif [[ -f apache2.conf || -f httpd.conf || -f .htaccess ]]; then
+  SERVER_KIND="apache"; SERVER_APPLICABLE="true"
+elif [[ -f Caddyfile ]]; then
+  SERVER_KIND="caddy"; SERVER_APPLICABLE="true"
+elif [[ -f vercel.json ]]; then
+  SERVER_KIND="vercel"; SERVER_APPLICABLE="true"
+elif [[ -f netlify.toml ]]; then
+  SERVER_KIND="netlify"; SERVER_APPLICABLE="true"
+elif [[ -f clevercloud.json ]]; then
+  SERVER_KIND="clevercloud"; SERVER_APPLICABLE="true"
+elif grep -RlE "require\(['\"]express['\"]\)|from ['\"]express['\"]|import express|fastify|koa|hono" \
+        --include='*.js' --include='*.ts' --include='*.mjs' . 2>/dev/null | head -1 | grep -q . ; then
+  SERVER_KIND="express"; SERVER_APPLICABLE="true"
+elif grep -RlE "Flask|Django|from wsgi|from asgi|FastAPI" --include='*.py' . 2>/dev/null | head -1 | grep -q . ; then
+  SERVER_KIND="python-web"; SERVER_APPLICABLE="true"
+fi
+
+# ---------------------------------------------------------- emit
+
+jq -n \
+  --arg repoRoot "$REPO_ROOT" \
+  --arg generatedAt "$(date -u +%FT%TZ)" \
+  --argjson ecosystems "$(printf '%s\n' "${ECOSYSTEMS[@]:-}" | jq -Rn '[inputs | select(length>0)]')" \
+  --argjson npmAudit "$NPM_AUDIT_JSON" \
+  --argjson pipAudit "$PIP_AUDIT_JSON" \
+  --argjson ghsa "$GHSA_JSON" \
+  --argjson trackedFiles "$TRACKED_FILES_JSON" \
+  --argjson trackedEnvFiles "$TRACKED_ENV_FILES_JSON" \
+  --argjson securityIgnore "$SECURITYIGNORE_JSON" \
+  --arg serverKind "$SERVER_KIND" \
+  --arg serverApplicable "$SERVER_APPLICABLE" \
+  '{
+    repoRoot: $repoRoot,
+    generatedAt: $generatedAt,
+    ecosystems: $ecosystems,
+    deps: {
+      npmAudit: $npmAudit,
+      pipAudit: $pipAudit,
+      dependabotAlerts: $ghsa
+    },
+    files: {
+      tracked: $trackedFiles,
+      envFiles: $trackedEnvFiles
+    },
+    securityIgnore: $securityIgnore,
+    server: {
+      applicable: ($serverApplicable == "true"),
+      kind: $serverKind
+    }
+  }'

--- a/claude-skills/skills/security-report/scripts/deps.sh
+++ b/claude-skills/skills/security-report/scripts/deps.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# deps.sh — dependency vulnerability reporter.
+#
+# Reads the security snapshot (from collect.sh or --snapshot) and emits
+# a normalized JSON summary of dependency vulnerabilities across every
+# detected ecosystem, plus a `noFix[]` list of critical findings with no
+# available fix.
+
+set -euo pipefail
+
+SNAPSHOT=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --snapshot) SNAPSHOT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "$SNAPSHOT" ]]; then
+  SNAPSHOT=$(mktemp -t security-snap.XXXXXX.json)
+  trap 'rm -f "$SNAPSHOT"' EXIT
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+  bash "$SCRIPT_DIR/collect.sh" > "$SNAPSHOT"
+fi
+
+# Transform npm audit output into a flat findings[] array.
+NPM_FINDINGS=$(jq '
+  (.deps.npmAudit.vulnerabilities // {}) as $v
+  | [ $v | to_entries[] |
+      .value as $entry |
+      {
+        package: .key,
+        version: ($entry.range // "unknown"),
+        severity: ($entry.severity // "unknown"),
+        cve: ($entry.via | if type=="array" then (.[0].url // .[0] // null) else null end),
+        fixedIn: ($entry.fixAvailable | if type=="object" then .version else null end),
+        source: "npm audit"
+      }
+    ]
+' "$SNAPSHOT")
+
+# Transform pip-audit output.
+PIP_FINDINGS=$(jq '
+  (.deps.pipAudit.dependencies // []) as $deps
+  | [ $deps[] as $d
+      | ($d.vulns // []) as $vulns
+      | $vulns[] |
+      {
+        package: $d.name,
+        version: $d.version,
+        severity: (.aliases // [] | map(select(startswith("CVE-"))) | first // .severity // "unknown"),
+        cve: (.id // (.aliases // [] | map(select(startswith("CVE-"))) | first)),
+        fixedIn: ((.fix_versions // [])[0] // null),
+        source: "pip-audit"
+      }
+    ]
+' "$SNAPSHOT")
+
+# Transform Dependabot alerts.
+DEPENDABOT_FINDINGS=$(jq '
+  (.deps.dependabotAlerts // []) as $alerts
+  | [ $alerts[]
+      | select(.state == "open" or .state == null)
+      | {
+        package: (.security_vulnerability.package.name // .dependency.package.name // "unknown"),
+        version: (.dependency.manifest_path // "unknown"),
+        severity: (.security_vulnerability.severity // "unknown"),
+        cve: (.security_advisory.cve_id // .security_advisory.ghsa_id // null),
+        fixedIn: (.security_vulnerability.first_patched_version.identifier // null),
+        source: "dependabot"
+      }
+    ]
+' "$SNAPSHOT")
+
+# Merge and deduplicate on (package, cve).
+FINDINGS=$(jq -n \
+  --argjson a "$NPM_FINDINGS" \
+  --argjson b "$PIP_FINDINGS" \
+  --argjson c "$DEPENDABOT_FINDINGS" \
+  '($a + $b + $c) | unique_by([.package, .cve])')
+
+SUMMARY=$(jq -n --argjson f "$FINDINGS" '
+  {
+    total: ($f | length),
+    critical: ($f | map(select(.severity == "critical")) | length),
+    high:     ($f | map(select(.severity == "high"))     | length),
+    moderate: ($f | map(select(.severity == "moderate")) | length),
+    low:      ($f | map(select(.severity == "low"))      | length)
+  }')
+
+NO_FIX=$(jq -n --argjson f "$FINDINGS" '
+  $f | map(select((.severity == "critical" or .severity == "high") and (.fixedIn == null or .fixedIn == "")))')
+
+jq -n \
+  --argjson summary "$SUMMARY" \
+  --argjson findings "$FINDINGS" \
+  --argjson noFix "$NO_FIX" \
+  '{ summary: $summary, findings: $findings, noFix: $noFix }'

--- a/claude-skills/skills/security-report/scripts/generate-report.sh
+++ b/claude-skills/skills/security-report/scripts/generate-report.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# generate-report.sh — compose a full security audit report.
+#
+# Collects once, runs every reporter, composes a markdown document on
+# stdout. Intended as the single invocation behind `@security tick`.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+SNAPSHOT=$(mktemp -t security-snap.XXXXXX.json)
+trap 'rm -f "$SNAPSHOT"' EXIT
+
+bash "$SCRIPT_DIR/collect.sh" > "$SNAPSHOT"
+
+DEPS=$(bash "$SCRIPT_DIR/deps.sh"    --snapshot "$SNAPSHOT")
+SECRETS=$(bash "$SCRIPT_DIR/secrets.sh" --snapshot "$SNAPSHOT")
+HEADERS=$(bash "$SCRIPT_DIR/headers.sh" --snapshot "$SNAPSHOT")
+
+DATE=$(date +%F)
+REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
+
+cat <<EOF
+# Security Audit — $DATE
+
+**Repository:** \`$REPO\`
+**Generated:** $(jq -r '.generatedAt' "$SNAPSHOT")
+**Ecosystems detected:** $(jq -r '.ecosystems | join(", ") // "(none)"' "$SNAPSHOT")
+
+---
+
+## Dependency Vulnerabilities
+
+$(jq -r '
+  .summary as $s
+  | "**Summary:** \($s.total) total — \($s.critical) critical, \($s.high) high, \($s.moderate) moderate, \($s.low) low"
+' <<<"$DEPS")
+
+$(jq -r '
+  if (.findings | length) == 0 then
+    "_No vulnerabilities reported._"
+  else
+    (
+      "| Package | Version | Severity | CVE | Fix available |",
+      "|---------|---------|----------|-----|----------------|",
+      (.findings[] | "| \(.package) | \(.version) | \(.severity) | \(.cve // "-") | \(.fixedIn // "no") |")
+    )
+  end
+' <<<"$DEPS")
+
+$(jq -r '
+  if (.noFix | length) == 0 then
+    ""
+  else
+    "\n**No-fix-available (critical/high):** " + ([.noFix[] | .package] | join(", "))
+  end
+' <<<"$DEPS")
+
+---
+
+## Secret Scan
+
+$(jq -r '
+  .summary as $s
+  | "**Summary:** \($s.findings) finding(s), \($s.trackedEnvFiles) tracked .env file(s), \($s.scannedFiles) file(s) scanned"
+' <<<"$SECRETS")
+
+$(jq -r '
+  if (.findings | length) == 0 then
+    "_No secret patterns detected in tracked files._"
+  else
+    (
+      "| File | Line | Kind | Match |",
+      "|------|------|------|-------|",
+      (.findings[] | "| \(.file) | \(.line) | \(.kind) | " + "\u0060" + .match + "\u0060" + " |")
+    )
+  end
+' <<<"$SECRETS")
+
+$(jq -r '
+  if (.trackedEnvFiles | length) == 0 then
+    ""
+  else
+    "\n**Tracked env files (silence-breaker):** " + ([.trackedEnvFiles[]] | join(", "))
+  end
+' <<<"$SECRETS")
+
+---
+
+## Configuration Hardening
+
+$(jq -r '
+  if .applicable == false then
+    "_Not applicable — this repo does not serve HTTP._"
+  else
+    "**Server kind detected:** \(.serverKind)\n\n" +
+    (
+      if (.missing | length) == 0 then "_All required security headers are present._"
+      else
+        "### Missing headers\n\n" +
+        "| Header | Severity |\n|--------|----------|\n" +
+        ([.missing[] | "| \(.header) | \(.severity) |"] | join("\n"))
+      end
+    ) +
+    (
+      if (.weak | length) == 0 then ""
+      else
+        "\n\n### Weak / permissive headers\n\n" +
+        "| Header | Severity | Reason |\n|--------|----------|--------|\n" +
+        ([.weak[] | "| \(.header) | \(.severity) | \(.reason) |"] | join("\n"))
+      end
+    )
+  end
+' <<<"$HEADERS")
+
+---
+
+## OWASP Top-10 Quick Check
+
+_Populated by the \`@security\` agent based on this snapshot. See
+\`references/owasp.md\` for the heuristic catalog. Category-by-category
+analysis is LLM-driven; the scripts only provide the raw signals
+above._
+
+EOF

--- a/claude-skills/skills/security-report/scripts/headers.sh
+++ b/claude-skills/skills/security-report/scripts/headers.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# headers.sh — audit HTTP security headers configured in the repo.
+#
+# Reads the server kind from the snapshot, applies a static catalog of
+# required headers, and emits found[] / missing[] / weak[] lists. Returns
+# `{"applicable": false}` for non-HTTP-serving repos.
+
+set -euo pipefail
+
+SNAPSHOT=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --snapshot) SNAPSHOT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "$SNAPSHOT" ]]; then
+  SNAPSHOT=$(mktemp -t security-snap.XXXXXX.json)
+  trap 'rm -f "$SNAPSHOT"' EXIT
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+  bash "$SCRIPT_DIR/collect.sh" > "$SNAPSHOT"
+fi
+
+APPLICABLE=$(jq -r '.server.applicable' "$SNAPSHOT")
+if [[ "$APPLICABLE" != "true" ]]; then
+  echo '{"applicable": false}'
+  exit 0
+fi
+
+SERVER_KIND=$(jq -r '.server.kind' "$SNAPSHOT")
+REPO_ROOT=$(jq -r '.repoRoot' "$SNAPSHOT")
+cd "$REPO_ROOT"
+
+# Required headers + severity.
+REQUIRED=(
+  "Content-Security-Policy|critical"
+  "Strict-Transport-Security|critical"
+  "X-Content-Type-Options|high"
+  "X-Frame-Options|high"
+  "Referrer-Policy|moderate"
+  "Permissions-Policy|moderate"
+)
+
+# Grep across likely config/source files. The heuristic is coarse on
+# purpose — we're looking for "is this header mentioned anywhere" rather
+# than "is it set correctly at runtime."
+SEARCH_FILES=$(git ls-files '*.conf' '*.js' '*.ts' '*.py' '*.toml' '*.json' '*.yaml' '*.yml' '.htaccess' Caddyfile 2>/dev/null | tr '\n' ' ')
+
+FOUND='[]'
+MISSING='[]'
+WEAK='[]'
+
+for entry in "${REQUIRED[@]}"; do
+  header="${entry%%|*}"
+  severity="${entry#*|}"
+
+  # Case-insensitive grep for the header name.
+  if [[ -n "$SEARCH_FILES" ]] && grep -IliE "\b${header}\b" $SEARCH_FILES 2>/dev/null | head -1 | grep -q . ; then
+    FOUND=$(jq --arg h "$header" '. + [$h]' <<<"$FOUND")
+
+    # Soft heuristics for weakness.
+    case "$header" in
+      "Content-Security-Policy")
+        if grep -IliE "Content-Security-Policy.*(unsafe-inline|unsafe-eval|\*)" $SEARCH_FILES 2>/dev/null | head -1 | grep -q . ; then
+          WEAK=$(jq --arg h "$header" --arg s "$severity" --arg r "uses unsafe-inline / unsafe-eval / wildcard source" \
+            '. + [{header: $h, severity: $s, reason: $r}]' <<<"$WEAK")
+        fi
+        ;;
+      "Strict-Transport-Security")
+        if ! grep -IliE "Strict-Transport-Security.*max-age=[3-9][0-9]{7,}" $SEARCH_FILES 2>/dev/null | head -1 | grep -q . ; then
+          WEAK=$(jq --arg h "$header" --arg s "$severity" --arg r "max-age < 1 year or missing" \
+            '. + [{header: $h, severity: $s, reason: $r}]' <<<"$WEAK")
+        fi
+        ;;
+    esac
+  else
+    MISSING=$(jq --arg h "$header" --arg s "$severity" \
+      '. + [{header: $h, severity: $s}]' <<<"$MISSING")
+  fi
+done
+
+jq -n \
+  --arg kind "$SERVER_KIND" \
+  --argjson found "$FOUND" \
+  --argjson missing "$MISSING" \
+  --argjson weak "$WEAK" \
+  '{
+    applicable: true,
+    serverKind: $kind,
+    found: $found,
+    missing: $missing,
+    weak: $weak
+  }'

--- a/claude-skills/skills/security-report/scripts/secrets.sh
+++ b/claude-skills/skills/security-report/scripts/secrets.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# secrets.sh — scan tracked files for secret patterns.
+#
+# Reads tracked-file list from the snapshot, applies a regex catalog,
+# respects .securityignore, and emits findings[] + trackedEnvFiles[]
+# lists.
+
+set -euo pipefail
+
+SNAPSHOT=""
+REDACT=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --snapshot) SNAPSHOT="$2"; shift 2 ;;
+    --redact)   REDACT=true;   shift   ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "$SNAPSHOT" ]]; then
+  SNAPSHOT=$(mktemp -t security-snap.XXXXXX.json)
+  trap 'rm -f "$SNAPSHOT"' EXIT
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+  bash "$SCRIPT_DIR/collect.sh" > "$SNAPSHOT"
+fi
+
+REPO_ROOT=$(jq -r '.repoRoot' "$SNAPSHOT")
+cd "$REPO_ROOT"
+
+# Pattern catalog. Keep entries as "<kind>|<regex>" so bash arrays handle
+# whitespace safely.
+PATTERNS=(
+  "AWS Access Key ID|AKIA[0-9A-Z]{16}"
+  "AWS Secret Access Key|aws_secret_access_key[[:space:]]*=[[:space:]]*[A-Za-z0-9/+=]{40}"
+  "GitHub personal token|ghp_[A-Za-z0-9]{36}"
+  "GitHub server token|ghs_[A-Za-z0-9]{36}"
+  "OpenAI/Anthropic API key|sk-[A-Za-z0-9]{20,}"
+  "Slack bot token|xoxb-[0-9A-Za-z-]+"
+  "Private key|-----BEGIN (RSA|OPENSSH|EC) PRIVATE KEY-----"
+)
+
+# Collect the list of files to skip and per-pattern exclusions from
+# .securityignore.
+SKIP_FILES_TMP=$(mktemp); trap 'rm -f "$SKIP_FILES_TMP"' EXIT
+PATTERN_SKIPS_TMP=$(mktemp)
+if jq -e '.securityignore | length > 0' "$SNAPSHOT" >/dev/null; then
+  jq -r '.securityignore' "$SNAPSHOT" | while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+    if [[ "$line" =~ ^pattern:[[:space:]]*(.+)[[:space:]]+in[[:space:]]+(.+)$ ]]; then
+      echo "${BASH_REMATCH[1]}|${BASH_REMATCH[2]}" >> "$PATTERN_SKIPS_TMP"
+    else
+      echo "$line" >> "$SKIP_FILES_TMP"
+    fi
+  done
+fi
+
+FINDINGS_JSON="[]"
+
+# Write tracked files list to a temp file to avoid a subshell that would
+# lose findings accumulated in a pipe.
+TRACKED_LIST=$(mktemp); trap 'rm -f "$TRACKED_LIST"' EXIT
+jq -r '.files.tracked[]' "$SNAPSHOT" > "$TRACKED_LIST"
+
+SCANNED=0
+while IFS= read -r file; do
+  [[ -f "$file" ]] || continue
+
+  # Skip explicit .securityignore globs (naive prefix match).
+  skip=0
+  while IFS= read -r skip_pat; do
+    [[ -z "$skip_pat" ]] && continue
+    case "$file" in $skip_pat) skip=1; break ;; esac
+  done < "$SKIP_FILES_TMP"
+  [[ $skip -eq 1 ]] && continue
+
+  SCANNED=$((SCANNED + 1))
+
+  for entry in "${PATTERNS[@]}"; do
+    kind="${entry%%|*}"
+    regex="${entry#*|}"
+
+    # grep -I skips binaries, -n adds line numbers, -H adds filename, -E extended regex.
+    matches=$(grep -IHnE "$regex" "$file" 2>/dev/null || true)
+    [[ -z "$matches" ]] && continue
+
+    while IFS= read -r m; do
+      # Format: <file>:<line>:<content>
+      line_no=$(echo "$m" | awk -F: 'NR==1 {print $2}')
+      content=$(echo "$m" | sed -E "s/^[^:]+:[0-9]+://")
+      match_text=$(echo "$content" | grep -oE "$regex" | head -1)
+
+      # Check pattern-scoped .securityignore exclusions.
+      excluded=0
+      while IFS='|' read -r pat pfile; do
+        [[ -z "$pat" ]] && continue
+        if [[ "$file" == "$pfile" && "$match_text" == *"$pat"* ]]; then
+          excluded=1; break
+        fi
+      done < "$PATTERN_SKIPS_TMP"
+      [[ $excluded -eq 1 ]] && continue
+
+      if [[ "$REDACT" == true && ${#match_text} -gt 8 ]]; then
+        head="${match_text:0:4}"
+        tail="${match_text: -4}"
+        match_text="${head}***${tail}"
+      fi
+
+      FINDINGS_JSON=$(jq --arg file "$file" --argjson line "$line_no" \
+                         --arg kind "$kind" --arg match "$match_text" \
+        '. + [{file: $file, line: $line, kind: $kind, match: $match}]' \
+        <<<"$FINDINGS_JSON")
+    done <<< "$matches"
+  done
+done < "$TRACKED_LIST"
+
+TRACKED_ENV=$(jq '.files.envFiles' "$SNAPSHOT")
+
+jq -n --argjson findings "$FINDINGS_JSON" \
+      --argjson trackedEnv "$TRACKED_ENV" \
+      --argjson scanned "$SCANNED" '
+  {
+    summary: {
+      findings: ($findings | length),
+      trackedEnvFiles: ($trackedEnv | length),
+      scannedFiles: $scanned
+    },
+    findings: $findings,
+    trackedEnvFiles: $trackedEnv
+  }
+'


### PR DESCRIPTION
## Summary

Closes #44 — implements PRD-001 end-to-end. Ships a `@security` subagent
and the `security-report` skill it delegates to.

- **Agent** (`claude-skills/agents/security.md`): thin router, declares
  \`tick\`, \`output: pr\`, and the silence-breaker thresholds as the
  product definition.
- **Skill** (`claude-skills/skills/security-report/`):
  - `collect.sh` — one cross-ecosystem snapshot (npm / pip / go /
    cargo auto-detected, Dependabot alerts, tracked files, server kind).
  - `deps.sh` — normalizes npm-audit / pip-audit / Dependabot findings
    into a single shape with summary + \`noFix[]\`.
  - `secrets.sh` — AWS / GitHub / OpenAI / Slack / private-key patterns
    across tracked files, respecting \`.securityignore\`.
  - `headers.sh` — CSP, HSTS, X-Content-Type-Options, X-Frame-Options,
    Referrer-Policy, Permissions-Policy with weakness heuristics.
  - `generate-report.sh` — composes the full \`@security tick\` audit.
- 4 reference docs (\`deps.md\`, \`secrets.md\`, \`owasp.md\`,
  \`headers.md\`).
- INSTALL.md catalog rows added.

All 7 claude-skills tests pass. End-to-end smoke test on this repo
produces a clean report (0 vulns, 0 secrets, headers n/a).

## Test plan

- [ ] \`python3 claude-skills/tests/test_skills.py\` — green
- [ ] \`bash claude-skills/skills/security-report/scripts/generate-report.sh\`
      runs end-to-end on this repo without errors
- [ ] \`@security tick\` from a developer machine produces a dated
      report, lands it via \`open-report-pr.sh\`, and stays silent when
      clean
- [ ] Running against a repo with known CVEs (e.g. lodash 4.17.19 pinned)
      surfaces them and triggers the silence-breaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)