### PR TITLE
plan(po): rewrite PLAN.md to match parse-plan.sh schema

### DIFF
--- a/po/PLAN.md
+++ b/po/PLAN.md
@@ -1,4 +1,4 @@
-# po/PLAN.md — beyond-scale-group/bsg-stack
+# Big plan — beyond-scale-group/bsg-stack
 
 ## Mission
 
@@ -7,140 +7,50 @@ and subagents shared across the BSG org. Its job: keep the catalog healthy,
 install reliably on every developer machine, and run agent sweeps that are
 cheap, idempotent, and trustworthy.
 
----
+## Objectives
+
+- Drive a no-change `/tick-all` sweep below 10 k tokens and enforce one-line receipts  [epic:#90] [epic:#91] [epic:#97]
+- Keep `update-bsg-skills.py` resilient so every agent lands on every developer machine  [epic:#67]
+- Make every reporting agent's tick receipt a GitHub PR URL, never a local worktree path  [epic:#84]
+- Grow the catalog with backlog-hygiene, intent-file, and smarter-bootstrap capabilities  [epic:#62] [epic:#63] [epic:#115]
+- Stop `/learn` from regenerating identical proposals on unchanged sessions  [epic:#104]
+- Fix the silent parse-plan.sh failure and ship a plan validator  [epic:#128]
 
 ## Epics
 
-### E1 — tick-hygiene
-> Make every agent tick cheap, one-line, and idempotent.
-
-The recurring `/tick-all` sweep currently costs ~131–160 k tokens per run
-with an 8-agent roster. Three failure modes compound: receipts exceed the
-one-line contract, same-day reports are regenerated in full, and no budget
-gate exists on the dispatcher. This epic drives all three to zero.
-
-**Binds:** [epic:#90] [epic:#91] [epic:#97]
-
-**Done when:** a no-change `/tick-all` sweep costs < 10 k tokens and all 8
-agents return a single-line receipt.
-
----
-
-### E2 — install-reliability
-> The updater must never abort mid-sync; every agent must land on every
-> developer machine.
-
-A dangling symlink under `~/.claude/` currently crashes
-`update-bsg-skills.py` before it reaches the `agents/` section, silently
-leaving 7 of 8 agents uninstalled. Per-section error isolation and
-resilient path handling are the fix.
-
-**Binds:** [epic:#67]
-
-**Done when:** `update-bsg-skills.py` completes all four sections even if
-one path is unresolvable, and all 8 agents are present in
-`~/.claude/agents/` after a fresh install on a machine with path
-conflicts.
-
----
-
-### E3 — agent-pr-contract
-> Every reporting agent must open a PR via `open-report-pr.sh`; tick
-> receipts must contain a GitHub URL, never a local path.
-
-`tech-lead` currently returns a worktree-local path on some ticks; the
-2026-04-23 sweeps showed `security` and `storytelling` also fall back to
-worktree paths in the short-circuit code path. PR #92 codifies the
-one-line receipt and same-day short-circuit conventions in `CLAUDE.md`
-so future agents can't diverge silently.
-
-**Binds:** [epic:#84] [tag:pr-92]
-
-**Done when:** all 8 agents' tick receipts contain a
-`https://github.com/…/pull/NN` URL; no agent writes a local path to the
-receipt line.
-
----
-
-### E4 — catalog-growth
-> Grow the agent catalog with backlog-hygiene and intent-file
-> capabilities, and sharpen the `/po` skill's bootstrap path.
-
-Three greenfield features: the `@cleaner` agent for label/backlog
-hygiene, per-domain intent files (`ROADMAP.md`, `ARCHITECTURE.md`, etc.)
-that give agents repo-specific context without coupling them to a shared
-config format, and a smarter `bootstrap-plan.sh` that seeds epics from
-open issues when milestones are absent. All are enhancements with no
-current blockers from E1–E3.
-
-**Binds:** [epic:#62] [epic:#63] [epic:#115]
-
-**Done when:** `@cleaner` is in `registry.json` and runs last in
-`/tick-all`; `read-intent-file.sh` exists and `@po-manager` reads
-`ROADMAP.md` for stale threshold and milestone scope;
-`bootstrap-plan.sh` proposes clustered epics instead of placeholders
-when no milestones exist.
-
----
-
-### E5 — learn-skill-dedup
-> The `/learn` skill should not regenerate identical proposals when run
-> repeatedly on an unchanged session.
-
-When `/loop 5m /learn all and create tickets` fires, successive
-iterations re-analyze unchanged state and produce 80 %+ overlapping
-proposals. A pre-flight overlap check lets the skill short-circuit with
-a one-line skip receipt instead.
-
-**Binds:** [epic:#104]
-
-**Done when:** a third consecutive `/learn` run on an unchanged session
-emits a one-line skip receipt citing the prior ticket(s).
-
----
+- **E1 tick-hygiene** — make every agent tick cheap, one-line, and idempotent  [epic:#90] [epic:#91] [epic:#97] [label:enhancement]
+- **E2 install-reliability** — the updater must never abort mid-sync; every agent must land on every developer machine  [epic:#67] [label:bug]
+- **E3 agent-pr-contract** — every reporting agent opens a PR via `open-report-pr.sh`; tick receipts contain a GitHub URL, never a local path  [epic:#84] [label:bug]
+- **E4 catalog-growth** — grow the catalog with `@cleaner`, per-domain intent files, and a smarter `bootstrap-plan.sh`  [epic:#62] [epic:#63] [epic:#115] [label:enhancement]
+- **E5 learn-skill-dedup** — the `/learn` skill should short-circuit when no new signal since the prior iteration  [epic:#104] [label:enhancement]
+- **E6 plan-schema-hygiene** — surface format-mismatch errors from `parse-plan.sh` instead of silently emitting `[]`, and add a plan validator  [epic:#128] [label:bug]
 
 ## Non-goals (scope-creep detection has teeth here)
 
-- **CI automation for agent sweeps.** Tick runs are human-initiated
-  only; no GitHub Actions cron, no Renovate scheduler, no
-  `repo_dispatch` triggers.
-- **Cross-repo portfolio view.** `bsg-stack` is a catalog repo; it does
-  not aggregate data from tracked repos. Each tracked repo runs its own
-  agents.
-- **Billing or quota enforcement infrastructure.** Token budgets (#97)
-  are documented policy and dispatcher-level gates, not a metering
-  service.
-- **Agent UI / dashboard.** No web frontend, Slack app, or external
-  notification layer unless a separate proposal is approved.
-- **Changes to tracked repos' source code.** This repo ships skills; it
-  does not implement features in the repos that consume them.
+Items below are deliberately out of scope. New issues matching these patterns
+should be closed with a link to this section.
 
----
+- CI automation for agent sweeps — tick runs are human-initiated only; no GitHub Actions cron, no Renovate scheduler, no `repo_dispatch` triggers
+- Cross-repo portfolio view — `bsg-stack` is a catalog repo; it does not aggregate data from tracked repos
+- Billing or quota enforcement infrastructure — token budgets are documented policy and dispatcher-level gates, not a metering service
+- Agent UI / dashboard — no web frontend, Slack app, or external notification layer
+- Changes to tracked repos' source code — this repo ships skills; it does not implement features in the repos that consume them
 
 ## Cadence and review rhythm
 
 | Rhythm | What happens |
 |---|---|
 | Each `/tick-all` sweep | PO manager runs adherence check; silence-breakers fire if any issue is unbound or any epic is stale |
-| Weekly (Monday) | Quick milestone scan; confirm E1–E3 progress; triage any new issues into an epic or into non-goals |
+| Weekly (Monday) | Quick milestone scan; confirm E1–E6 progress; triage any new issues into an epic or into non-goals |
 | On new issue | PO binds it to an epic within 1 business day or adds it to the non-goals list with a comment explaining why |
 | On epic completion | Epic is marked `status: done` in this file; issues are closed; next candidate epic is proposed |
 
----
-
 ## Decision log
 
-- 2026-04-23: Plan bootstrapped from `@po-manager propose plan` session
-  output after 4 consecutive `/tick-all` ticks reported all 8 open
-  issues as unbound scope creep. Scripted `bootstrap-plan.sh` output
-  was a skeleton (no open milestones) — ticket #115 tracks making it
-  produce issue-clustered epics in future repos. `[tag:decision]`
-
----
+- 2026-04-23: Plan bootstrapped from `@po-manager propose plan` session output; first version used `###` headers + narrative paragraphs which `parse-plan.sh` couldn't parse. Rewrote to the bullet-with-inline-tags schema defined in `references/plan-schema.md`.  [tag:decision]
+- 2026-04-23: Established the two-layer worktree cleanup (per-agent unlock in `open-report-pr.sh` + dispatcher-level prune in `/tick-all`) via PR #120 after observing 30+ stale worktrees accumulated across one `/loop 5m /tick-all` session.  [tag:decision]
 
 ## Tracked risks
 
-- `/tick-all` at a 5-minute `/loop` cadence currently burns ~45 M
-  tokens/day on unchanged state. If E1 is not closed within two weeks,
-  the default recommended cadence in `claude-skills/commands/tick-all.md`
-  should be raised to `30m`. `[tag:risk]`
+- `/tick-all` at a 5-minute `/loop` cadence currently burns ~45 M tokens/day on unchanged state. If E1 is not closed within two weeks, the default recommended cadence in `claude-skills/commands/tick-all.md` should be raised to `30m`.  [tag:risk]
+- `qa` subagent tokens have trended 18 k → 37 k per tick over one session on identical findings; root cause (likely growing report-archive scan) is embedded in E1 but should not be missed.  [tag:risk]


### PR DESCRIPTION
## Summary

The first cut of \`po/PLAN.md\` (shipped in #116) used \`###\` headers and narrative paragraphs, which \`parse-plan.sh\` silently rejected — \`parsed 0 bound plan items\`, \`planFound: false\`, every subsequent \`po-manager\` tick thought the file didn't exist (#128).

Rewrite to the bullet-with-inline-tags grammar defined in \`claude-skills/skills/po/references/plan-schema.md\`.

## Validation

\`\`\`
$ bash ~/.claude/skills/po/scripts/parse-plan.sh | jq 'length as \$n | "parsed \(\$n) bound plan items"'
"parsed 16 bound plan items"
\`\`\`

Every open issue (#62, #63, #67, #84, #90, #91, #97, #104, #115, #128) is now bound to either an Objective or an Epic bullet, with explicit \`[epic:#N]\` tags the parser picks up.

## Test plan

- [ ] Next \`/tick-all\` sweep shows \`po-manager\` returning \`planFound: true\` and \`scopeCreep: []\`
- [ ] The adherence section of po-manager's report lists every open issue under its bound epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)