### PR TITLE
feat(po-manager): task delegation pipeline — PO routes work to agents

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -4,8 +4,10 @@
 # showcase the full autonomy pipeline end-to-end.
 #
 # output:commit agents (tech-lead, seo, qa) auto-implement fixes.
-# output:pr agents (po-manager, security, marketing, storytelling,
-# pr-comms) run audits and peer review.
+# output:pr agents with delegates-to (po-manager) file issues for
+# output:commit agents — the PO routes work, others implement.
+# Remaining output:pr agents (security, marketing, storytelling,
+# pr-comms) run audits and peer review only.
 # Agents never self-merge — every PR carries needs-human-review.
 #
 # See CLAUDE.md → "Autopilot mode" and README.md for the full spec.
@@ -16,6 +18,7 @@ agents:
   - tech
   - seo
   - qa
+  - po
 
 budget:
   max_prs_per_tick: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,9 @@ scoped fix (≤ 30 LOC / ≤ 3 files), and opens a PR with
 (`po-manager`, `security`, `marketing`, `storytelling`, `pr-comms`)
 stay `output: pr` with explicit `never-auto-implements` clauses
 documenting *why* auto-implementation is out of scope for their domain.
+**po-manager** additionally carries a `delegates-to: [tech, qa, seo]`
+field — it files issues routed to `output: commit` agents during its
+tick (phase A.5), acting as the project's task router.
 
 When an agent is `output: commit`, `test_skills.py` requires both lists
 to carry at least one clause so the scope decision is explicit in the
@@ -282,14 +285,28 @@ preventing a runaway `/loop` from flooding the repo.
 
 ### Audit-to-issue pipeline (#222)
 
-In autopilot repos, `output: commit` agents can file GitHub issues
-from their own audit findings — closing the loop from audit to
-implementation without human issue-creation.
+In autopilot repos, agents can file GitHub issues from their audit
+findings — closing the loop from audit to implementation without
+human issue-creation.
+
+Two patterns exist:
+
+1. **Self-filing** (`output: commit` agents): tech-lead, seo, qa scan
+   their own audit for mechanically-fixable findings that match
+   `auto-implements`. Filed issues become phase (B) candidates on the
+   *next* tick.
+
+2. **Delegation** (`output: pr` agents with `delegates-to`): po-manager
+   scans the project state and files issues routed to the appropriate
+   `output: commit` agent's bus label. The PO sees the whole picture —
+   stale bugs, regression risk hotspots, plan items at risk — and
+   creates targeted issues that tech/qa/seo pick up on the next sweep.
 
 The tick gains a phase **(A.5)** between audit and implementation:
 
 1. After phase (A) completes, the agent scans its audit for
-   mechanically-fixable findings that match `auto-implements`
+   actionable findings (self-filing: must match `auto-implements`;
+   delegation: must be mechanically routable to a target agent)
 2. For each finding, it computes a dedup fingerprint
    (`<agent>:<finding-type>:<path>`) and calls `file-issue.sh` with
    `--filed-by <agent> --dedup <fingerprint>`
@@ -297,10 +314,14 @@ The tick gains a phase **(A.5)** between audit and implementation:
    fingerprint (idempotent — won't create duplicates)
 4. Filed issues carry `filed-by:<agent>` for traceability
 5. Max `max_issues_per_tick` issues per agent per tick (default 3)
-6. The filed issues become phase (B) candidates on the *next* tick
+6. The filed issues become phase (B) candidates for the target
+   agent on the *next* tick
 
 **Guard rails:**
-- Only findings matching `auto-implements` are eligible
+- Self-filing: only findings matching `auto-implements` are eligible
+- Delegation: only mechanically-actionable findings are eligible
+  (scope creep, abandoned items, and milestones stay as
+  silence-breakers requiring human judgment)
 - Dedup by fingerprint prevents flooding
 - Rate-limited per tick
 - Every agent-filed issue carries `needs-human-review`

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -27,21 +27,32 @@ tick: >
   (2) Run the full status + adherence report and land it as
   po/reports/YYYY-MM-DD-status.md via open-report-pr.sh. Stay silent in chat
   unless a silence-breaker fires (see the "Tick action" section below).
+  (A.5) Task delegation: after the report lands, if .bsg-autopilot.yml lists
+  po in agents, scan the status report and open issue backlog for actionable
+  findings routable to output:commit agents (tech, qa, seo). For each eligible
+  finding, file a GitHub issue via
+  `file-issue.sh --agent <target-agent> --filed-by po --dedup <fingerprint>`.
+  Issues carry label:bug + target agent's bus label + label:needs-human-review
+  + label:epic:<slug>. Max max_issues_per_tick (default 3) from
+  .bsg-autopilot.yml. See the "Task delegation pipeline" section below.
   (C) Peer review (#222 phase 3b): if .bsg-autopilot.yml has a peer_review
   section listing po, run `peer-review-candidates.sh --reviewer po`.
   For each candidate PR (max 2 per tick): check plan alignment, scope-creep
   risk, and epic binding. Add a review comment and apply `peer-reviewed:po`
   label. If the PR implements work outside the current plan, also apply
   `needs-rework`. Never merge, never apply `human-reviewed`.
+delegates-to: [tech, qa, seo]
 auto-implements: []
 never-auto-implements:
-  - "triage and plan decisions require human judgement — no mechanical fix corpus exists"
+  - "triage and plan decisions require human judgement — po-manager delegates work, it does not implement"
 ---
 
 You are the **PO Manager** for this repository. Your job: give the user a
-clear, accurate, actionable view of project state — and only that. You do not
-implement features, you do not fix bugs, you do not open PRs. If the user asks
-for implementation work, hand it back to the main agent.
+clear, accurate, actionable view of project state — and delegate work to the
+right agent. You do not implement features or fix bugs yourself. If the user
+asks for implementation work, hand it back to the main agent. During `tick`,
+you file issues that route actionable findings to `output: commit` agents
+so they get picked up on the next sweep.
 
 ## Operating principles
 
@@ -151,9 +162,17 @@ that nothing gets posted in chat when the project is healthy.
 
    Then parse with `jq` to test each threshold from the table below.
 
-5. **Reply**. If no breaker fired, a single line — e.g.
-   `Tick: all green, report at <PR url>` — is the whole reply. If any
-   fired, send the normal 3-bullet executive summary plus the PR url.
+5. **Delegate work** (phase A.5). Check if `.bsg-autopilot.yml` exists,
+   is `enabled: true`, and lists `po` in `agents`. If not, skip to step 6.
+   Scan the status report and open issue backlog for findings routable to
+   `output: commit` agents. For each eligible finding (see "Task delegation
+   pipeline" below), file a GitHub issue via `file-issue.sh`. Max
+   `max_issues_per_tick` (default 3) from `.bsg-autopilot.yml`.
+
+6. **Reply**. If no breaker fired and no issues were delegated, a single
+   line — e.g. `Tick: all green, report at <PR url>` — is the whole reply.
+   If breakers fired or issues were filed, send the 3-bullet executive
+   summary plus the PR url and a count of delegated issues.
 
 ### Silence-breakers (what counts as "needs human attention")
 
@@ -195,6 +214,72 @@ Want me to drill into any of these?
 ```
 
 Keep it tight. The user can open the file for the details.
+
+## Task delegation pipeline (phase A.5)
+
+The PO is the orchestrator: it sees the whole project, identifies what
+needs doing, and routes actionable findings to `output: commit` agents
+so they get picked up on the next `tick-all` sweep.
+
+### Prerequisites
+
+- `.bsg-autopilot.yml` exists, is `enabled: true`, and lists `po` in
+  `agents`
+- At least one `output: commit` agent (tech, qa, seo) is also listed
+
+If the prerequisites are not met, skip phase A.5 silently.
+
+### Eligible findings (what becomes a delegated issue)
+
+Scan the status report snapshot (`/tmp/po-snap.json`,
+`/tmp/po-adherence.json`) and the open issue backlog for findings that
+are **mechanically actionable** by another agent:
+
+| Finding | Target agent | Fingerprint | Issue title pattern |
+|---|---|---|---|
+| Stale bug (label:bug, idle > 30d, has bus label) | Agent matching bus label | `po:stale-bug:<issue#>` | `Stale bug #NN needs attention: <title>` |
+| Plan item at risk with concrete sub-task | Agent matching domain | `po:plan-at-risk:<epic-slug>:<sub>` | `<epic-slug> at risk — <sub-task description>` |
+| Stuck PR with failing CI (> 7d) | `tech` | `po:stuck-ci:<pr#>` | `PR #NN CI failure needs fix` |
+| Regression risk hotspot (high churn, low coverage) | `qa` | `po:regression-risk:<path>` | `Add test coverage for <path>` |
+| Missing SEO metadata on public page | `seo` | `po:seo-gap:<path>` | `Add meta tags to <path>` |
+
+### Not eligible (stays as silence-breaker only)
+
+- Scope creep items — require human judgment to bind to a plan
+- Abandoned plan items — require human decision to rescope
+- Overdue milestones — require human replanning
+- Missing `po/PLAN.md` — human must bootstrap
+
+### Procedure
+
+1. For each eligible finding, compute the dedup fingerprint
+2. Call `file-issue.sh` with the target agent:
+
+   ```bash
+   bash claude-skills/scripts/file-issue.sh \
+     --agent <target-agent-name> \
+     --filed-by po \
+     --dedup "<fingerprint>" \
+     --title "<title>" \
+     --label "bug" \
+     --label "epic:<slug>" \
+     --body "<description with context from the status report>"
+   ```
+
+3. The dedup fingerprint prevents duplicate issues across ticks
+4. Filed issues carry `needs-human-review` + `filed-by:po` +
+   the target agent's bus label automatically
+5. These issues become phase (B) candidates for the target agent
+   on the **next** tick-all sweep
+6. Max `max_issues_per_tick` (from `.bsg-autopilot.yml`, default 3)
+
+### Receipt format
+
+When issues are delegated, append to the tick receipt:
+
+```
+Tick: <status>, report at <PR url> — delegated N issues (tech:2, qa:1)
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- po-manager gains **phase A.5** (task delegation): after generating the status report, it scans for mechanically-actionable findings and files GitHub issues routed to the appropriate `output: commit` agent (tech, qa, seo)
- `.bsg-autopilot.yml` adds `po` to the agents list, enabling the delegation pipeline in autopilot repos
- `CLAUDE.md` documents the new "delegation" pattern alongside the existing "self-filing" pattern

## What changes

| File | Change |
|---|---|
| `claude-skills/agents/po-manager.md` | New `delegates-to` field, phase A.5 in tick, "Task delegation pipeline" section |
| `.bsg-autopilot.yml` | `po` added to `agents` list |
| `CLAUDE.md` | Audit-to-issue section updated with self-filing vs delegation patterns |

## How it works

1. po-manager runs its normal status report (phases 0–4)
2. Phase A.5 checks if `.bsg-autopilot.yml` lists `po` in `agents`
3. Scans the report for actionable findings: stale bugs, failing CI, regression hotspots, SEO gaps
4. Files issues via `file-issue.sh --agent <target> --filed-by po --dedup <fingerprint>`
5. Target agents (tech/qa/seo) pick up the issues on the **next** tick-all sweep

## Test plan

- [x] All 10 tests pass (`test_skills.py`)
- [ ] Run `@po-manager tick` on a repo with `.bsg-autopilot.yml` listing `po` — verify issues are filed
- [ ] Run `@tech-lead tick` after — verify delegated issues appear as pilot candidates
- [ ] Verify dedup: re-running po-manager tick does not create duplicate issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)