### PR TITLE
fix(tick-all): remove false-positives + consent-pauses from sweep

### DIFF
--- a/.securityignore
+++ b/.securityignore
@@ -1,0 +1,10 @@
+# .securityignore — paths/patterns the @security agent should skip.
+#
+# Format (see claude-skills/skills/security-report/scripts/secrets.sh):
+#   - one path glob per line to skip that file entirely
+#   - `PATTERN=<name> <glob>` to suppress one pattern on matching paths
+#
+# This repo hosts the security-report skill itself, so the skill's
+# own reference docs contain deliberate pattern *examples* (AWS doc
+# placeholder keys, sample tokens) that must never be flagged.
+claude-skills/skills/security-report/references/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,12 @@ Semantics every `tick` must follow:
   (`po/reports/YYYY-MM-DD-*.md`, `compliance/reports/...`), commit it, and
   return a short summary only if something needs human attention (risk flag,
   drift crossing a threshold, new blocker). No news = no chat noise.
+- **Never pause for consent.** A `tick` on an `output: pr` agent must open
+  the report PR without asking. If a silence-breaker requires a human
+  decision, the report documents it and the PR *is* the consent surface —
+  reviewers act on the finding by merging, commenting, or closing. Pausing
+  mid-sweep with "do you want me to open a PR?" breaks `/tick-all` and is
+  a bug. Consent belongs to explicit, non-`tick` user asks.
 - **No CI cron.** `tick` is still human-initiated per the on-demand principle
   above. Scheduled execution goes through Claude Code's own `/schedule` or
   `/loop` (which the user sets up explicitly on their machine) — not through

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -94,6 +94,15 @@ Thresholds live here (in the agent's product definition), not in the
 skill's scripts. The scripts emit raw counts; the agent decides what
 counts as "needs attention."
 
+**Known false-positive class.** Repos that ship the `security-report`
+skill itself (e.g., `bsg-stack`) contain deliberate pattern examples
+in `claude-skills/skills/security-report/references/**` — AWS doc
+placeholder keys, sample tokens used to illustrate the patterns the
+secrets scanner looks for. A tick that flags these and nothing else
+is *not* a silence-breaker. If the repo does not yet have a
+`.securityignore`, bootstrap one with that reference path on the
+first tick and note it in the report.
+
 ## How to improve this skill
 
 This file is a cached copy of `claude-skills/agents/security.md` in

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -85,13 +85,20 @@ Break silence if **any** of these hold for the audit you just produced:
 | Orphan page (no inbound links)          | `links.sh` → `orphanPages[]`               | Non-empty           |
 | Broken internal link                    | `links.sh` → `brokenLinks[]`               | Non-empty           |
 | Target keyword with no content          | `content.sh` → `uncoveredKeywords[]`       | Non-empty (only if KEYWORDS.md exists) |
-| Missing `sitemap.xml`                   | `technical.sh` → `sitemapFound: false`     | Always              |
-| Missing `robots.txt`                    | `technical.sh` → `robotsFound: false`      | Always              |
+| Missing `sitemap.xml`                   | `technical.sh` → `sitemapFound: false`     | Only if `pages \| length > 0` |
+| Missing `robots.txt`                    | `technical.sh` → `robotsFound: false`      | Only if `pages \| length > 0` |
 | Pages not in sitemap                    | `technical.sh` → `pagesNotInSitemap[]`     | > 3                 |
 
 Thresholds live here (in the agent's product definition), not in
 the skill's scripts. Scripts emit raw counts; the agent decides
 what counts as "needs attention."
+
+**Tooling-repo suppression.** If `collect.sh` emits zero pages
+(repos like `bsg-stack` that ship commands/skills, not web pages),
+the sitemap and robots silence-breakers are noise: a tooling repo
+will never ship either. Skip them when `.pages | length == 0`. The
+same rule applies to any other page-derived signal — no pages, no
+finding.
 
 ## How to improve this skill
 

--- a/claude-skills/agents/storytelling.md
+++ b/claude-skills/agents/storytelling.md
@@ -45,9 +45,12 @@ you do not launch campaigns.
    rather than "wrong." Writing is a human craft.
 6. **Confirm before any externally-visible action.** Commenting on
    assets, opening issues, editing the bible — always confirm first.
+   **Exception:** `open-report-pr.sh` during `tick` is the declared
+   output of an `output: pr` agent and never requires consent.
 7. **Never edit `brand/NARRATIVE.md` without explicit consent.** The
    bible is owned by the founder / marketing lead. Bootstrap, don't
-   rewrite.
+   rewrite. A `tick` may *recommend* bootstrapping in its report; it
+   must not pause the sweep waiting for approval.
 
 ## Routing
 

--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -77,17 +77,23 @@ if [[ ! -f "$FILE" ]]; then
   exit 2
 fi
 
-# Guard: only <file> may have uncommitted changes. Other dirty files
-# would be pulled into the branch by accident.
+# Guard: only <file> may have *tracked* uncommitted changes. Untracked
+# paths are safe — `git checkout -B` carries them along and `git add
+# "$FILE"` only stages the named path, so they cannot be pulled into
+# the report branch by accident. Allowing them matters during a
+# `/tick-all` sweep: sibling agents write their own untracked report
+# dirs (`marketing/`, `qa/`, `security/`…) in parallel, and rejecting
+# those would break the sweep for no real safety gain.
 other_dirty=$(
   git status --porcelain -- . \
+  | grep -v '^??' \
   | awk '{print substr($0, 4)}' \
   | grep -v -F -x "$FILE" \
   || true
 )
 if [[ -n "$other_dirty" ]]; then
   echo "open-report-pr.sh: refusing to proceed — working tree has other" >&2
-  echo "uncommitted changes besides $FILE:" >&2
+  echo "tracked uncommitted changes besides $FILE:" >&2
   printf '  %s\n' $other_dirty >&2
   echo "Commit or stash them first." >&2
   exit 2

--- a/claude-skills/skills/storytelling-report/SKILL.md
+++ b/claude-skills/skills/storytelling-report/SKILL.md
@@ -34,11 +34,15 @@ For a **full audit** run `generate-report.sh`.
 1. **Never invent metrics.** Every score and drift reading comes from
    a script's output.
 2. **Always write the final report to `brand/reports/YYYY-MM-DD-*.md`.**
-3. **Don't edit the narrative bible.** Bootstrap on the first tick
-   (with user consent); never rewrite on subsequent runs.
+3. **Don't edit the narrative bible without explicit consent.** Creating
+   or rewriting `brand/NARRATIVE.md` is out of scope for `tick`. The
+   tick report may *recommend* bootstrapping the bible; it must not
+   create the file or pause the tick waiting for a decision.
 4. **Tone scores are heuristic.** Present them as "signals that
    warrant review," not verdicts.
-5. **Confirm before posting** to GitHub.
+5. **Confirm before posting** to GitHub outside the tick PR flow.
+   `open-report-pr.sh` inside a `tick` is not "posting" — it is the
+   expected output of a `output: pr` agent and never requires consent.
 
 ## Available scripts
 
@@ -91,13 +95,18 @@ Users invoke `tick` (via `@storytelling tick` from `/loop` or
      > brand/reports/$(date +%F)-audit.md
    ```
 
-2. Land the report:
+2. Land the report **without pausing for consent**:
 
    ```bash
    bash ~/.claude/scripts/open-report-pr.sh \
      brand/reports/$(date +%F)-audit.md \
      --agent storytelling
    ```
+
+   If `brand/NARRATIVE.md` is missing, the report itself should note
+   "bootstrap recommended" as a silence-breaker, **then** open the PR.
+   Do not ask the user "do you want me to open a PR?" — the
+   `output: pr` contract is the answer.
 
 3. Evaluate silence-breakers. Agent owns thresholds.
 

--- a/docs/known-false-positives.md
+++ b/docs/known-false-positives.md
@@ -1,0 +1,46 @@
+# Known false-positives in BSG agent ticks
+
+Findings that repeatedly surface during `/tick-all` sweeps but do not
+represent real issues. Track them here so new contributors aren't
+surprised and so we remember to patch the underlying skills rather
+than re-diagnose each tick.
+
+When an entry is fixed upstream (in `claude-skills/`), close it out by
+moving the row to a "Resolved" subsection with the PR that fixed it.
+
+## Active
+
+### security-report flags its own pattern examples
+
+- **Where:** `claude-skills/skills/security-report/references/secrets.md`
+  contains `AKIAIOSFODNN7EXAMPLE` and other AWS / token placeholders used
+  as *illustrations* of the patterns the skill scans for.
+- **Why it fires:** `secrets.sh` has no default exclusion for the skill's
+  own reference docs.
+- **Mitigation:** Repo-level `.securityignore` lists
+  `claude-skills/skills/security-report/references/**`.
+- **Upstream fix owed:** bake the exclusion into the skill itself so
+  every host repo gets it without bootstrapping.
+
+### seo-report flags sitemap / robots on tooling repos
+
+- **Where:** `bsg-stack` (and any other command/skill/agent repo with no
+  web surface).
+- **Why it fires:** `@seo` silence-breakers for missing `sitemap.xml` /
+  `robots.txt` default to "always" rather than "only if pages exist."
+- **Mitigation:** `claude-skills/agents/seo.md` now scopes both
+  silence-breakers to `pages | length > 0`.
+- **Upstream fix owed:** teach `generate-report.sh` to suppress the
+  whole technical section when no pages are scanned so the agent
+  doesn't have to filter after the fact.
+
+### open-report-pr.sh rejected sibling-agent untracked dirs
+
+- **Where:** Any `/tick-all` sweep where multiple report agents ran in
+  parallel and wrote their output directories (`marketing/`, `qa/`,
+  `security/`, …) before the helper ran.
+- **Why it fired:** the "clean working tree" guard treated untracked
+  paths the same as modified tracked files.
+- **Fix:** `claude-skills/scripts/open-report-pr.sh` now only guards
+  against tracked uncommitted changes; untracked files ride along
+  safely.


### PR DESCRIPTION
## Summary

Applied via `/learn` after a `/tick-all` sweep surfaced five repeating friction points. Fixes each at its source and records the residual upstream work in `docs/known-false-positives.md`.

- **storytelling never pauses for consent in `tick`.** The `@storytelling tick` output asked "Do you want me to open a PR?" mid-sweep, breaking the `/tick-all` contract. Skill and agent now make it explicit: `tick` always opens the PR; the missing-bible case becomes a silence-breaker *inside* the report.
- **`open-report-pr.sh` tolerates sibling-agent untracked dirs.** The clean-tree guard now only blocks tracked modifications; untracked paths (`marketing/`, `qa/`, `security/`, …) ride along safely, which is the default state during a parallel `/tick-all`.
- **`@seo` suppresses sitemap / robots silence-breakers on zero-page repos.** Threshold scoped to `.pages | length > 0`. Tooling repos (including `bsg-stack` itself) stop firing both every tick.
- **`@security` known-false-positive class documented + `.securityignore` bootstrapped.** Excludes `claude-skills/skills/security-report/references/**`, which hosts the skill's own pattern examples (AWS doc placeholder keys, sample tokens).
- **`CLAUDE.md` codifies "never pause for consent in `tick`".** Added to the tick convention semantics — the PR itself is the consent surface.

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` → 7/7 OK (agent frontmatter, output mode, catalog sync, footers)
- [x] `bash -n claude-skills/scripts/open-report-pr.sh` → syntax OK
- [ ] Next `/tick-all` sweep: storytelling should open its PR without prompting; pr-comms should no longer error on sibling untracked dirs; seo should stay silent on `bsg-stack`; security should stop flagging its own reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)