### PR TITLE
fix(open-report-pr): normalise abs vs relative paths in dirty-file guard (#137)

### DIFF
--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -87,10 +87,24 @@ fi
 # parallel, tripping this guard. The dispatcher now spawns each
 # agent with `isolation: "worktree"` so siblings can't contaminate
 # this tree — the strict guard is safe again.
+#
+# `git status --porcelain` emits repo-relative paths. Callers may pass
+# $FILE as an absolute path, so normalise to the same form before
+# comparing. Without this the grep excludes nothing and the guard
+# spuriously fires on the caller's own report file (see #137).
+repo_root="$(git rev-parse --show-toplevel)"
+file_rel="$(python3 -c '
+import os, sys
+# Resolve symlinks on both sides so /tmp vs /private/tmp (macOS) and
+# similar path aliases do not produce a bogus ../../../ relpath.
+f = os.path.realpath(sys.argv[1])
+r = os.path.realpath(sys.argv[2])
+print(os.path.relpath(f, r))
+' "$FILE" "$repo_root")"
 other_dirty=$(
   git status --porcelain -- . \
   | awk '{print substr($0, 4)}' \
-  | grep -v -F -x "$FILE" \
+  | grep -v -F -x "$file_rel" \
   || true
 )
 if [[ -n "$other_dirty" ]]; then


### PR DESCRIPTION
Closes #137.

## Summary

The dirty-file guard in \`open-report-pr.sh\` compared \`git status --porcelain\` output (always repo-relative) against \`\$FILE\` (caller-passed, often absolute). When \`\$FILE\` was absolute, the fixed-string exact-match excluded nothing and the guard spuriously fired on the caller's own report file.

Normalise both sides via \`os.path.realpath\` before computing the relative path — handles the macOS \`/tmp\` → \`/private/tmp\` symlink case that tripped the first attempt.

## Smoke test

\`\`\`bash
cd /tmp/abs-test && git init -q && git commit -q --allow-empty -m init
echo hello > report.md
bash path/to/open-report-pr.sh "\$(pwd)/report.md" --agent test
# Before: "refusing to proceed — other uncommitted changes besides report.md"
# After: guard passes, proceeds to branch creation
\`\`\`

Discovered by \`@security\` during a /tick-all sweep on 2026-04-23. See #137 for the full diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)