### PR TITLE
feat(google-workspace): default to HTML for all Gmail emails

### DIFF
--- a/claude-skills/skills/google-workspace/SKILL.md
+++ b/claude-skills/skills/google-workspace/SKILL.md
@@ -196,7 +196,8 @@ Quick taste:
 
 ```bash
 gws gmail +triage --max 10 --format table
-gws gmail +send --to alice@x.com --subject 'Ping' --body 'hi'
+gws gmail +send --to alice@x.com --subject 'Ping' \
+  --body '<p>Hi Alice!</p>' --html
 gws calendar +agenda --today --format table
 gws calendar +insert --summary 'Review' \
   --start '2026-04-17T10:00:00+02:00' --end '2026-04-17T10:30:00+02:00' \
@@ -245,6 +246,10 @@ discover via `gws <svc> --help` and `gws schema <svc.res.method>`.
 
 ## Agent-friendly conventions
 
+- **`--html` on all emails** — always pass `--html` to `gws gmail +send`
+  (both send and `--draft`). Compose the `--body` as HTML (`<p>`, `<a>`,
+  `<img>`, `<strong>`). HTML renders clickable links, inline images, and
+  proper formatting. Plain text looks broken in modern email clients.
 - **`--dry-run`** validates the request locally without calling Google. Use
   it to verify shape before any mutating call.
 - **`--format json`** (default) for parsing; `--format table` for humans;

--- a/claude-skills/skills/google-workspace/references/helpers.md
+++ b/claude-skills/skills/google-workspace/references/helpers.md
@@ -14,15 +14,27 @@ All helpers accept `--format json|table|yaml|csv` and `--dry-run`.
 ```
 --to <EMAILS>          (required) comma-separated
 --subject <SUBJECT>    (required)
---body <TEXT>          (required) plain text, or HTML with --html
+--body <TEXT>          (required) HTML content (always use --html)
 --cc <EMAILS>          comma-separated
 --bcc <EMAILS>         comma-separated
---html                 treat --body as HTML
+--html                 treat --body as HTML (**always pass this flag**)
+--draft                save as draft instead of sending
+--from <EMAIL>         sender address (for send-as/alias)
 ```
 
+**Always use `--html`** for all emails (send and draft). HTML gives proper
+formatting: clickable links, inline images, paragraphs, bold/italic. Plain
+text renders poorly in modern email clients. Structure the body with `<p>`,
+`<a href>`, `<img>`, `<strong>` tags.
+
 ```bash
-gws gmail +send --to alice@x.com --subject 'Hi' --body 'Hello Alice'
-gws gmail +send --to a@x.com --cc b@x.com --subject 'Report' --body '<b>done</b>' --html
+# Send (always --html)
+gws gmail +send --to alice@x.com --subject 'Hi' \
+  --body '<p>Hello Alice,</p><p>See the <a href="https://example.com">report</a>.</p>' --html
+
+# Draft (always --html)
+gws gmail +send --to alice@x.com --subject 'Review' \
+  --body '<p>Please review the attached.</p><p><strong>Thanks!</strong></p>' --html --draft
 ```
 
 No attachment support — use raw API (`gws gmail users messages send --json`)


### PR DESCRIPTION
## Summary
- Always use `--html` with `gws gmail +send` for all emails (send and draft)
- HTML renders clickable links, inline images, and proper formatting
- Plain text renders poorly in modern email clients

## Changes
- `references/helpers.md`: updated `+send` docs to mandate `--html`, added `--draft` and `--from` flags, updated examples
- `SKILL.md`: added `--html` convention in agent-friendly conventions section, updated quick-taste example

## Test plan
- [ ] Verify skill loads correctly after update
- [ ] Send a test email with `--html` flag and confirm formatting
- [ ] Create a draft with `--html --draft` and verify in Gmail