### PR TITLE
docs: add human-reviewed label + document full BSG label set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,46 @@ gh label create "needs-human-review" \
   --description "Awaiting a human decision (triage, merge, or scope)"
 ```
 
+### Label `human-reviewed` — proof a human touched it
+
+Reciprocal to `needs-human-review`. Marks items where a human has made a
+disposition decision: merged, closed, bound to a plan item, or commented
+with a disposition. Because agents operate under the developer's own `gh`
+credentials, GitHub records every agent-driven action under the human's
+account. This label is the one signal that cleanly distinguishes "a human
+actually looked at this" from "Claude ran `gh` as me."
+
+**What counts as review.** A human has reviewed an item when they made a
+disposition call on it:
+
+| Action | Counts as review? |
+|---|---|
+| Read the diff / issue, then merge, close, or bind to a plan item | ✅ Yes |
+| Remove `needs-human-review` as part of acting | ✅ Yes |
+| Comment with a decision (e.g. "defer to Q3", "wontfix", "merge after CI") | ✅ Yes |
+| Glance at a GitHub notification | ❌ No |
+| An agent auto-applies a label | ❌ No |
+| Automation (CI bots, Renovate, Dependabot) | ❌ No |
+
+**Hard rule: only a human may apply `human-reviewed`.** Agents MUST NOT add
+this label under any circumstance. If a non-human actor ever applies it,
+that is a bug in the applying automation. The label marks the *fact* of
+review, not the outcome — merge, close, and defer all count.
+
+How a human applies it, as part of the action:
+
+```bash
+# When merging a PR
+gh pr merge <n> --squash && gh pr edit <n> --add-label human-reviewed
+
+# When closing or deciding on an issue
+gh issue close <n> --reason completed
+gh issue edit <n> --add-label human-reviewed
+```
+
+Bootstrap the label once per repo — see `claude-skills/INSTALL.md#github-labels-used-by-bsg-agents`
+for the full label table and bootstrap commands.
+
 ### Scripts before LLM
 
 Inside a skill, deterministic bash + jq scripts do the aggregation and

--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -89,6 +89,39 @@ The merge is **idempotent** and **narrow**:
 To add or remove a managed key, edit `claude-skills/settings.json` **and**
 update the `BSG_MANAGED_*` lists in the installer in the same PR.
 
+## GitHub labels used by BSG agents
+
+BSG agents expect the following labels to exist on any repo where they file
+issues or open PRs. `claude-skills/scripts/file-issue.sh` auto-creates
+`needs-human-review` on first use; the others are standard GitHub defaults
+that most repos already have.
+
+| Label | Color | Applied by | Meaning |
+|---|---|---|---|
+| `needs-human-review` | `fbca04` (yellow) | Agents **and** humans | Awaiting a human decision (triage, merge, or scope). `file-issue.sh` adds it to every agent-filed issue; humans add it to non-auto-merge PRs at creation. Never removed automatically. |
+| `human-reviewed` | `0e8a16` (green) | **Humans only — agents forbidden** | A human has made a disposition decision on the item: merged, closed, bound to a plan item, or commented with a decision. Proves the audit trail. Only a human GitHub account may apply this label; if a non-human actor ever applies it, that is a bug. |
+| `bug` | `d73a4a` (red) | Agents and humans | Standard GitHub label for defects. |
+| `enhancement` | `a2eeef` (cyan) | Agents and humans | Standard GitHub label for feature requests and improvements. |
+
+Why `human-reviewed` matters: agents operate under the developer's own `gh`
+credentials, so GitHub records every agent-driven merge/close/comment under
+the human's account. The label is the one signal that cleanly distinguishes
+"a human actually looked at this" from "Claude ran `gh` as me." Humans
+apply it as part of the action — `gh pr edit <n> --add-label human-reviewed`
+when they merge — and agents treat its absence as "still unverified."
+
+To bootstrap the two BSG labels on a new repo (one-time, idempotent):
+
+```bash
+gh label create needs-human-review \
+  --color fbca04 \
+  --description "Awaiting a human decision (triage, merge, or scope)"
+
+gh label create human-reviewed \
+  --color 0e8a16 \
+  --description "A human has reviewed and validated this item (agents MUST NOT apply)"
+```
+
 ## How it works under the hood
 
 The whole install flow boils down to: **drop one Python script in


### PR DESCRIPTION
## Summary

\`needs-human-review\` tells us what's awaiting action, but doesn't answer "did a human actually touch it?" — agents operate under the developer's own \`gh\` credentials, so every agent-driven merge/close/comment gets attributed to the human account. The reciprocal label \`human-reviewed\` plugs that audit hole.

## Changes

- **\`CLAUDE.md\`** — new section "Label \`human-reviewed\` — proof a human touched it" with strict disposition-based criteria, a hard "humans only" rule, and worked examples for PR-merge and issue-close.
- **\`claude-skills/INSTALL.md\`** — new section "GitHub labels used by BSG agents" with a full table (\`needs-human-review\`, \`human-reviewed\`, \`bug\`, \`enhancement\`) and idempotent bootstrap commands for new repos.

## Criteria (quick reference)

A human has reviewed when they made a disposition call:
- Merge / close / bind to a plan item → ✅
- Remove \`needs-human-review\` as part of acting → ✅
- Comment with a decision → ✅
- Glance at a notification → ❌
- Automation action → ❌

**Hard rule**: agents MUST NOT apply \`human-reviewed\`, ever.

## Test plan

- [ ] Bootstrap commands create both labels idempotently on a fresh repo
- [ ] Humans apply \`human-reviewed\` as part of \`gh pr merge\` / issue close
- [ ] No agent (including \`file-issue.sh\`) ever applies \`human-reviewed\`
- [ ] Audit query \`label:human-reviewed -author:<known-human>\` returns empty (if anyone else appears, that's a bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)