### PR TITLE
report(marketing): 2026-04-22 audit tick

### DIFF
--- a/brand/reports/2026-04-22-audit.md
+++ b/brand/reports/2026-04-22-audit.md
@@ -1,0 +1,51 @@
+# Brand Audit — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:22Z
+**Narrative bible:** missing
+
+---
+
+## Narrative Bible Summary
+
+_No `brand/NARRATIVE.md` found. See `references/narrative.md` for the schema and bootstrap with the team before the next tick._
+
+---
+
+## Voice Consistency
+
+**Summary:** 9 assets scored; target = 7.0, mean = 6.33, σ = 1.71, drift = 0
+
+| Asset | Tone | Avg sentence | Passive ratio | Jargon density | Flesch |
+|------|------|--------------|---------------|----------------|--------|
+| README.md | 6.09 | 12.97 | 0.02 | 0 | 61.04 |
+| CHANGELOG.md | 3.89 | 13 | 1 | 0 | 43.96 |
+| docs/workflows.md | 3.84 | 81 | 0 | 0 | 38.43 |
+| docs/claude-skills.md | 4.74 | 6.53 | 0 | 0 | 47.41 |
+| docs/po-agent-plan.md | 7.23 | 11.46 | 0.03 | 0 | 72.47 |
+| docs/label-taxonomy.md | 7.19 | 27.16 | 0.05 | 0 | 72.17 |
+| docs/migration-v2.md | 7.99 | 19.27 | 0.16 | 0 | 80.73 |
+| docs/reorganisation-plan.md | 8.89 | 9.66 | 0.01 | 0 | 89.02 |
+| docs/renovate.md | 7.18 | 11.57 | 0 | 0 | 71.85 |
+
+
+
+---
+
+## Key Message Alignment
+
+_No key messages declared in the narrative bible._
+
+
+
+
+
+---
+
+## Talking Points for Releases
+
+_No talking-point files yet under `brand/talking-points/`._
+
+
+_No unnarrated releases._
+

--- a/marketing/reports/2026-04-22-audit.md
+++ b/marketing/reports/2026-04-22-audit.md
@@ -1,0 +1,51 @@
+# Marketing Audit — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:26Z
+**Releases tracked:** 2
+**Milestones tracked:** 0
+
+---
+
+## Content Calendar
+
+_No `marketing/CALENDAR.md` found. Create one using the template in `references/calendar.md` to enable calendar auditing._
+
+
+
+
+
+---
+
+## Feature-Marketing Alignment
+
+**Summary:** 2 shipped, 2 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 2 claimed-but-unshipped
+
+
+### Unmarketed shipped features (silence-breaker)
+
+| Release | Feature | Released at |
+|---------|---------|-------------|
+| v2.1.0 | v2.1.0 — Drop Renovate compat stubs | 2026-04-14T10:57:12Z |
+| v2.0.0 | v2.0.0 — Stack reorganisation | 2026-04-14T10:41:10Z |
+
+
+
+### Claimed but not (yet) shipped
+
+- `BSG STACK — THE INFRASTRUCTURE THAT RUNS THE EMPIRE` (found in README.md)
+- `What's in the Box` (found in README.md)
+
+---
+
+## Campaign Briefs
+
+### Plan (not yet written to disk)
+
+_Run the skill with `--write` to generate these stubs._
+
+- `marketing/briefs/2026-04-14-2.1.0-v2-1-0-drop-renovate-compat-stubs.md` — v2.1.0 v2.1.0 — Drop Renovate compat stubs
+- `marketing/briefs/2026-04-14-2.0.0-v2-0-0-stack-reorganisation.md` — v2.0.0 v2.0.0 — Stack reorganisation
+
+
+

--- a/security/reports/2026-04-22-audit.md
+++ b/security/reports/2026-04-22-audit.md
@@ -1,0 +1,44 @@
+# Security Audit — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:24Z
+**Ecosystems detected:** 
+
+---
+
+## Dependency Vulnerabilities
+
+**Summary:** 0 total — 0 critical, 0 high, 0 moderate, 0 low
+
+_No vulnerabilities reported._
+
+
+
+---
+
+## Secret Scan
+
+**Summary:** 2 finding(s), 0 tracked .env file(s), 185 file(s) scanned
+
+| File | Line | Kind | Match |
+|------|------|------|-------|
+| claude-skills/skills/security-report/references/secrets.md | 58 | AWS Access Key ID | `AKIAIOSFODNN7EXAMPLE` |
+| claude-skills/skills/security-report/references/secrets.md | 80 | AWS Access Key ID | `AKIAIOSFODNN7EXAMPLE` |
+
+
+
+---
+
+## Configuration Hardening
+
+_Not applicable — this repo does not serve HTTP._
+
+---
+
+## OWASP Top-10 Quick Check
+
+_Populated by the `@security` agent based on this snapshot. See
+`references/owasp.md` for the heuristic catalog. Category-by-category
+analysis is LLM-driven; the scripts only provide the raw signals
+above._
+

--- a/seo/reports/2026-04-22-audit.md
+++ b/seo/reports/2026-04-22-audit.md
@@ -1,0 +1,43 @@
+# SEO Audit — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:17Z
+**Pages detected:** 0
+
+---
+
+## Meta Tag Coverage
+
+**Summary:** 0 pages scanned — 0 missing title, 0 missing description, 0 missing canonical; OG full=0 partial=0 none=0
+
+_No title / description gaps._
+
+---
+
+## Internal Link Health
+
+**Summary:** 0 pages — 0 orphan, 0 broken, avg inbound: 0
+
+
+
+
+
+---
+
+## Content Coverage
+
+_No `seo/KEYWORDS.md` found. Create one to enable keyword coverage analysis._
+
+---
+
+## Technical SEO
+
+| Check | Status |
+|-------|--------|
+| sitemap.xml | **Missing** |
+| robots.txt | **Missing** |
+| Canonical hosts | n/a |
+| Robots blanket disallow | no |
+
+
+

--- a/tech/reports/2026-04-22-health.md
+++ b/tech/reports/2026-04-22-health.md
@@ -1,0 +1,42 @@
+# Tech Health — 2026-04-22
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-04-22T21:42:17Z
+**Ecosystems:** 
+
+---
+
+## Dependency Health
+
+**Summary:** 0 tracked — 0 up-to-date, 0 patch-behind, 0 minor-behind, 0 major-behind
+
+_No major-version-behind dependencies._
+
+---
+
+## Code Quality
+
+**Summary:** 3 source files analyzed — 0 oversized (> 500 LOC), 0 function-dense (> 20), 0 circular-import cycles
+
+_No oversized files._
+
+
+
+---
+
+## Tech Debt Inventory
+
+**Summary:** 0 markers — TODO: 0, FIXME: 0, HACK: 0; oldest: n/a
+
+**Debt score:** 0 (no previous)
+
+_No stale TODOs (> 90 days)._
+
+---
+
+## Architecture Decision Records
+
+_No ADR directory found. Consider creating `adr/0001-start.md` to document the first architectural decision of this repo._
+
+
+


### PR DESCRIPTION
## Marketing Audit — 2026-04-22

Auto-generated by `@marketing tick`.

### Silence-breakers fired

- **No content calendar** — `marketing/CALENDAR.md` does not exist.
- **2 unmarketed shipped releases** — v2.0.0 (Stack reorganisation) and v2.1.0 (Drop Renovate compat stubs), both released 2026-04-14, have no corresponding marketing content.
- **2 claimed-but-unshipped items** — README.md contains section headings that the alignment script flagged as marketing claims without matching releases.

### Report file

`marketing/reports/2026-04-22-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)