### PR TITLE
fix(updater): authenticate api.github.com via gh token

### DIFF
--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -43,6 +43,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 import sys
 import time
 import urllib.error
@@ -78,6 +80,43 @@ API_HEADERS = {
     "X-GitHub-Api-Version": "2022-11-28",
     "User-Agent": "bsg-skills-updater",
 }
+
+
+def _discover_github_token() -> str | None:
+    """Return a GitHub token from env vars or `gh auth token`, else None.
+
+    The unauthenticated api.github.com limit is 60/hr per IP and is easy
+    to exhaust on a shared-egress machine. Any token bumps it to 5000/hr.
+    We try env vars first (explicit > implicit) then fall back to the
+    already-authenticated `gh` CLI, so nothing is required from the user
+    when gh is installed and logged in — which every BSG skill assumes
+    anyway.
+    """
+    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(var, "").strip()
+        if token:
+            return token
+    if not shutil.which("gh"):
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    token = result.stdout.strip()
+    return token or None
+
+
+_token = _discover_github_token()
+if _token:
+    API_HEADERS["Authorization"] = f"Bearer {_token}"
 
 # Sections of the repo that are mirrored into ~/.claude/. Each tuple is:
 #   (api subpath under claude-skills/, local destination, manifest prefix)


### PR DESCRIPTION
## Summary
- The updater hit api.github.com unauthenticated, so a shared IP or a morning of concurrent sessions trips the 60/hr anon limit, the script silently 403s, and users run with stale skills.
- Resolve a token from `GH_TOKEN` / `GITHUB_TOKEN` / `gh auth token` at startup and attach `Authorization: Bearer …` to `API_HEADERS`. No-op when nothing is available, so the zero-dep bootstrap property is preserved.
- `gh` is already a hard dep of every other BSG skill (`github-bus.sh`, `open-report-pr.sh`, `po`, `github-compliance`), so the fallback is effectively free in practice.

## Test plan
- [x] Reproduced: unauthenticated run hits `HTTP 403` on every `contents/...` call and leaves files stale
- [x] Patched run (same machine, gh authenticated) fetches all sections and installs `/tick-all` plus other new commands
- [x] `python3 -m py_compile` passes
- [ ] Manual: verify on a machine without `gh` installed → script still exits 0, logs the anon 403 as today (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)