### PR TITLE
report(storytelling): 2026-04-22-audit

### DIFF
--- a/brand/reports/2026-04-22-audit.md
+++ b/brand/reports/2026-04-22-audit.md
@@ -1,7 +1,7 @@
 # Brand Audit — 2026-04-23
 
-**Repository:** `agent-aa6a60ae`
-**Generated:** 2026-04-22T23:25:20Z
+**Repository:** `agent-af03f014`
+**Generated:** 2026-04-23T00:00:45Z
 **Narrative bible:** missing
 
 ---


### PR DESCRIPTION
Brand narrative audit for 2026-04-22.

**Silence-breaker: `brand/NARRATIVE.md` is missing.**

Bootstrap recommended — no narrative bible found in this repo. Voice scoring ran against defaults; key-message alignment and talking-points checks returned empty because there are no declared key messages or tagged releases.

Generated by the `@storytelling` agent via `generate-report.sh`.