### PR TITLE
report(storytelling): 2026-04-22 brand narrative audit

### DIFF
--- a/brand/reports/2026-04-22-audit.md
+++ b/brand/reports/2026-04-22-audit.md
@@ -1,7 +1,7 @@
-# Brand Audit — 2026-04-22
+# Brand Audit — 2026-04-23
 
-**Repository:** `bsg-stack`
-**Generated:** 2026-04-22T21:42:22Z
+**Repository:** `agent-a6876588`
+**Generated:** 2026-04-22T22:23:38Z
 **Narrative bible:** missing
 
 ---
@@ -14,12 +14,13 @@ _No `brand/NARRATIVE.md` found. See `references/narrative.md` for the schema and
 
 ## Voice Consistency
 
-**Summary:** 9 assets scored; target = 7.0, mean = 6.33, σ = 1.71, drift = 0
+**Summary:** 11 assets scored; target = 7.0, mean = 6.38, σ = 1.67, drift = 0
 
 | Asset | Tone | Avg sentence | Passive ratio | Jargon density | Flesch |
 |------|------|--------------|---------------|----------------|--------|
 | README.md | 6.09 | 12.97 | 0.02 | 0 | 61.04 |
 | CHANGELOG.md | 3.89 | 13 | 1 | 0 | 43.96 |
+| docs/known-false-positives.md | 5.1 | 18 | 0.18 | 0 | 51.97 |
 | docs/workflows.md | 3.84 | 81 | 0 | 0 | 38.43 |
 | docs/claude-skills.md | 4.74 | 6.53 | 0 | 0 | 47.41 |
 | docs/po-agent-plan.md | 7.23 | 11.46 | 0.03 | 0 | 72.47 |
@@ -27,6 +28,7 @@ _No `brand/NARRATIVE.md` found. See `references/narrative.md` for the schema and
 | docs/migration-v2.md | 7.99 | 19.27 | 0.16 | 0 | 80.73 |
 | docs/reorganisation-plan.md | 8.89 | 9.66 | 0.01 | 0 | 89.02 |
 | docs/renovate.md | 7.18 | 11.57 | 0 | 0 | 71.85 |
+| marketing/reports/2026-04-22-audit.md | 8.1 | 6.09 | 0 | 0 | 81.02 |
 
 
 


### PR DESCRIPTION
Automated brand narrative audit — 2026-04-22.

Generated by `@storytelling tick`.

**Silence-breaker:** `brand/NARRATIVE.md` is missing. Bootstrap recommended before the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)