### PR TITLE
feat(browser): Chrome MCP fallback + HubSpot/Yousign onboarding

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -76,6 +76,7 @@ Currently-managed keys:
 |---|---|
 | `autoMemoryEnabled` | Set to `false` — disables the Claude Code auto-memory system globally so durable context lives in project `CLAUDE.md` files and committed agent outputs (`po/`, reports, etc.) instead of per-project memory stores. |
 | `mcpServers.context7` | Pre-registers the [Context7](https://context7.com) MCP server so documentation lookups (React, Next.js, library APIs, …) are available in every session with no per-session setup. Honors `CONTEXT7_API_KEY` if set; works on the public-rate tier otherwise. |
+| `mcpServers.claude-in-chrome` | Pre-registers the [Chrome MCP](https://www.npmjs.com/package/@anthropic-ai/claude-code-chrome-mcp) server as a fallback when `agent-browser` gets blocked by anti-bot detection, CAPTCHAs, or device-trust checks (LinkedIn, Pappers, Gmail passkey flows, etc.). Connects to the user's real Chrome instance with existing sessions and extensions. |
 
 The merge is **idempotent** and **narrow**:
 

--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -62,7 +62,7 @@ SCRIPT_NAME = "update-bsg-skills.py"
 BSG_MANAGED_SETTINGS_KEYS = ["autoMemoryEnabled"]
 # Sub-keys under `mcpServers` that the updater owns. Other MCP servers the
 # user has configured are preserved.
-BSG_MANAGED_MCP_SERVERS = ["context7"]
+BSG_MANAGED_MCP_SERVERS = ["context7", "claude-in-chrome"]
 
 CLAUDE_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
 COMMANDS_DIR = CLAUDE_DIR / "commands"

--- a/claude-skills/settings.json
+++ b/claude-skills/settings.json
@@ -8,6 +8,10 @@
       "env": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
+    },
+    "claude-in-chrome": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/claude-code-chrome-mcp"]
     }
   }
 }

--- a/claude-skills/skills/browser/SKILL.md
+++ b/claude-skills/skills/browser/SKILL.md
@@ -32,12 +32,14 @@ at the onboarding orchestrator:
 bash scripts/onboard.sh
 ```
 
-It walks through **2 services** in headed mode, one at a time:
+It walks through **4 services** in headed mode, one at a time:
 
 | Step | Profile | Service |
 |------|---------|---------|
 | 1 | `google` | Google (Gmail, Drive, GCP Console) |
 | 2 | `github` | GitHub |
+| 3 | `hubspot` | HubSpot (CRM, Marketing, Sales) |
+| 4 | `yousign` | Yousign (e-signatures) |
 
 For each service a browser window opens, the user logs in (including 2FA /
 passkey), and the session is saved as a named profile. After onboarding,
@@ -59,6 +61,40 @@ List available services:
 ```bash
 bash scripts/onboard.sh --list
 ```
+
+## Chrome MCP fallback
+
+**Default tool is always `agent-browser`.** Try it first for every task.
+
+Some sites actively block headless browsers and Playwright-based automation
+(anti-bot walls, aggressive CAPTCHAs, device fingerprinting). When
+`agent-browser` gets stuck — page won't load, CAPTCHA loop, login rejected —
+**fall back to Chrome MCP** (`claude-in-chrome`), which connects to the user's
+real Chrome instance with all existing sessions, cookies, and extensions.
+
+Known sites that frequently require Chrome MCP fallback:
+
+| Site | Typical blocker |
+|---|---|
+| LinkedIn | Anti-bot detection, login challenge |
+| Pappers | CAPTCHA / bot wall |
+| Gmail (complex flows) | Passkey re-auth, device trust |
+| HubSpot | SSO redirect loops |
+| Yousign | Session validation |
+
+Decision flow:
+
+```
+1. Try agent-browser (with --profile if authenticated)
+2. Blocked? (CAPTCHA, anti-bot, login rejected, blank page)
+   → Switch to Chrome MCP — the user's real Chrome is already logged in
+3. Chrome MCP unavailable? (no Chrome open, extension not running)
+   → Ask the user to open Chrome and enable the MCP extension
+```
+
+Chrome MCP is **not** a replacement for `agent-browser` — it cannot run
+headlessly, cannot save/replay profiles, and depends on the user's live
+Chrome session. Use it only when `agent-browser` hits a wall.
 
 ## Hard rules
 
@@ -253,6 +289,9 @@ if the app keeps open connections.
 | "Set up browser", "onboard", "log in to everything" | `bash scripts/onboard.sh` |
 | "Log in to Google" | `bash scripts/onboard.sh --step google` |
 | "Log in to GitHub" | `bash scripts/onboard.sh --step github` |
+| "Log in to HubSpot" | `bash scripts/onboard.sh --step hubspot` |
+| "Log in to Yousign" | `bash scripts/onboard.sh --step yousign` |
+| "Blocked by CAPTCHA / anti-bot on LinkedIn, Pappers…" | Fall back to **Chrome MCP** (user's real Chrome) |
 | "Check my logins", "are sessions still valid?" | `bash scripts/onboard.sh --check` |
 | "Log in to X" (non-BSG site) | `bash scripts/with-profile.sh <name> open <url> --headed` |
 | "Open this URL", "go to site" | `agent-browser open <url> [--headed]` |

--- a/claude-skills/skills/browser/scripts/login-yousign.sh
+++ b/claude-skills/skills/browser/scripts/login-yousign.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Yousign account login helper for agent-browser.
+# Saves session under the "yousign" profile for headless reuse.
+#
+# Usage:
+#   bash login-yousign.sh [email@example.com]
+
+PROFILE="yousign"
+EMAIL="${1:-}"
+URL="https://yousign.app/login"
+
+if [ -n "$EMAIL" ]; then
+  URL="https://yousign.app/login?email=${EMAIL}"
+fi
+
+command -v agent-browser >/dev/null 2>&1 || {
+  echo "Error: agent-browser not installed. Run: npm install -g agent-browser" >&2
+  exit 1
+}
+
+echo "Opening Yousign login in headed mode..."
+echo "Complete authentication in the browser window."
+echo ""
+
+agent-browser --profile "$PROFILE" open "$URL" --headed
+
+echo ""
+echo "Waiting for login to complete (watching for yousign.app dashboard)..."
+echo "You have 2 minutes to complete authentication."
+
+agent-browser wait --url "**/yousign.app/**" --timeout 120000 2>/dev/null \
+  || {
+    echo ""
+    echo "Warning: timed out waiting for expected post-login URL."
+    echo "If you completed login, the session may still be saved."
+  }
+
+CURRENT_URL=$(agent-browser get url 2>/dev/null || echo "unknown")
+echo ""
+echo "Current URL: $CURRENT_URL"
+
+agent-browser close 2>/dev/null || true
+
+echo ""
+echo "Yousign session saved under profile '$PROFILE'."
+echo "Future runs with --profile $PROFILE will reuse this session."
+echo ""
+echo "Test it:"
+echo "  agent-browser --profile $PROFILE open https://yousign.app"

--- a/claude-skills/skills/browser/scripts/onboard.sh
+++ b/claude-skills/skills/browser/scripts/onboard.sh
@@ -21,6 +21,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SERVICES=(
   "google|google|https://accounts.google.com|**/myaccount.google.com/**|Google (Gmail, Drive, GCP Console)"
   "github|github|https://github.com/login|**/github.com|GitHub"
+  "hubspot|hubspot|https://app.hubspot.com/login|**/app.hubspot.com/**|HubSpot (CRM, Marketing, Sales)"
+  "yousign|yousign|https://yousign.app/login|**/yousign.app/**|Yousign (e-signatures)"
 )
 
 TIMEOUT=120000  # 2 minutes per login


### PR DESCRIPTION
## Summary

- Register `claude-in-chrome` MCP (`@anthropic-ai/claude-code-chrome-mcp`) in the BSG-managed settings as a fallback when `agent-browser` gets blocked by anti-bot detection (LinkedIn, Pappers, Gmail passkey flows, etc.)
- Add HubSpot and Yousign to the browser onboarding service catalog (`onboard.sh`)
- Create dedicated `login-yousign.sh` helper script
- Document the Chrome MCP fallback decision flow in `SKILL.md`

## Test plan

- [x] `test_skills.py` passes (8/8 tests, 70 subtests)
- [ ] Run `bash onboard.sh --list` to verify 4 services appear
- [ ] Verify `update-bsg-skills.py` merges `claude-in-chrome` into `~/.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)