### PR TITLE
feat(tick-all): run each agent in its own git worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,13 @@ Semantics every `tick` must follow:
   GitHub Actions, Renovate, or any org-level scheduler.
 - **Repo-scoped.** `tick` runs inside one repo's working directory and touches
   only that repo. Multi-repo sweeps are out of scope for `tick`.
+- **Worktree-isolated in parallel sweeps.** When `/tick-all` fires every
+  agent in parallel, each agent runs in its own git worktree
+  (`isolation: "worktree"`) branched off the current HEAD. A single
+  working tree can't safely host eight agents writing into `po/`,
+  `security/`, `qa/`, `tech/`, `seo/`, `marketing/`, `brand/`, and
+  `comms/` concurrently — worktrees make each tick hermetic and let
+  `open-report-pr.sh` keep its strict clean-tree guard.
 
 Implementation tracked in beyond-scale-group/bsg-stack#33. Until that
 lands, agents document `tick` as a planned alias in their frontmatter but

--- a/claude-skills/commands/tick-all.md
+++ b/claude-skills/commands/tick-all.md
@@ -17,11 +17,31 @@ each agent's own responsibility.
    If `claude-skills/agents/registry.json` is absent, fall back to the
    hardcoded default list at the bottom of this file.
 
-2. **Fire each agent's tick in parallel.**
+2. **Fire each agent's tick in parallel — each in its own git worktree.**
 
-   Spawn one Agent tool call per entry with `prompt: "tick"` and
-   `subagent_type: "<name>"`. Do **not** wait for one to finish before
-   starting the next — send all calls in the same tool-use block.
+   Spawn one Agent tool call per entry with:
+
+   - `prompt: "tick"`
+   - `subagent_type: "<name>"`
+   - `isolation: "worktree"`
+
+   Do **not** wait for one to finish before starting the next — send
+   all calls in the same tool-use block.
+
+   The `isolation: "worktree"` flag is essential: it gives each agent
+   its own git worktree branched off the current HEAD. Without it,
+   eight parallel agents writing `po/`, `security/`, `qa/`,
+   `tech/`, `seo/`, `marketing/`, `brand/`, and `comms/` into the
+   same working tree produce cross-contamination — a sibling's
+   untracked output dir can block another agent's
+   `open-report-pr.sh` call, and race conditions on
+   `git checkout -B` are real. With worktrees, each tick is
+   hermetic: writes stay local, the report branch is created off a
+   clean tree, and the PR merges back into `main` the normal way.
+
+   Clean-up is automatic: the Agent runtime tears down the worktree
+   once the agent returns (unless it made unstaged changes, in
+   which case the runtime reports the worktree path for inspection).
 
 3. **Collect results.**
 
@@ -62,8 +82,11 @@ See `docs/label-taxonomy.md` for the full label schema and
 
 ## Rules
 
-- **Repo-scoped.** Each agent's tick runs inside the current repo's working
-  directory and touches only that repo.
+- **Repo-scoped.** Each agent's tick runs inside the current repo —
+  specifically inside its own worktree of the repo — and touches only
+  that repo.
+- **Worktree-isolated.** Every agent gets `isolation: "worktree"`.
+  Parallel ticks must never share a working tree.
 - **Human-initiated.** For recurring sweeps, use `/loop 30m /tick-all` or
   `/schedule` — never a GitHub Actions cron.
 - **Idempotent.** Re-running is safe: `open-report-pr.sh` reuses existing

--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -77,23 +77,25 @@ if [[ ! -f "$FILE" ]]; then
   exit 2
 fi
 
-# Guard: only <file> may have *tracked* uncommitted changes. Untracked
-# paths are safe — `git checkout -B` carries them along and `git add
-# "$FILE"` only stages the named path, so they cannot be pulled into
-# the report branch by accident. Allowing them matters during a
-# `/tick-all` sweep: sibling agents write their own untracked report
-# dirs (`marketing/`, `qa/`, `security/`…) in parallel, and rejecting
-# those would break the sweep for no real safety gain.
+# Guard: only <file> may be dirty in any way — tracked or untracked.
+# Other entries would be pulled into the branch by accident (either
+# `git checkout -B` carries them along, or a stray later `git add`
+# stages unintended content).
+#
+# Under `/tick-all`, sibling agents used to write their output dirs
+# (`marketing/`, `qa/`, `security/`…) into the same working tree in
+# parallel, tripping this guard. The dispatcher now spawns each
+# agent with `isolation: "worktree"` so siblings can't contaminate
+# this tree — the strict guard is safe again.
 other_dirty=$(
   git status --porcelain -- . \
-  | grep -v '^??' \
   | awk '{print substr($0, 4)}' \
   | grep -v -F -x "$FILE" \
   || true
 )
 if [[ -n "$other_dirty" ]]; then
   echo "open-report-pr.sh: refusing to proceed — working tree has other" >&2
-  echo "tracked uncommitted changes besides $FILE:" >&2
+  echo "uncommitted changes besides $FILE:" >&2
   printf '  %s\n' $other_dirty >&2
   echo "Commit or stash them first." >&2
   exit 2

--- a/docs/known-false-positives.md
+++ b/docs/known-false-positives.md
@@ -34,13 +34,17 @@ moving the row to a "Resolved" subsection with the PR that fixed it.
   whole technical section when no pages are scanned so the agent
   doesn't have to filter after the fact.
 
+## Resolved
+
 ### open-report-pr.sh rejected sibling-agent untracked dirs
 
 - **Where:** Any `/tick-all` sweep where multiple report agents ran in
   parallel and wrote their output directories (`marketing/`, `qa/`,
   `security/`, …) before the helper ran.
-- **Why it fired:** the "clean working tree" guard treated untracked
-  paths the same as modified tracked files.
-- **Fix:** `claude-skills/scripts/open-report-pr.sh` now only guards
-  against tracked uncommitted changes; untracked files ride along
-  safely.
+- **Why it fired:** sibling agents shared a single working tree, so
+  untracked output dirs collided with each other's clean-tree checks.
+- **Resolution:** `/tick-all` now spawns each agent with
+  `isolation: "worktree"`, so siblings run in separate trees and
+  can't contaminate each other at all. The strict clean-tree guard
+  in `open-report-pr.sh` has been restored — tracked *and*
+  untracked stragglers now fail the guard.


### PR DESCRIPTION
## Summary

Follow-up to #76. `/tick-all` now spawns each agent with `isolation: \"worktree\"` so parallel ticks are truly hermetic.

- **Root cause of the previous patch.** Eight agents writing `po/`, `security/`, `qa/`, `tech/`, `seo/`, `marketing/`, `brand/`, `comms/` into the *same* working tree couldn't share one `git checkout -B` flow — a sibling's untracked dir tripped the next agent's `open-report-pr.sh` clean-tree guard. #76 loosened the guard; this PR removes the need for the loosening.
- **Fix.** Every `Agent` tool call from the dispatcher now carries `isolation: \"worktree\"`. Each agent gets a worktree branched off current HEAD, runs its tick, opens its PR, and the runtime tears the worktree down on return.
- **Strict guard restored.** `open-report-pr.sh` goes back to rejecting *any* dirty entry — tracked or untracked — besides the report file. Comment updated to explain the worktree invariant.
- **CLAUDE.md** gains a \"worktree-isolated in parallel sweeps\" clause under the tick convention.
- **docs/known-false-positives.md** creates a `## Resolved` section; the sibling-untracked-dirs entry moves there.

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` → 7/7 OK
- [x] `bash -n claude-skills/scripts/open-report-pr.sh` → syntax OK
- [ ] Next `/tick-all` sweep: observe one worktree per agent, verify `open-report-pr.sh` runs clean on every PR, and confirm sibling writes don't cross-contaminate

🤖 Generated with [Claude Code](https://claude.com/claude-code)