### PR TITLE
docs(claude): codify one-line tick receipt + same-day short-circuit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,18 @@ Semantics every `tick` must follow:
   (`po/reports/YYYY-MM-DD-*.md`, `compliance/reports/...`), commit it, and
   return a short summary only if something needs human attention (risk flag,
   drift crossing a threshold, new blocker). No news = no chat noise.
+- **One-line tick receipt.** The in-chat return value of a `tick` is a
+  single line of ≤~160 chars: `Tick: <state> — <PR url>` when green, or
+  `⚠️ <N> sb: <shortlist> — <PR url>` when silence-breakers fire.
+  Detailed narrative belongs in the committed report file, never duplicated
+  in chat. Multi-line receipts break `/tick-all`'s summary format and leak
+  tokens at scale (8 agents × recurring `/loop` cadence).
+- **Short-circuit on same-day idempotency.** When today's report for the
+  same agent is already merged and inputs haven't changed, the tick must
+  skip its full aggregation and return `Tick: unchanged — see PR #NN`.
+  Re-running the entire audit pipeline to produce a byte-identical PR is a
+  pure token leak on recurring sweeps. `security` and `pr-comms` already
+  implement this check — other agents should follow.
 - **Never pause for consent.** A `tick` on an `output: pr` agent must open
   the report PR without asking. If a silence-breaker requires a human
   decision, the report documents it and the PR *is* the consent surface —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ Semantics every `tick` must follow:
   Detailed narrative belongs in the committed report file, never duplicated
   in chat. Multi-line receipts break `/tick-all`'s summary format and leak
   tokens at scale (8 agents × recurring `/loop` cadence).
+  Explicitly forbidden in chat output:
+  1. Reasoning-narration ("Let me check the silence-breakers…", "Evaluating…")
+     — reasoning happens silently; only the final receipt emits.
+  2. Silence-breaker evaluation matrices (`scopeCreep: Non-empty`, `stale: Empty`)
+     — that detail belongs in the report file.
+  3. Contradictory receipts like `PR #94 opened. Nothing to report` — if a PR
+     was opened, state what it says; if nothing to report, don't open a PR.
 - **Short-circuit on same-day idempotency.** When today's report for the
   same agent is already merged and inputs haven't changed, the tick must
   skip its full aggregation and return `Tick: unchanged — see PR #NN`.


### PR DESCRIPTION
## Summary

Two conventions that were implicit in the `/tick-all` flow but unwritten in `CLAUDE.md`. Both surface as measurable token leaks on recurring `/loop /tick-all` sweeps. Codifying them here so future agent authors can't diverge silently.

- One-line tick receipts — closes the chat-vs-report duplication (#90)
- Short-circuit on same-day idempotency — already honored by `security` and `pr-comms`; generalize (#91)

## Surfaced from

`/learn all and create tickets — with every iteration, surface at least one token-efficiency improvement` iteration at 2026-04-23 00:40, after observing the 00:35 `/tick-all` sweep.

## Test plan

- [ ] Next `/tick-all` sweep shows all 8 agents returning a single-line receipt
- [ ] Re-running `/tick-all` within the same day opens zero new PRs when no inputs changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)