### PR TITLE
fix(po): parse-plan.sh typed status — distinguish missing vs unparseable (#128)

### DIFF
--- a/claude-skills/skills/po/scripts/adherence.sh
+++ b/claude-skills/skills/po/scripts/adherence.sh
@@ -45,12 +45,18 @@ if [[ -z "$snapshot" ]]; then
 fi
 
 # --- plan items ---
+# Call parse-plan.sh in --typed mode so we can distinguish three cases
+# (#128): file missing, file present but unparseable, ok. Then feed jq
+# the items array plus the plan status separately.
 if [[ -z "$PLAN_PATH" ]]; then
   plan_args=()
 else
   plan_args=(--plan "$PLAN_PATH")
 fi
-plan_json=$(bash "$HERE/parse-plan.sh" "${plan_args[@]}")
+plan_envelope=$(bash "$HERE/parse-plan.sh" --typed "${plan_args[@]}")
+plan_status=$(jq -r '.status' <<<"$plan_envelope")
+plan_reason=$(jq -r '.reason // ""' <<<"$plan_envelope")
+plan_json=$(jq '.items' <<<"$plan_envelope")
 
 # --- milestone risk flags (reuse existing script) ---
 milestones_json=$(printf '%s' "$snapshot" | bash "$HERE/milestone-progress.sh")
@@ -61,10 +67,14 @@ milestones_json=$(printf '%s' "$snapshot" | bash "$HERE/milestone-progress.sh")
 printf '%s' "$snapshot" | jq \
   --argjson plan "$plan_json" \
   --argjson milestones "$milestones_json" \
-  --arg planPath "${PLAN_PATH:-po/PLAN.md}" '
+  --arg planPath "${PLAN_PATH:-po/PLAN.md}" \
+  --arg planStatus "$plan_status" \
+  --arg planReason "$plan_reason" '
   . as $snap
   | $plan as $planItems
-  | ($planItems | length > 0) as $planFound
+  | ($planStatus == "ok") as $planFound
+  | ($planStatus == "missing") as $planMissing
+  | ($planStatus == "unparseable") as $planFormatDrift
 
   # --- per-item status --------------------------------------------------
   | ($planItems | map(
@@ -162,7 +172,11 @@ printf '%s' "$snapshot" | jq \
 
   | {
       planPath: $planPath,
+      planStatus: $planStatus,
       planFound: $planFound,
+      planMissing: $planMissing,
+      planFormatDrift: $planFormatDrift,
+      planReason: $planReason,
       generatedAt: $snap.generatedAt,
       repo: $snap.repo,
       items: $scored,

--- a/claude-skills/skills/po/scripts/parse-plan.sh
+++ b/claude-skills/skills/po/scripts/parse-plan.sh
@@ -6,14 +6,31 @@
 # at least one binding tag. See `references/plan-schema.md` for the
 # grammar.
 #
-# If PLAN.md is missing, emits an empty array "[]" — NOT an error —
-# so downstream adherence can still run and surface "no plan found".
+# Default output (backward-compatible):
+#
+#   [{"raw": "...", "bindings": {...}, ...}, ...]
+#
+# With `--typed`, output is an object that distinguishes three states:
+#
+#   {"status": "ok",          "items": [ ... ]}
+#   {"status": "missing",     "items": [], "reason": "..."}
+#   {"status": "unparseable", "items": [], "reason": "..."}
+#
+# `missing`     — PLAN.md does not exist
+# `unparseable` — PLAN.md exists but contains zero bullets with binding tags
+#                 (format drift — was masquerading as "planFound: false" per #128)
+# `ok`          — at least one bound plan item parsed
+#
+# If PLAN.md is missing in default mode, emits an empty array "[]" —
+# NOT an error — so legacy downstream adherence can still run.
 set -euo pipefail
 
 PLAN_PATH=""
+TYPED=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --plan) PLAN_PATH="$2"; shift 2 ;;
+    --plan)  PLAN_PATH="$2"; shift 2 ;;
+    --typed) TYPED=1; shift ;;
     *) echo "parse-plan.sh: unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -23,19 +40,28 @@ if [[ -z "$PLAN_PATH" ]]; then
 fi
 
 if [[ ! -f "$PLAN_PATH" ]]; then
-  echo '[]'
+  if [[ $TYPED -eq 1 ]]; then
+    jq -n --arg path "$PLAN_PATH" '{
+      status: "missing",
+      items: [],
+      reason: ($path + " does not exist")
+    }'
+  else
+    echo '[]'
+  fi
   exit 0
 fi
 
 # We do the parse in python3 — the tag grammar involves nested brackets
 # and multiple bindings per bullet, which gets fiddly in pure bash.
-python3 - "$PLAN_PATH" <<'PY'
+python3 - "$PLAN_PATH" "$TYPED" <<'PY'
 import json
 import re
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
+typed = sys.argv[2] == "1"
 text = path.read_text()
 
 # One tag: [kind:value]. Kinds we recognise; everything else is preserved
@@ -106,6 +132,20 @@ for lineno, raw_line in enumerate(text.splitlines(), start=1):
         }
     )
 
-json.dump(items, sys.stdout, indent=2)
+if typed:
+    if not items:
+        out = {
+            "status": "unparseable",
+            "items": [],
+            "reason": (
+                f"{path} exists but contains zero bullets with recognised "
+                "binding tags. See references/plan-schema.md for the grammar."
+            ),
+        }
+    else:
+        out = {"status": "ok", "items": items}
+    json.dump(out, sys.stdout, indent=2)
+else:
+    json.dump(items, sys.stdout, indent=2)
 sys.stdout.write("\n")
 PY


### PR DESCRIPTION
Closes #128.

## Problem

\`parse-plan.sh\` returned \`[]\` for both "file missing" and "file present but format-invalid" — no way to tell which. \`adherence.sh\` reported \`planFound: false\` in both cases. When session 2026-04-23 hand-edited \`po/PLAN.md\` with headers instead of tagged bullets, adherence silently went blind.

## Fix

- **\`parse-plan.sh\`**: new \`--typed\` flag. Emits \`{status, items, reason}\` with three states: \`ok\` / \`missing\` / \`unparseable\`. Default unwrapped-array output stays for backward compat.
- **\`adherence.sh\`**: consumes \`--typed\` internally, surfaces \`planStatus\`, \`planFound\`, \`planMissing\`, \`planFormatDrift\`, \`planReason\` in its output.

## Test plan

- [x] Default \`parse-plan.sh\` still emits the array — 16 items on current PLAN.md
- [x] \`--typed\` on current PLAN.md → status \`ok\`
- [x] \`--typed --plan /nonexistent\` → status \`missing\`
- [x] \`--typed\` on a file with no tagged bullets → status \`unparseable\`
- [x] \`adherence.sh\` on current state emits all four booleans correctly
- [ ] Downstream wiring: po-manager tick report should surface \`planFormatDrift\` as a distinct silence-breaker (follow-up, not blocking this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)