### PR TITLE
report(seo): 2026-04-22 technical SEO audit

### DIFF
--- a/seo/reports/2026-04-22-audit.md
+++ b/seo/reports/2026-04-22-audit.md
@@ -1,0 +1,43 @@
+# SEO Audit — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:17Z
+**Pages detected:** 0
+
+---
+
+## Meta Tag Coverage
+
+**Summary:** 0 pages scanned — 0 missing title, 0 missing description, 0 missing canonical; OG full=0 partial=0 none=0
+
+_No title / description gaps._
+
+---
+
+## Internal Link Health
+
+**Summary:** 0 pages — 0 orphan, 0 broken, avg inbound: 0
+
+
+
+
+
+---
+
+## Content Coverage
+
+_No `seo/KEYWORDS.md` found. Create one to enable keyword coverage analysis._
+
+---
+
+## Technical SEO
+
+| Check | Status |
+|-------|--------|
+| sitemap.xml | **Missing** |
+| robots.txt | **Missing** |
+| Canonical hosts | n/a |
+| Robots blanket disallow | no |
+
+
+

--- a/tech/reports/2026-04-22-health.md
+++ b/tech/reports/2026-04-22-health.md
@@ -1,0 +1,42 @@
+# Tech Health — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:17Z
+**Ecosystems:** 
+
+---
+
+## Dependency Health
+
+**Summary:** 0 tracked — 0 up-to-date, 0 patch-behind, 0 minor-behind, 0 major-behind
+
+_No major-version-behind dependencies._
+
+---
+
+## Code Quality
+
+**Summary:** 3 source files analyzed — 0 oversized (> 500 LOC), 0 function-dense (> 20), 0 circular-import cycles
+
+_No oversized files._
+
+
+
+---
+
+## Tech Debt Inventory
+
+**Summary:** 0 markers — TODO: 0, FIXME: 0, HACK: 0; oldest: n/a
+
+**Debt score:** 0 (no previous)
+
+_No stale TODOs (> 90 days)._
+
+---
+
+## Architecture Decision Records
+
+_No ADR directory found. Consider creating `adr/0001-start.md` to document the first architectural decision of this repo._
+
+
+


### PR DESCRIPTION
Automated SEO audit generated by the `@seo` agent on 2026-04-22.

## Findings

Two silence-breakers fired:

- `sitemap.xml` is missing
- `robots.txt` is missing

No HTML/JSX/Vue/Svelte/Astro pages were detected in this repository (it is a tooling/skills repo, not a web-content repo), so meta, link-graph, and keyword checks returned zero findings.

## Report

`seo/reports/2026-04-22-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)