### PR TITLE
feat(tick): /tick-all sweep + GitHub-as-bus coordination layer

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -30,6 +30,7 @@ No git clone, no script to run, no cron to set up.
 |------|-------------|
 | `/babysit` | Monitor a long-running or flaky process (shell command or CI run), diagnose failures, fix root causes, retry until green. Includes PR mergeability rules. |
 | `/ocr` | Extract text from images and PDFs without uploading them into Claude's multimodal context. Cascades through Apple Vision (macOS) → Tesseract/OCRmyPDF → Mistral OCR API, writing `<source>.ocr.md` next to the source. Designed to save Anthropic tokens on document-heavy workflows. |
+| `/tick-all` | Fire every registered BSG agent's `tick` in parallel and print a one-line sweep summary per agent. Uses `claude-skills/agents/registry.json` as the agent roster. Each agent handles its own GitHub-bus inbox (claim → work → handoff) via `claude-skills/scripts/github-bus.sh`. Run with `/loop 30m /tick-all` for a recurring sweep — no CI cron required. |
 
 ## Available skills
 

--- a/claude-skills/agents/registry.json
+++ b/claude-skills/agents/registry.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "description": "Registry of BSG agents that participate in /tick-all sweeps and the GitHub coordination bus. See docs/label-taxonomy.md for the full label schema.",
+  "agents": [
+    { "name": "po-manager",   "bus_label": "po",          "output": "pr" },
+    { "name": "security",     "bus_label": "security",    "output": "pr" },
+    { "name": "qa",           "bus_label": "qa",          "output": "pr" },
+    { "name": "tech-lead",    "bus_label": "tech",        "output": "pr" },
+    { "name": "seo",          "bus_label": "seo",         "output": "pr" },
+    { "name": "marketing",    "bus_label": "marketing",   "output": "pr" },
+    { "name": "storytelling", "bus_label": "storytelling","output": "pr" },
+    { "name": "pr-comms",     "bus_label": "pr-comms",    "output": "pr" }
+  ]
+}

--- a/claude-skills/commands/tick-all.md
+++ b/claude-skills/commands/tick-all.md
@@ -1,0 +1,105 @@
+Run a full tick sweep across all registered BSG agents for this repository.
+
+You are the **tick-all dispatcher**. Your job is to fire every registered
+BSG agent's `tick` action in parallel, collect their one-line results, and
+print a brief sweep summary. Nothing more — routing, work, and handoffs are
+each agent's own responsibility.
+
+## Steps
+
+1. **Load the registry.**
+
+   ```bash
+   REGISTRY=$(cat claude-skills/agents/registry.json 2>/dev/null || echo '{"agents":[]}')
+   AGENTS=$(echo "$REGISTRY" | jq -r '.agents[].name')
+   ```
+
+   If `claude-skills/agents/registry.json` is absent, fall back to the
+   hardcoded default list at the bottom of this file.
+
+2. **Fire each agent's tick in parallel.**
+
+   Spawn one Agent tool call per entry with `prompt: "tick"` and
+   `subagent_type: "<name>"`. Do **not** wait for one to finish before
+   starting the next — send all calls in the same tool-use block.
+
+3. **Collect results.**
+
+   Each agent returns a one-line tick receipt (e.g.
+   `Tick: all green, report at <PR url>` or a silence-breaker summary).
+   If a subagent errors, record `ERROR: <agent>: <message>` and continue.
+
+4. **Print the sweep summary.**
+
+   ```
+   ## tick-all — 2026-04-22T14:00:00Z
+
+   ✅ po-manager   Tick: all green, report at https://github.com/…/pull/123
+   ✅ security     Tick: all green, report at https://github.com/…/pull/124
+   ⚠️ seo         Tick: 3 pages missing canonical — report at …/pull/125
+   ❌ marketing    ERROR: registry entry missing bus_label
+
+   4 agents swept in 18 s
+   ```
+
+   Prefix: ✅ green (no silence-breaker), ⚠️ silence-breaker fired, ❌ error.
+   Total elapsed time on the last line.
+
+## GitHub bus inbox processing
+
+Agents that implement the GitHub coordination bus additionally process their
+issue inbox during `tick`. The bus primitives live in
+`claude-skills/scripts/github-bus.sh`. `tick-all` itself does NOT touch
+the bus — it only orchestrates the sweep. Each agent's own `tick` is
+responsible for:
+
+1. Sourcing `github-bus.sh`
+2. Calling `bus_claim <bus_label>` to get its inbox
+3. Locking, working, and handing off each issue
+
+See `docs/label-taxonomy.md` for the full label schema and
+`claude-skills/scripts/github-bus.sh` for the API.
+
+## Rules
+
+- **Repo-scoped.** Each agent's tick runs inside the current repo's working
+  directory and touches only that repo.
+- **Human-initiated.** For recurring sweeps, use `/loop 30m /tick-all` or
+  `/schedule` — never a GitHub Actions cron.
+- **Idempotent.** Re-running is safe: `open-report-pr.sh` reuses existing
+  open branches, and `bus_claim` skips locked issues.
+- **No chat noise when all green.** Forward each agent's verbatim receipt;
+  don't add commentary when everything is healthy.
+
+## Default agent registry
+
+Used when `claude-skills/agents/registry.json` is absent:
+
+| Agent name     | bus_label     | output |
+|----------------|---------------|--------|
+| `po-manager`   | `po`          | pr     |
+| `security`     | `security`    | pr     |
+| `qa`           | `qa`          | pr     |
+| `tech-lead`    | `tech`        | pr     |
+| `seo`          | `seo`         | pr     |
+| `marketing`    | `marketing`   | pr     |
+| `storytelling` | `storytelling`| pr     |
+| `pr-comms`     | `pr-comms`    | pr     |
+
+---
+
+## How to improve this skill
+
+This file is a cached copy of `claude-skills/commands/tick-all.md` in
+[beyond-scale-group/bsg-stack](https://github.com/beyond-scale-group/bsg-stack).
+That repo is the single source of truth — `~/.claude/commands/tick-all.md` is
+overwritten every time the BSG install flow runs.
+
+If the user asks you to improve, fix, or extend this skill, do **not** edit
+the local file. Instead:
+
+1. `gh repo clone beyond-scale-group/bsg-stack` (or work in an existing clone)
+2. Edit `claude-skills/commands/tick-all.md` on a feature branch
+3. Open a pull request against `main`
+
+Bug reports and ideas without a fix → open an issue on the same repo.

--- a/claude-skills/scripts/github-bus.sh
+++ b/claude-skills/scripts/github-bus.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# github-bus.sh — GitHub-as-coordination-bus primitives for BSG agents.
+#
+# Every BSG agent's `tick` action uses these functions to implement
+# claim → work → handoff pipelines entirely through GitHub labels and
+# comments. No central database, no message broker — GitHub is the bus.
+#
+# Label schema (see docs/label-taxonomy.md for the full reference):
+#
+#   needs:<agent>          Issue is waiting for <agent> to process it.
+#   agent:lock:<agent>     Mutex: <agent>'s tick has claimed this issue
+#                          and is currently working on it.
+#   agent:done             Pipeline complete — no more agent hops needed.
+#   agent:blocked          Human intervention required before pipeline
+#                          can continue.
+#
+# Comment markers let agents leave machine-readable messages:
+#
+#   <!-- agent:<name> v1 kind:<kind> -->
+#   <yaml body>
+#   <!-- /agent:<name> -->
+#
+# Issue body manifest:
+#   A fenced block labelled `agents-state` at the bottom of the issue
+#   body holds the shared JSON state that every agent can read/update.
+#
+# Usage: source this file, then call the functions below.
+#
+#   source claude-skills/scripts/github-bus.sh
+#   issues=$(bus_claim seo)
+#   for num in $(echo "$issues" | jq -r '.[]'); do
+#     bus_lock   "$num" seo
+#     # … do work …
+#     bus_handoff "$num" seo marketing "handed off after keyword audit"
+#     bus_unlock  "$num" seo
+#   done
+#
+# Requirements: gh (GitHub CLI), jq
+
+set -euo pipefail
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+_bus_require() {
+  for cmd in "$@"; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+      echo "github-bus.sh: required command not found: $cmd" >&2
+      return 1
+    }
+  done
+}
+
+_bus_repo() {
+  gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null
+}
+
+# ── Claim ─────────────────────────────────────────────────────────────────────
+
+# bus_claim <needs-label>
+#
+# Find open issues labeled "needs:<needs-label>" that are NOT currently
+# locked by any agent. Prints a JSON array of issue numbers to stdout.
+# Returns 0 even if the list is empty (empty inbox is not an error).
+#
+# Example:
+#   issues=$(bus_claim seo)            # → [12, 34]
+#   count=$(echo "$issues" | jq 'length')
+bus_claim() {
+  _bus_require gh jq
+  local label="needs:${1:?bus_claim: needs-label required}"
+
+  # Fetch open issues with the inbox label.
+  # Filter client-side: exclude any that carry an agent:lock:* label so
+  # two concurrent ticks never race on the same issue.
+  gh issue list \
+    --label "$label" \
+    --state open \
+    --json number,labels \
+    --limit 100 \
+    | jq '[
+        .[]
+        | select(
+            .labels
+            | map(.name)
+            | map(startswith("agent:lock:"))
+            | any
+            | not
+          )
+        | .number
+      ]'
+}
+
+# ── Lock / Unlock ─────────────────────────────────────────────────────────────
+
+# bus_lock <issue-number> <agent-name>
+#
+# Add the "agent:lock:<agent-name>" label to prevent another concurrent
+# tick from claiming the same issue. Always call bus_unlock when done
+# (even on error — use a trap).
+bus_lock() {
+  _bus_require gh
+  local num="${1:?bus_lock: issue number required}"
+  local agent="${2:?bus_lock: agent name required}"
+  gh issue edit "$num" --add-label "agent:lock:${agent}" >/dev/null
+}
+
+# bus_unlock <issue-number> <agent-name>
+#
+# Remove the "agent:lock:<agent-name>" label acquired by bus_lock.
+bus_unlock() {
+  _bus_require gh
+  local num="${1:?bus_unlock: issue number required}"
+  local agent="${2:?bus_unlock: agent name required}"
+  gh issue edit "$num" --remove-label "agent:lock:${agent}" >/dev/null 2>&1 || true
+}
+
+# ── Handoff ───────────────────────────────────────────────────────────────────
+
+# bus_handoff <issue-number> <from-label> <to-label> [comment]
+#
+# Swap the routing label on an issue to pass it to the next agent.
+# - Removes "needs:<from-label>"
+# - Adds    "needs:<to-label>"      (unless <to-label> == "done")
+# - If done: removes any remaining "needs:*" labels and adds "agent:done"
+# - Optionally posts <comment> as a plain GitHub comment (not a marker).
+#
+# Example:
+#   bus_handoff 42 seo marketing "keyword audit complete"
+#   bus_handoff 42 marketing done "all agent passes finished"
+bus_handoff() {
+  _bus_require gh jq
+  local num="${1:?bus_handoff: issue number required}"
+  local from="${2:?bus_handoff: from-label required}"
+  local to="${3:?bus_handoff: to-label required}"
+  local comment="${4:-}"
+
+  gh issue edit "$num" --remove-label "needs:${from}" >/dev/null 2>&1 || true
+
+  if [[ "$to" == "done" ]]; then
+    # Remove all remaining needs:* labels and mark done.
+    local needs_labels
+    needs_labels=$(gh issue view "$num" --json labels \
+      | jq -r '.labels[].name | select(startswith("needs:"))')
+    for lbl in $needs_labels; do
+      gh issue edit "$num" --remove-label "$lbl" >/dev/null 2>&1 || true
+    done
+    gh issue edit "$num" --add-label "agent:done" >/dev/null
+  else
+    gh issue edit "$num" --add-label "needs:${to}" >/dev/null
+  fi
+
+  if [[ -n "$comment" ]]; then
+    gh issue comment "$num" --body "$comment" >/dev/null
+  fi
+}
+
+# ── Structured marker comments ────────────────────────────────────────────────
+
+# bus_post_marker <issue-number> <agent-name> <kind> <yaml-body>
+#
+# Post a machine-readable comment on an issue. The comment is wrapped in
+# HTML markers so other agents can extract it without parsing prose.
+#
+# Format:
+#   <!-- agent:<name> v1 kind:<kind> -->
+#   <yaml-body>
+#   <!-- /agent:<name> -->
+#
+# Example:
+#   bus_post_marker 42 seo handoff "$(cat <<'EOF'
+#   to: marketing
+#   reason: keyword audit complete
+#   artifact: seo/reports/2026-04-22-audit.md
+#   EOF
+#   )"
+bus_post_marker() {
+  _bus_require gh
+  local num="${1:?bus_post_marker: issue number required}"
+  local agent="${2:?bus_post_marker: agent name required}"
+  local kind="${3:?bus_post_marker: kind required}"
+  local body="${4:?bus_post_marker: yaml-body required}"
+
+  local comment
+  comment=$(printf '<!-- agent:%s v1 kind:%s -->\n%s\n<!-- /agent:%s -->' \
+    "$agent" "$kind" "$body" "$agent")
+  gh issue comment "$num" --body "$comment" >/dev/null
+}
+
+# bus_read_markers <issue-number> <agent-name>
+#
+# Extract all marker blocks posted by <agent-name> on the issue.
+# Prints each YAML body separated by "---" (one document per marker).
+#
+# Example:
+#   markers=$(bus_read_markers 42 seo)
+bus_read_markers() {
+  _bus_require gh jq
+  local num="${1:?bus_read_markers: issue number required}"
+  local agent="${2:?bus_read_markers: agent name required}"
+  local open_tag="<!-- agent:${agent} v1"
+  local close_tag="<!-- /agent:${agent} -->"
+
+  gh issue view "$num" --comments --json comments \
+    | jq -r '.comments[].body' \
+    | awk \
+        -v open="$open_tag" \
+        -v close="$close_tag" \
+        'BEGIN { inside=0; first=1 }
+         $0 ~ open  { inside=1; next }
+         $0 ~ close {
+           if (!first) print "---"
+           first=0
+           inside=0
+           next
+         }
+         inside { print }'
+}
+
+# ── Shared manifest (issue body JSON block) ───────────────────────────────────
+
+# bus_set_manifest <issue-number> <json>
+#
+# Write (or overwrite) the `agents-state` fenced block at the bottom
+# of the issue body. The block holds shared JSON state across all agents.
+#
+# The block looks like:
+#   ```agents-state
+#   { "phase": "seo", "owner": "seo", "blockers": [] }
+#   ```
+#
+# Example:
+#   bus_set_manifest 42 '{"phase":"marketing","owner":"marketing","blockers":[]}'
+bus_set_manifest() {
+  _bus_require gh jq
+  local num="${1:?bus_set_manifest: issue number required}"
+  local json="${2:?bus_set_manifest: json required}"
+
+  # Validate JSON.
+  echo "$json" | jq . >/dev/null || {
+    echo "github-bus.sh: bus_set_manifest: invalid JSON" >&2
+    return 1
+  }
+
+  local current_body
+  current_body=$(gh issue view "$num" --json body --jq '.body')
+
+  local block
+  block=$(printf '```agents-state\n%s\n```' "$(echo "$json" | jq -c .)")
+
+  # Replace existing block or append a new one.
+  local new_body
+  if echo "$current_body" | grep -q '```agents-state'; then
+    new_body=$(echo "$current_body" \
+      | awk -v block="$block" '
+          /^```agents-state/ { in_block=1; print block; next }
+          in_block && /^```$/ { in_block=0; next }
+          !in_block { print }
+        ')
+  else
+    new_body=$(printf '%s\n\n---\n\n%s' "$current_body" "$block")
+  fi
+
+  gh issue edit "$num" --body "$new_body" >/dev/null
+}
+
+# bus_get_manifest <issue-number>
+#
+# Extract and print the JSON from the `agents-state` block in the issue
+# body. Prints `null` if no block is found.
+#
+# Example:
+#   phase=$(bus_get_manifest 42 | jq -r '.phase')
+bus_get_manifest() {
+  _bus_require gh jq
+  local num="${1:?bus_get_manifest: issue number required}"
+
+  gh issue view "$num" --json body --jq '.body' \
+    | awk '/^```agents-state/{found=1; next} found && /^```$/{exit} found{print}' \
+    | jq -c '.' 2>/dev/null || echo 'null'
+}

--- a/docs/label-taxonomy.md
+++ b/docs/label-taxonomy.md
@@ -1,0 +1,126 @@
+# GitHub Bus — Label Taxonomy
+
+Labels are the only routing and state primitive for the BSG agent
+coordination bus. Every label that an agent reads or writes must appear
+in this document. No agent may invent labels outside this schema.
+
+## Routing labels — `needs:<agent>`
+
+Signal that an issue or PR is waiting for a specific agent to process it.
+Exactly one `needs:*` label should be present at any time during the
+pipeline (the bus is a hand-off chain, not a fan-out).
+
+| Label | Owner agent | Meaning |
+|-------|-------------|---------|
+| `needs:po` | `po-manager` | Needs PO triage / plan alignment check |
+| `needs:security` | `security` | Needs security or dependency audit |
+| `needs:qa` | `qa` | Needs QA / coverage or regression review |
+| `needs:tech` | `tech-lead` | Needs architecture / tech-debt review |
+| `needs:seo` | `seo` | Needs SEO / meta / content audit |
+| `needs:marketing` | `marketing` | Needs marketing content review |
+| `needs:storytelling` | `storytelling` | Needs brand / voice audit |
+| `needs:pr-comms` | `pr-comms` | Needs press release or announcement draft |
+
+## Mutex labels — `agent:lock:<agent>`
+
+Applied by `bus_lock` at the start of a tick, removed by `bus_unlock`
+when the agent finishes (or errors). Prevents two concurrent tick sweeps
+from racing on the same issue.
+
+| Label | Set by | Released by |
+|-------|--------|-------------|
+| `agent:lock:po` | `po-manager tick` | `po-manager tick` (always) |
+| `agent:lock:security` | `security tick` | `security tick` |
+| `agent:lock:qa` | `qa tick` | `qa tick` |
+| `agent:lock:tech` | `tech-lead tick` | `tech-lead tick` |
+| `agent:lock:seo` | `seo tick` | `seo tick` |
+| `agent:lock:marketing` | `marketing tick` | `marketing tick` |
+| `agent:lock:storytelling` | `storytelling tick` | `storytelling tick` |
+| `agent:lock:pr-comms` | `pr-comms tick` | `pr-comms tick` |
+
+> **Rule:** an agent MUST release its lock even on error. Use a Bash
+> `trap 'bus_unlock "$num" "$AGENT"' EXIT` pattern.
+
+## Terminal labels
+
+| Label | Meaning |
+|-------|---------|
+| `agent:done` | All agent hops complete; no further routing needed. Applied by `bus_handoff <num> <from> done`. |
+| `agent:blocked` | Human intervention required. Applied manually or by an agent that cannot proceed. Should always be accompanied by a `bus_post_marker` comment explaining the blocker. |
+
+## Structured comment markers
+
+Agents post machine-readable comments using `bus_post_marker`. Format:
+
+```
+<!-- agent:<name> v1 kind:<kind> -->
+<YAML body>
+<!-- /agent:<name> -->
+```
+
+Standard `kind` values:
+
+| Kind | When used |
+|------|-----------|
+| `handoff` | Agent finished its work and routed to the next agent |
+| `blocked` | Agent could not complete; explains why |
+| `result` | Agent completed a terminal step (no next agent) |
+| `note` | Informational; does not change routing |
+
+Example handoff marker:
+```
+<!-- agent:seo v1 kind:handoff -->
+to: marketing
+reason: keyword audit complete, 3 pages updated
+artifact: seo/reports/2026-04-22-audit.md
+<!-- /agent:seo -->
+```
+
+## Issue body manifest — `agents-state` block
+
+A fenced code block at the bottom of the issue body, managed by
+`bus_set_manifest` / `bus_get_manifest`. Holds shared JSON state:
+
+```
+```agents-state
+{
+  "phase":    "marketing",
+  "owner":    "marketing",
+  "blockers": [],
+  "history":  ["po", "seo"]
+}
+```
+```
+
+Fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `phase` | string | Current routing target (mirrors the active `needs:*` label) |
+| `owner` | string | Agent currently holding the lock, or `null` |
+| `blockers` | array | Human-readable blocker descriptions |
+| `history` | array | Ordered list of agents that have already processed this issue |
+
+## Label creation
+
+Labels are not auto-created by `github-bus.sh`. Run this once per repo
+to seed all bus labels:
+
+```bash
+# routing
+for agent in po security qa tech seo marketing storytelling pr-comms; do
+  gh label create "needs:${agent}" --color "0075ca" --force
+done
+
+# locks
+for agent in po security qa tech seo marketing storytelling pr-comms; do
+  gh label create "agent:lock:${agent}" --color "e4e669" --force
+done
+
+# terminal
+gh label create "agent:done"    --color "0e8a16" --force
+gh label create "agent:blocked" --color "d93f0b" --force
+```
+
+Keep label colors consistent across repos so the board is visually
+scannable without opening individual issues.


### PR DESCRIPTION
## Summary

- **`/tick-all`** slash command fires every registered BSG agent's `tick` in parallel and prints a one-line sweep summary per agent
- **`claude-skills/scripts/github-bus.sh`** shared bash primitives: `bus_claim` / `bus_lock` / `bus_unlock` / `bus_handoff` / `bus_post_marker` / `bus_read_markers` / `bus_set_manifest` / `bus_get_manifest`
- **`claude-skills/agents/registry.json`** agent roster (8 agents), consumed by `tick-all` and extensible
- **`docs/label-taxonomy.md`** canonical label schema (`needs:*`, `agent:lock:*`, `agent:done`, `agent:blocked`), marker comment format, `agents-state` manifest spec, and label seed script

## Design

GitHub is the only coordination substrate — no central DB, no message broker:
- **Labels** = state machine + routing (`needs:<agent>` moves work, `agent:lock:<agent>` is the mutex)
- **Structured comments** = messages between agents (HTML-marker wrapped YAML)
- **Issue body manifest** = shared JSON state block (`agents-state` fenced block)

All 7 existing tests pass (footer, tick/output frontmatter, catalog-sync).

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py -v` → 7/7 OK
- [ ] Seed labels on a test repo: run the `gh label create` script in `docs/label-taxonomy.md`
- [ ] Open a test issue, add `needs:seo`, run `@seo tick` — verify claim → handoff → `needs:marketing`
- [ ] Run `/tick-all` — verify sweep summary with one line per agent
- [ ] Run `/loop 30m /tick-all` — verify recurring sweep stays silent when all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)