### PR TITLE
feat(agents): bus_claim wiring + scope contract frontmatter (#199, #200)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,42 @@ output: chat      # agents that only return a chat summary (no persisted artifac
 A unit test in `claude-skills/tests/test_skills.py` enforces that every agent
 declares a valid `output` field.
 
+### Per-agent scope contract
+
+Every agent frontmatter carries two lists that declare what it will
+and won't attempt automatically when running in `output: commit` mode:
+
+```yaml
+auto-implements:
+  - "label:bug + label:epic:* + label:safe-to-automate"
+  - "LOC estimate <= 30"
+never-auto-implements:
+  - "files under security/*"
+  - "dependency version bumps (belongs to Renovate)"
+```
+
+For today's `output: pr` agents both lists are empty (`[]`) — the
+contract is structural scaffolding for the #181 pilot. When an agent
+flips to `output: commit`, `test_skills.py` requires both lists to
+carry at least one clause so the scope decision is explicit in the
+diff, not implicit in the agent's narrative.
+
+### Coordination bus (GitHub labels as queues)
+
+`claude-skills/scripts/github-bus.sh` exposes `bus_claim`, `bus_lock`,
+`bus_handoff`, `bus_unlock` primitives. The label schema is:
+
+- `needs:<agent>` — inbox item waiting for that agent
+- `agent:lock:<agent>` — mutex held while a tick works on the issue
+- `agent:done` / `agent:blocked` — terminal pipeline states
+
+Every agent's `tick:` starts with step 0: `source github-bus.sh`
+then `bus_claim <name>`. Today the inbox is empty for every agent
+(no `needs:*` labels have been applied yet), so the call is defensive
+plumbing — it runs without effect. Ticket #199 tracks the rest: each
+agent needs a per-role handler that decides what to do with a claimed
+issue. Until that lands, tick behavior is unchanged — audit only.
+
 ### Label `needs-human-review` for human-gated items
 
 Anything that requires a human decision — triage, merge, or scope — must carry

--- a/claude-skills/agents/marketing.md
+++ b/claude-skills/agents/marketing.md
@@ -14,11 +14,14 @@ skills: [marketing-report]
 color: pink
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim marketing` to fetch any inbox items — today this returns empty because no `needs:marketing` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Audit the content calendar for overdue items, check feature-marketing
   alignment against recent releases and milestones, land the report as
   marketing/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent unless a silence-breaker fires (overdue item, unmarketed
   shipped feature, premature marketing claim, stale campaign brief).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **Marketing Agent** for this repository. Your job:

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -17,12 +17,15 @@ skills: [po, daily-standup]
 color: purple
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim po` to fetch any inbox items — today this returns empty because no `needs:po` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   (1) Run `reconcile-labels.sh` to project po/PLAN.md bindings onto GitHub
   labels — epic:<slug> on bound issues/PRs, scope-creep on unbound ones
   (idempotent; skip silently if the plan is missing or unparseable).
   (2) Run the full status + adherence report and land it as
   po/reports/YYYY-MM-DD-status.md via open-report-pr.sh. Stay silent in chat
   unless a silence-breaker fires (see the "Tick action" section below).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **PO Manager** for this repository. Your job: give the user a

--- a/claude-skills/agents/pr-comms.md
+++ b/claude-skills/agents/pr-comms.md
@@ -14,12 +14,15 @@ skills: [pr-comms-report]
 color: cyan
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim pr-comms` to fetch any inbox items — today this returns empty because no `needs:pr-comms` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Scan for PR-worthy events since last tick, draft press angles for
   unannounced events, land the report as
   comms/reports/YYYY-MM-DD-events.md via open-report-pr.sh, and stay
   silent unless a silence-breaker fires (unannounced major release,
   milestone closed without comms, stale press-kit asset, security
   advisory, community milestone).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **PR / Comms Agent** for this repository. Your job:

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -13,10 +13,13 @@ skills: [qa-report]
 color: green
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim qa` to fetch any inbox items — today this returns empty because no `needs:qa` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Run the full QA audit (coverage + risk + flaky), archive the snapshot to
   qa/history/, land the report as qa/reports/YYYY-MM-DD-audit.md via
   open-report-pr.sh, and stay silent in chat unless a silence-breaker
   fires (coverage drop > 5%, new high-risk file, new flaky test).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **QA Agent** for this repository. Your job: surface quality

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -13,10 +13,13 @@ skills: [security-report]
 color: red
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim security` to fetch any inbox items — today this returns empty because no `needs:security` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Run the full security audit (deps + secrets + config), land it as
   security/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent in chat unless a silence-breaker fires (critical/high CVE, secret
   found, missing critical header, tracked `.env`).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **Security Agent** for this repository. Your job: produce a

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -14,11 +14,14 @@ skills: [seo-report]
 color: orange
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim seo` to fetch any inbox items — today this returns empty because no `needs:seo` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Run the full SEO audit (meta + links + content + sitemap), land it
   as seo/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent in chat unless a silence-breaker fires (missing title/meta,
   orphan page, broken internal link, uncovered keyword, missing
   sitemap/robots).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **SEO Agent** for this repository. Your job: surface

--- a/claude-skills/agents/storytelling.md
+++ b/claude-skills/agents/storytelling.md
@@ -14,12 +14,15 @@ skills: [storytelling-report]
 color: violet
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim storytelling` to fetch any inbox items — today this returns empty because no `needs:storytelling` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Audit public-facing repo assets against brand/NARRATIVE.md (voice
   consistency, key-message coverage, talking points for unnarrated
   releases), land the report as brand/reports/YYYY-MM-DD-audit.md via
   open-report-pr.sh, and stay silent unless a silence-breaker fires
   (voice drift, missing key message, stale positioning, unnarrated
   release, missing narrative bible).
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **Storytelling Agent** for this repository. Your job:

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -13,12 +13,15 @@ skills: [tech-report]
 color: blue
 output: pr
 tick: >
+  (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim tech` to fetch any inbox items — today this returns empty because no `needs:tech` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   Run the full architecture health check (deps + quality + debt + ADR gap
   detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md
   and land it on main via `claude-skills/scripts/open-report-pr.sh`. In chat,
   reply with the PR URL plus a one-line verdict. Stay silent on the detailed
   narrative — if a silence-breaker fires, add at most a 3-bullet summary
   after the receipt linking to the same PR.
+auto-implements: []  # populated when agent is output: commit (#200)
+never-auto-implements: []  # populated when agent is output: commit (#200)
 ---
 
 You are the **Tech Lead** for this repository. Your job: surface

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -253,6 +253,79 @@ class TestSharedSkills(unittest.TestCase):
                     f"Allowed values: {sorted(ALLOWED_OUTPUT_MODES)}.",
                 )
 
+    # -------------------------------------------------- scope contract (#200)
+
+    def test_every_agent_declares_scope_contract_fields(self) -> None:
+        """Every agent frontmatter must carry `auto-implements` and
+        `never-auto-implements` lists (may be empty for output: pr agents).
+
+        For `output: commit` agents the contract is additionally enforced —
+        both lists must be non-empty so the reviewer can see exactly what
+        the agent will (and won't) attempt automatically. See CLAUDE.md →
+        "Per-agent scope contract" and ticket #200.
+        """
+        agents = list_agents()
+        for path in agents:
+            with self.subTest(agent=path.stem):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match)
+                frontmatter = fm_match.group(1)
+                keys = set(TOP_LEVEL_KEY_RE.findall(frontmatter))
+
+                self.assertIn(
+                    "auto-implements",
+                    keys,
+                    f"{path.relative_to(REPO_ROOT)}: missing `auto-implements:` "
+                    f"in frontmatter. Add an empty list `auto-implements: []` "
+                    f"for output: pr agents; see #200 for the schema.",
+                )
+                self.assertIn(
+                    "never-auto-implements",
+                    keys,
+                    f"{path.relative_to(REPO_ROOT)}: missing "
+                    f"`never-auto-implements:` in frontmatter. Add an empty "
+                    f"list for output: pr agents; see #200 for the schema.",
+                )
+
+                # output: commit tightens the rule — both lists must be
+                # non-empty so the contract is explicit.
+                scalars = dict(FRONTMATTER_SCALAR_RE.findall(frontmatter))
+                if scalars.get("output") == "commit":
+                    auto_line = re.search(
+                        r"^auto-implements:\s*(.*)$", frontmatter, re.MULTILINE
+                    )
+                    never_line = re.search(
+                        r"^never-auto-implements:\s*(.*)$", frontmatter, re.MULTILINE
+                    )
+                    # An empty list is either `[]` on the same line or
+                    # nothing below. If a block form follows, look for a
+                    # `- ` bullet below the key line.
+                    auto_empty = (
+                        auto_line is not None
+                        and auto_line.group(1).strip().startswith("[]")
+                    ) or not re.search(
+                        r"^auto-implements:\s*\n\s*-\s+", frontmatter, re.MULTILINE
+                    )
+                    never_empty = (
+                        never_line is not None
+                        and never_line.group(1).strip().startswith("[]")
+                    ) or not re.search(
+                        r"^never-auto-implements:\s*\n\s*-\s+",
+                        frontmatter,
+                        re.MULTILINE,
+                    )
+                    self.assertFalse(
+                        auto_empty,
+                        f"{path.relative_to(REPO_ROOT)}: output: commit agents "
+                        f"must list at least one `auto-implements` clause.",
+                    )
+                    self.assertFalse(
+                        never_empty,
+                        f"{path.relative_to(REPO_ROOT)}: output: commit agents "
+                        f"must list at least one `never-auto-implements` clause.",
+                    )
+
     # ----------------------------------------------------------- catalog sync
 
     def test_install_md_commands_catalog_in_sync(self) -> None:


### PR DESCRIPTION
Related: #199, #200. Prerequisite for #181.

## Summary

Two structural additions across all 8 agent \`.md\` files plus validator + docs. No behavior change in ticks today — this is scaffolding so #181 (output:commit pilot) has the required contract in place.

## Changes

- **Bus wiring (#199 partial)**: every agent's \`tick:\` gains step 0 — \`source github-bus.sh; bus_claim <name>\`. Returns empty today (no \`needs:*\` labels exist), so it's defensive plumbing. Full per-role handlers deferred to #199.
- **Scope contract (#200)**: every agent frontmatter gains \`auto-implements: []\` and \`never-auto-implements: []\`. test_skills.py asserts presence; for \`output: commit\` agents, both lists must be non-empty.
- **CLAUDE.md**: two new short sections documenting both conventions alongside the existing output-mode block.

## Test plan

- [x] \`test_skills.py\` — 8 tests passing (including new \`test_every_agent_declares_scope_contract_fields\`)
- [x] Every agent file now has the two new frontmatter fields
- [x] Every agent's tick: frontmatter has the step 0 bus_claim reference

## Follow-up

- **#199** — wire per-role handlers that actually process the claimed inbox (currently the call runs for side effects only)
- **#181** — flip tech-lead to output: commit with populated scope contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)