### PR TITLE
fix(tick): input-fingerprint short-circuit for same-day idempotency (#91)

### DIFF
--- a/claude-skills/agents/marketing.md
+++ b/claude-skills/agents/marketing.md
@@ -15,6 +15,9 @@ color: pink
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim marketing` to fetch any inbox items — today this returns empty because no `needs:marketing` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh marketing marketing)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   Audit the content calendar for overdue items, check feature-marketing
   alignment against recent releases and milestones, land the report as
   marketing/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -18,6 +18,9 @@ color: purple
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim po` to fetch any inbox items — today this returns empty because no `needs:po` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh po-manager po)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (1) Run `reconcile-labels.sh` to project po/PLAN.md bindings onto GitHub
   labels — epic:<slug> on bound issues/PRs, scope-creep on unbound ones
   (idempotent; skip silently if the plan is missing or unparseable).

--- a/claude-skills/agents/pr-comms.md
+++ b/claude-skills/agents/pr-comms.md
@@ -15,6 +15,9 @@ color: cyan
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim pr-comms` to fetch any inbox items — today this returns empty because no `needs:pr-comms` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh pr-comms comms)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   Scan for PR-worthy events since last tick, draft press angles for
   unannounced events, land the report as
   comms/reports/YYYY-MM-DD-events.md via open-report-pr.sh, and stay

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -14,6 +14,9 @@ color: green
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim qa` to fetch any inbox items — today this returns empty because no `needs:qa` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh qa qa)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   Run the full QA audit (coverage + risk + flaky), archive the snapshot to
   qa/history/, land the report as qa/reports/YYYY-MM-DD-audit.md via
   open-report-pr.sh, and stay silent in chat unless a silence-breaker

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -14,6 +14,9 @@ color: red
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim security` to fetch any inbox items — today this returns empty because no `needs:security` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh security security)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   Run the full security audit (deps + secrets + config), land it as
   security/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent in chat unless a silence-breaker fires (critical/high CVE, secret

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -15,6 +15,9 @@ color: orange
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim seo` to fetch any inbox items — today this returns empty because no `needs:seo` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh seo seo)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   Run the full SEO audit (meta + links + content + sitemap), land it
   as seo/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent in chat unless a silence-breaker fires (missing title/meta,

--- a/claude-skills/agents/storytelling.md
+++ b/claude-skills/agents/storytelling.md
@@ -15,6 +15,9 @@ color: violet
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim storytelling` to fetch any inbox items — today this returns empty because no `needs:storytelling` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh storytelling brand)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   Audit public-facing repo assets against brand/NARRATIVE.md (voice
   consistency, key-message coverage, talking points for unnarrated
   releases), land the report as brand/reports/YYYY-MM-DD-audit.md via

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -14,6 +14,9 @@ color: blue
 output: commit
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim tech` to fetch any inbox items — today this returns empty because no `needs:tech` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh tech-lead tech)"`.
+  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (A) Run the full architecture health check (deps + quality + debt + ADR gap
   detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md
   and land it on main via `claude-skills/scripts/open-report-pr.sh`.

--- a/claude-skills/scripts/tick-fingerprint.sh
+++ b/claude-skills/scripts/tick-fingerprint.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tick-fingerprint.sh — deterministic input-fingerprint for tick short-circuit.
+#
+# Every reporting agent sources this at tick start. It computes a SHA-256
+# of the repo's current "input state" and compares it against the
+# fingerprint stored in the last merged report. If they match, the agent
+# can skip the full audit.
+#
+# Usage:
+#   eval "$(bash tick-fingerprint.sh <agent-name> <report-dir> [--extra-hash <string>])"
+#
+# Exports:
+#   TICK_SHORT_CIRCUIT   1 if today's report exists and fingerprint matches; 0 otherwise
+#   TICK_LAST_PR         PR number of the existing report (empty if none)
+#   TICK_FINGERPRINT     Current input fingerprint (SHA-256, first 16 hex chars)
+#   TICK_REPORT_FILE     Path to today's report file on disk (may not exist yet)
+
+set -euo pipefail
+
+AGENT=""
+REPORT_DIR=""
+EXTRA_HASH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --extra-hash) EXTRA_HASH="$2"; shift 2 ;;
+    -*)           echo "tick-fingerprint.sh: unknown flag: $1" >&2; exit 2 ;;
+    *)
+      if [[ -z "$AGENT" ]]; then
+        AGENT="$1"; shift
+      elif [[ -z "$REPORT_DIR" ]]; then
+        REPORT_DIR="$1"; shift
+      else
+        echo "tick-fingerprint.sh: unexpected arg: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$AGENT" || -z "$REPORT_DIR" ]]; then
+  echo "usage: tick-fingerprint.sh <agent-name> <report-dir> [--extra-hash <string>]" >&2
+  exit 2
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+TODAY=$(date +%F)
+
+# ---------------------------------------------------------------- helpers
+
+slug_for_agent() {
+  case "$1" in
+    po-manager)   echo "${TODAY}-status" ;;
+    security)     echo "${TODAY}-audit" ;;
+    qa)           echo "${TODAY}-audit" ;;
+    tech-lead)    echo "${TODAY}-health" ;;
+    seo)          echo "${TODAY}-audit" ;;
+    marketing)    echo "${TODAY}-audit" ;;
+    storytelling) echo "${TODAY}-audit" ;;
+    pr-comms)     echo "${TODAY}-events" ;;
+    *)            echo "${TODAY}-report" ;;
+  esac
+}
+
+SLUG=$(slug_for_agent "$AGENT")
+REPORT_FILE="${REPO_ROOT}/${REPORT_DIR}/reports/${SLUG}.md"
+
+# ------------------------------------------------ compute current fingerprint
+# Hash a stable set of repo-wide signals that any agent cares about.
+# Per-agent extensions go through --extra-hash.
+
+fingerprint_inputs=""
+
+# 1. Open issue numbers + labels (sorted for stability)
+issue_state=$(gh issue list --state all --limit 500 --json number,state,labels \
+  --jq '[.[] | {n: .number, s: .state, l: [.labels[].name] | sort}] | sort_by(.n)' 2>/dev/null || echo "[]")
+fingerprint_inputs+="$issue_state"
+
+# 2. Open PR numbers + state
+pr_state=$(gh pr list --state all --limit 200 --json number,state \
+  --jq '[.[] | {n: .number, s: .state}] | sort_by(.n)' 2>/dev/null || echo "[]")
+fingerprint_inputs+="$pr_state"
+
+# 3. HEAD commit SHA (code changes)
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+fingerprint_inputs+="$head_sha"
+
+# 4. Per-agent extra hash (e.g. lockfile content hash for security)
+if [[ -n "$EXTRA_HASH" ]]; then
+  fingerprint_inputs+="$EXTRA_HASH"
+fi
+
+TICK_FINGERPRINT=$(printf '%s' "$fingerprint_inputs" | shasum -a 256 | cut -c1-16)
+
+# --------------------------------------------- extract fingerprint from last report
+
+TICK_SHORT_CIRCUIT=0
+TICK_LAST_PR=""
+
+if [[ -f "$REPORT_FILE" ]]; then
+  stored_fp=$(sed -n 's/^<!-- fingerprint: \(.*\) -->/\1/p' "$REPORT_FILE" | head -1)
+  if [[ "$stored_fp" == "$TICK_FINGERPRINT" ]]; then
+    # Find the PR that merged this report
+    branch_pattern="reports/${AGENT}/${SLUG}"
+    TICK_LAST_PR=$(gh pr list --state merged --head "$branch_pattern" --limit 1 \
+      --json number --jq '.[0].number' 2>/dev/null || echo "")
+    if [[ -n "$TICK_LAST_PR" ]]; then
+      TICK_SHORT_CIRCUIT=1
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------- emit exports
+# Caller evals the output: eval "$(bash tick-fingerprint.sh ...)"
+cat <<EXPORTS
+TICK_SHORT_CIRCUIT=$TICK_SHORT_CIRCUIT
+TICK_LAST_PR=$TICK_LAST_PR
+TICK_FINGERPRINT=$TICK_FINGERPRINT
+TICK_REPORT_FILE=$REPORT_FILE
+EXPORTS

--- a/claude-skills/skills/marketing-report/scripts/generate-report.sh
+++ b/claude-skills/skills/marketing-report/scripts/generate-report.sh
@@ -18,6 +18,7 @@ DATE=$(date +%F)
 REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # Marketing Audit — $DATE
 
 **Repository:** \`$REPO\`

--- a/claude-skills/skills/po/scripts/generate-report.sh
+++ b/claude-skills/skills/po/scripts/generate-report.sh
@@ -38,6 +38,7 @@ oldest_pr_age=$(printf '%s' "$status_json"    | jq -r '.pullRequests.oldestOpenA
 avg_review_h=$(printf '%s' "$status_json"     | jq -r '.pullRequests.avgTimeToFirstReviewHours // "—"')
 
 cat <<MD
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # PO Report — ${repo}
 
 _Generated: ${generated_at}_

--- a/claude-skills/skills/pr-comms-report/scripts/generate-report.sh
+++ b/claude-skills/skills/pr-comms-report/scripts/generate-report.sh
@@ -19,6 +19,7 @@ REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 VIS=$(jq -r '.visibility' "$SNAPSHOT")
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # PR / Comms Events — $DATE
 
 **Repository:** \`$REPO\` (visibility: $VIS)

--- a/claude-skills/skills/qa-report/scripts/generate-report.sh
+++ b/claude-skills/skills/qa-report/scripts/generate-report.sh
@@ -19,6 +19,7 @@ REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 TEST_SUITE_FOUND=$(jq -r '.testSuiteFound' "$SNAPSHOT")
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # QA Audit — $DATE
 
 **Repository:** \`$REPO\`

--- a/claude-skills/skills/security-report/scripts/generate-report.sh
+++ b/claude-skills/skills/security-report/scripts/generate-report.sh
@@ -21,6 +21,7 @@ DATE=$(date +%F)
 REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # Security Audit — $DATE
 
 **Repository:** \`$REPO\`

--- a/claude-skills/skills/seo-report/scripts/generate-report.sh
+++ b/claude-skills/skills/seo-report/scripts/generate-report.sh
@@ -20,6 +20,7 @@ REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 TOTAL_PAGES=$(jq '.pages | length' "$SNAPSHOT")
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # SEO Audit — $DATE
 
 **Repository:** \`$REPO\`

--- a/claude-skills/skills/storytelling-report/scripts/generate-report.sh
+++ b/claude-skills/skills/storytelling-report/scripts/generate-report.sh
@@ -19,6 +19,7 @@ REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 NARRATIVE_FOUND=$(jq -r '.narrative.found' "$SNAPSHOT")
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # Brand Audit — $DATE
 
 **Repository:** \`$REPO\`

--- a/claude-skills/skills/tech-report/scripts/generate-report.sh
+++ b/claude-skills/skills/tech-report/scripts/generate-report.sh
@@ -19,6 +19,7 @@ DATE=$(date +%F)
 REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
 
 cat <<EOF
+<!-- fingerprint: ${TICK_FINGERPRINT:-none} -->
 # Tech Health — $DATE
 
 **Repository:** \`$REPO\`


### PR DESCRIPTION
## Summary

- Adds `claude-skills/scripts/tick-fingerprint.sh` — shared script that hashes repo input state (issue numbers + labels + states, PR numbers + states, HEAD SHA) into a deterministic 16-char fingerprint
- Each `generate-report.sh` now embeds `<!-- fingerprint: ... -->` as the first line so future ticks can extract and compare
- All 8 agent definitions updated with step (0.5): run fingerprint check before full audit; short-circuit if fingerprint matches the merged report

**Before:** agents short-circuited on "does today's report file exist?" — reviewing tickets, closing issues, or merging PRs didn't trigger a re-audit.

**After:** fingerprint changes when any issue/PR state or label changes → next tick detects the difference → runs a fresh audit.

Closes #91

## Test plan

- [x] `test_skills.py` passes (8/8)
- [x] `tick-fingerprint.sh` returns `TICK_SHORT_CIRCUIT=0` for existing reports (no fingerprint yet)
- [x] `generate-report.sh` embeds fingerprint when `TICK_FINGERPRINT` is set
- [x] `generate-report.sh` falls back to `none` when `TICK_FINGERPRINT` is unset
- [ ] Run `/tick-all` after merge — first run produces reports with fingerprints
- [ ] Review a ticket, re-run `/tick-all` — agents should re-audit (fingerprint changed)
- [ ] Re-run `/tick-all` without changes — agents should short-circuit with matching fingerprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)