### PR TITLE
report(marketing): 2026-04-22 audit

### DIFF
--- a/marketing/reports/2026-04-22-audit.md
+++ b/marketing/reports/2026-04-22-audit.md
@@ -1,7 +1,7 @@
-# Marketing Audit — 2026-04-23
+# Marketing Audit — 2026-04-22
 
-**Repository:** `agent-a19c36d5`
-**Generated:** 2026-04-22T22:23:35Z
+**Repository:** `beyond-scale-group/bsg-stack`
+**Generated:** 2026-04-22
 **Releases tracked:** 2
 **Milestones tracked:** 0
 
@@ -11,16 +11,11 @@
 
 _No `marketing/CALENDAR.md` found. Create one using the template in `references/calendar.md` to enable calendar auditing._
 
-
-
-
-
 ---
 
 ## Feature-Marketing Alignment
 
-**Summary:** 2 shipped, 2 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 2 claimed-but-unshipped
-
+**Summary:** 2 shipped, 2 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 3 claimed-but-unshipped
 
 ### Unmarketed shipped features (silence-breaker)
 
@@ -29,23 +24,26 @@ _No `marketing/CALENDAR.md` found. Create one using the template in `references/
 | v2.1.0 | v2.1.0 — Drop Renovate compat stubs | 2026-04-14T10:57:12Z |
 | v2.0.0 | v2.0.0 — Stack reorganisation | 2026-04-14T10:41:10Z |
 
-
-
 ### Claimed but not (yet) shipped
 
 - `BSG STACK — THE INFRASTRUCTURE THAT RUNS THE EMPIRE` (found in README.md)
+- `Marketing Audit — 2026-04-23` (found in marketing/reports/2026-04-22-audit.md)
 - `What's in the Box` (found in README.md)
 
 ---
 
 ## Campaign Briefs
 
-### Plan (not yet written to disk)
+### Stubs not yet written
 
 _Run the skill with `--write` to generate these stubs._
 
-- `marketing/briefs/2026-04-14-2.1.0-v2-1-0-drop-renovate-compat-stubs.md` — v2.1.0 v2.1.0 — Drop Renovate compat stubs
-- `marketing/briefs/2026-04-14-2.0.0-v2-0-0-stack-reorganisation.md` — v2.0.0 v2.0.0 — Stack reorganisation
+- `marketing/briefs/2026-04-14-2.1.0-v2-1-0-drop-renovate-compat-stubs.md` — v2.1.0: Drop Renovate compat stubs
+- `marketing/briefs/2026-04-14-2.0.0-v2-0-0-stack-reorganisation.md` — v2.0.0: Stack reorganisation
 
+---
 
+## Limitations
 
+- CMS-hosted landing copy (Webflow, Contentful, or equivalent) is out of scope. This audit only sees source files in this repo (README.md, docs/, landing templates). If production messaging lives in an external CMS, that content was not evaluated.
+- `marketing/CALENDAR.md` is absent. Calendar-based overdue detection is unavailable until the file is bootstrapped.


### PR DESCRIPTION
## Marketing Audit — 2026-04-22

Auto-generated by the `@marketing` agent tick.

### Silence-breakers fired

- **2 unmarketed shipped features**: v2.1.0 (Drop Renovate compat stubs) and v2.0.0 (Stack reorganisation) have no corresponding marketing content in the repo.
- **No `marketing/CALENDAR.md`**: Calendar-based overdue detection is unavailable. Consider bootstrapping from the template in `references/calendar.md`.
- **3 claimed-but-unshipped items**: Phrases in README.md and a prior report file were flagged; the README claims appear to be product description copy rather than release-tied claims — worth reviewing for accuracy.

### Report

`marketing/reports/2026-04-22-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)