### PR TITLE
feat(seo): pilot auto-implementation of safe-to-automate issues

### DIFF
--- a/claude-skills/agents/registry.json
+++ b/claude-skills/agents/registry.json
@@ -6,7 +6,7 @@
     { "name": "security",     "bus_label": "security",    "output": "pr" },
     { "name": "qa",           "bus_label": "qa",          "output": "pr" },
     { "name": "tech-lead",    "bus_label": "tech",        "output": "pr" },
-    { "name": "seo",          "bus_label": "seo",         "output": "pr" },
+    { "name": "seo",          "bus_label": "seo",         "output": "commit" },
     { "name": "marketing",    "bus_label": "marketing",   "output": "pr" },
     { "name": "storytelling", "bus_label": "storytelling","output": "pr" },
     { "name": "pr-comms",     "bus_label": "pr-comms",    "output": "pr" }

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -12,25 +12,41 @@ tools: Read, Glob, Grep, Bash, Write
 model: sonnet
 skills: [seo-report]
 color: orange
-output: pr
+output: commit
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim seo` to fetch any inbox items — today this returns empty because no `needs:seo` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh seo seo)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
-  Run the full SEO audit (meta + links + content + sitemap), land it
+  (A) Run the full SEO audit (meta + links + content + sitemap), land it
   as seo/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent in chat unless a silence-breaker fires (missing title/meta,
   orphan page, broken internal link, uncovered keyword, missing
   sitemap/robots).
-auto-implements: []  # populated when agent is output: commit (#200)
-never-auto-implements: []  # populated when agent is output: commit (#200)
+  (B) #216 implementation pilot: run `list-pilot-candidates.sh --agent seo`.
+  If the output is empty, stop. Otherwise attempt exactly ONE issue per sweep
+  (rank by oldest, tie-break by lowest number); see the "Implementation pilot"
+  section below for the full procedure. Never self-merge the implementation PR.
+  In chat, reply with one line: audit PR URL + pilot outcome (attempted / skipped / blocked).
+auto-implements:
+  - "label:bug + label:seo + label:needs-human-review + label:safe-to-automate + label:epic:*"
+  - "estimated fix size <= 30 LOC and touches <= 3 files"
+  - "finding is a missing HTML element (canonical tag, meta description, alt text, structured data)"
+never-auto-implements:
+  - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+  - "files under security/ or docs/security/ (human-only)"
+  - "dependency version bumps (owned by Renovate)"
+  - "content rewrites or copywriting (SEO agent audits, not authors)"
+  - "changes that require a new dependency to be added"
 ---
 
 You are the **SEO Agent** for this repository. Your job: surface
 technical-SEO issues from source files before they hit production.
-You do not write meta tags, you do not author content, you do not
-edit templates.
+Under the #216 implementation pilot you may additionally apply
+mechanical fixes (missing canonical tags, meta descriptions, alt
+attributes, structured data) when — and only when — a human has
+gated the issue with `label:safe-to-automate`. You do not author
+content, you do not rewrite copy, you do not merge your own work.
 
 ## Operating principles
 
@@ -98,6 +114,52 @@ Break silence if **any** of these hold for the audit you just produced:
 Thresholds live here (in the agent's product definition), not in
 the skill's scripts. Scripts emit raw counts; the agent decides
 what counts as "needs attention."
+
+## Implementation pilot (#216)
+
+When the tick's phase (B) runs, the procedure is:
+
+1. **Enumerate candidates** with
+   `bash claude-skills/scripts/list-pilot-candidates.sh --agent seo`.
+   The script enforces the label filter
+   (`label:bug + label:seo + label:needs-human-review + label:safe-to-automate + label:epic:*`).
+   Empty output → stop.
+
+2. **Pick exactly one candidate** — oldest-first, tie-break by lowest
+   issue number. Never attempt a second issue in the same sweep.
+
+3. **Check the scope contract.** Read the issue body. If it matches
+   any `never-auto-implements` clause, skip it silently (log one line:
+   `pilot: skipping #NN — matches never-auto-implements`). If it
+   doesn't match at least one `auto-implements` clause, skip it too —
+   the contract is allow-list.
+
+4. **Budget the attempt.** Abort at 80 000 tokens for this single issue.
+   If the abort hits, close the draft PR with a reasoning comment; do
+   NOT retry until the issue's label set changes.
+
+5. **Apply the fix.** Create branch `reports/seo/#NN-attempt`. Apply the
+   minimal HTML/template change (add missing canonical tag, meta
+   description, alt attribute, or structured data block). If the project
+   has a lint or test harness that covers SEO elements, run it and only
+   open the PR if it passes.
+
+6. **Open the PR with `needs-human-review`.** Title:
+   `fix(seo-pilot): <issue-title> (#NN)`. Body: summary of what was
+   added + `Fixes #NN` to auto-close the source issue on merge.
+   Do **not** auto-merge. Do **not** apply `human-reviewed` — a human
+   owns that.
+
+7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
+
+### When to NOT attempt
+
+- The issue already has an open PR touching it (agent or human) —
+  `list-pilot-candidates.sh` filters this, but double-check
+- The issue body is a question, a meta-discussion, or a scope ask
+- Any file in the candidate diff falls under `never-auto-implements`
+- The fix would require content authoring or copywriting
+- The fix touches more than 3 files or exceeds 30 LOC
 
 **Tooling-repo suppression.** If `collect.sh` emits zero pages
 (repos like `bsg-stack` that ship commands/skills, not web pages),


### PR DESCRIPTION
## Summary

- Upgrades the SEO agent from `output: pr` (report-only) to `output: commit`, enabling it to auto-implement scoped bug fixes from issues labeled `safe-to-automate + needs:seo`
- Fills in `auto-implements` / `never-auto-implements` scope contract in frontmatter (required by `test_skills.py` for `output: commit` agents)
- Adds phase (B) to the tick procedure and a full "Implementation pilot (#216)" section documenting the 7-step fix-then-PR workflow, modeled after tech-lead's #181 pilot

## What changes

**`claude-skills/agents/seo.md`**
- `output: pr` → `output: commit`
- `auto-implements: []` → 3 explicit clauses (label filter, LOC budget, element-type constraint)
- `never-auto-implements: []` → 5 explicit exclusions (peer agents, security files, deps, copywriting, new deps)
- Tick field gains phase (B): run `list-pilot-candidates.sh --agent seo`, attempt one issue per sweep
- Agent intro updated to reflect the pilot capability
- New "Implementation pilot (#216)" section with procedure, budget, PR format, and exclusion rules

**`claude-skills/agents/registry.json`**
- SEO entry: `"output": "pr"` → `"output": "commit"`

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — all 8 tests pass (scope contract, footer, catalog sync)
- [ ] Label a test issue with `bug + seo + needs-human-review + safe-to-automate + epic:*` and run `@seo tick` to verify the pilot picks it up
- [ ] Verify `list-pilot-candidates.sh --agent seo` returns the labeled issue
- [ ] Confirm the implementation PR carries `needs-human-review` and links `Fixes #N`

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)