### PR TITLE
report(po-manager): 2026-04-22-status tick

### DIFF
--- a/po/reports/2026-04-22-status.md
+++ b/po/reports/2026-04-22-status.md
@@ -1,48 +1,61 @@
 # PO Report — beyond-scale-group/bsg-stack
 
-_Generated: 2026-04-22T21:31:49Z_
+_Generated: 2026-04-22 (tick)_
 
 ## Plan adherence
 
-_No `po/PLAN.md` found in this repo. The agent can draft one — ask_ `@po-manager propose a starter PLAN`.
+_No `po/PLAN.md` found in this repo. The agent can draft one — ask `@po-manager propose a starter PLAN`._
 
 _Until a plan exists, the sections below report raw activity only; there is no intent to compare against._
 
 ## At a glance
 
-| Metric                         | Value |
-| ------------------------------ | ----- |
-| Open issues                    | 2 |
-| Closed issues                  | 12 |
-| Open PRs                       | 0 |
-| Draft PRs                      | 0 |
-| PRs awaiting review            | 0 |
-| PRs with failing checks        | 0 |
-| Oldest open PR (days)          | — |
-| Avg time to first review (h)   | — |
+| Metric                        | Value |
+| ----------------------------- | ----- |
+| Open issues                   | 3     |
+| Open PRs                      | 0     |
+| Draft PRs                     | 0     |
+| PRs awaiting review           | 0     |
+| Oldest open PR (days)         | —     |
+| Avg time to first review (h)  | —     |
+
+## Open issues
+
+| # | Title | Labels | Assignee | Age |
+| --- | --- | --- | --- | --- |
+| #67 | updater: one broken path aborts the whole sync, leaving agents/ unsynced | bug | unassigned | 0d |
+| #63 | feat(agents): @cleaner agent — prune obsolete issues and reorder backlogs | enhancement | unassigned | 0d |
+| #62 | feat(agents): per-domain intent files as agent context (ROADMAP.md, ARCHITECTURE.md, BRAND.md…) | enhancement | unassigned | 0d |
 
 ## Top labels (open issues)
 
 | Label | Count |
 | --- | --- |
 | enhancement | 2 |
+| bug | 1 |
 
 ## Open issues by assignee
 
 | Assignee | Open |
 | --- | --- |
-| unassigned | 2 |
+| unassigned | 3 |
 
 ## Milestone progress
 
 _No open milestones._
 
-## Stale open issues (no comment activity > 14 days)
+## Stale open issues (no activity > 14 days)
 
 _None._
 
+## Recent merges (last 7 days)
 
+- #65 report(po-manager): 2026-04-22-status
+- #64 fix(updater): authenticate api.github.com via gh token or env
+- #61 feat(tick): add /tick-all sweep + GitHub-as-bus coordination layer
 
-## Oldest open PR
+## Risk flags
 
-_No open PRs._
+- **#67 bug (unassigned):** Updater aborts entire sync on one broken path, leaving agents/ unsynced — affects every developer install. No assignee; needs immediate triage.
+- **No milestones defined** — no delivery horizon tracked in GitHub.
+- **All 3 open issues unassigned** — no owner on any open item.


### PR DESCRIPTION
## Summary

- Tick run refreshing status report for 2026-04-22
- Open issue count updated from 2 to 3 (new bug #67 opened)
- Risk flag added for unassigned bug #67 (updater abort on broken path)

## Test plan

- [ ] Verify report file renders correctly in GitHub
- [ ] Confirm issue counts match live GitHub state

🤖 Generated with [Claude Code](https://claude.com/claude-code)