### PR TITLE
fix(tech-lead): open PR for tick report via open-report-pr.sh (#84)

### DIFF
--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -11,12 +11,14 @@ tools: Read, Glob, Grep, Bash, Write
 model: sonnet
 skills: [tech-report]
 color: blue
-output: chat
+output: pr
 tick: >
   Run the full architecture health check (deps + quality + debt + ADR gap
   detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md
-  and commit it. Stay silent in chat unless a silence-breaker fires — if any
-  fires, present a 3-bullet summary in chat linking to the committed report.
+  and land it on main via `claude-skills/scripts/open-report-pr.sh`. In chat,
+  reply with the PR URL plus a one-line verdict. Stay silent on the detailed
+  narrative — if a silence-breaker fires, add at most a 3-bullet summary
+  after the receipt linking to the same PR.
 ---
 
 You are the **Tech Lead** for this repository. Your job: surface
@@ -34,9 +36,11 @@ you do not choose frameworks, you do not perform code reviews.
    what you need, run it instead of scanning the repo yourself. Faster,
    deterministic, free of token cost.
 3. **Files persist, chat is ephemeral.** Write the audit to
-   `tech/reports/YYYY-MM-DD-health.md` and commit it locally. In the
-   chat, return a 3-bullet summary only if a silence-breaker fires;
-   otherwise a one-line receipt.
+   `tech/reports/YYYY-MM-DD-health.md` and land it on main via
+   `claude-skills/scripts/open-report-pr.sh` — never just a local
+   commit, never a worktree path in the receipt. The chat reply is a
+   one-line receipt with the PR URL; add a 3-bullet summary only if
+   a silence-breaker fires.
 4. **Silence is a feature.** When no silence-breaker fires, the chat
    reply is a single line.
 5. **Don't decide, document.** The agent flags *that* a decision is

--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -87,10 +87,24 @@ fi
 # parallel, tripping this guard. The dispatcher now spawns each
 # agent with `isolation: "worktree"` so siblings can't contaminate
 # this tree — the strict guard is safe again.
+#
+# `git status --porcelain` emits repo-relative paths. Callers may pass
+# $FILE as an absolute path, so normalise to the same form before
+# comparing. Without this the grep excludes nothing and the guard
+# spuriously fires on the caller's own report file (see #137).
+repo_root="$(git rev-parse --show-toplevel)"
+file_rel="$(python3 -c '
+import os, sys
+# Resolve symlinks on both sides so /tmp vs /private/tmp (macOS) and
+# similar path aliases do not produce a bogus ../../../ relpath.
+f = os.path.realpath(sys.argv[1])
+r = os.path.realpath(sys.argv[2])
+print(os.path.relpath(f, r))
+' "$FILE" "$repo_root")"
 other_dirty=$(
   git status --porcelain -- . \
   | awk '{print substr($0, 4)}' \
-  | grep -v -F -x "$FILE" \
+  | grep -v -F -x "$file_rel" \
   || true
 )
 if [[ -n "$other_dirty" ]]; then


### PR DESCRIPTION
Closes #84.

## Root cause

\`claude-skills/agents/tech-lead.md\` frontmatter said \`output: chat\` while \`registry.json\` said \`output: pr\`. The tick instructions said "commit it locally" without invoking \`open-report-pr.sh\`. So every tick wrote to the agent's worktree, committed there, and returned the worktree-local path in its receipt.

Meanwhile all 7 sibling agents (security, po-manager, qa, seo, marketing, storytelling, pr-comms) correctly ran \`open-report-pr.sh\` and returned PR URLs.

## Fix

- \`output: chat\` → \`output: pr\` to match registry.json
- Tick frontmatter + operating principle #3 both now mandate \`open-report-pr.sh\` and explicitly forbid worktree paths in the receipt
- Wording aligned with \`security.md\`'s working pattern

## Test plan

- [ ] Next \`/tick-all\` sweep produces a \`tech-lead\` receipt containing a \`https://github.com/…/pull/NN\` URL
- [ ] Receipt does not contain any \`.claude/worktrees/\` path
- [ ] Report lands on \`main\` under \`tech/reports/YYYY-MM-DD-health.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)