### PR TITLE
fix(pilot): require human-reviewed instead of needs-human-review

### DIFF
--- a/.github/workflows/ci-claude-skills-test.yaml
+++ b/.github/workflows/ci-claude-skills-test.yaml
@@ -20,6 +20,14 @@ jobs:
       - name: Run unit tests
         run: python3 claude-skills/tests/test_skills.py
 
+  pilot-candidates:
+    name: Pilot candidates label logic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run pilot candidate tests
+        run: bash claude-skills/tests/test_pilot_candidates.sh
+
   integration:
     name: po integration test (edomata)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,8 @@ fixes in a repository, a human must:
 2. **Feed the backlog.** File or label issues with:
    - `label:bug` — only bugs are eligible today
    - The agent's bus label (`tech`, `seo`, or `qa`)
-   - `label:needs-human-review`
+   - `label:human-reviewed` — proves a human triaged this (unless
+     autopilot mode is enabled, see below)
    - `label:safe-to-automate` — **human-only gate** (unless autopilot
      mode is enabled, see below)
    - At least one `epic:*` label binding the issue to a plan item
@@ -264,12 +265,12 @@ budget:
 ```
 
 When this file exists, is `enabled: true`, and lists the calling agent
-in `agents:`, `list-pilot-candidates.sh` drops the `safe-to-automate`
-label filter. Issues only need `label:bug` + bus label +
-`label:needs-human-review` + `label:epic:*` to be eligible.
+in `agents:`, `list-pilot-candidates.sh` drops both the `human-reviewed`
+and `safe-to-automate` label filters. Issues only need `label:bug` +
+bus label + `label:epic:*` to be eligible.
 
-The `safe-to-automate` label still works as a per-issue override on
-repos without the file or for agents not listed in `agents:`.
+The per-issue labels (`human-reviewed`, `safe-to-automate`) still work
+as gates on repos without the file or for agents not listed in `agents:`.
 
 **Daily circuit-breaker.** `pilot-circuit-breaker.sh` counts
 implementation PRs opened today and compares against `max_prs_per_day`

--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -4,14 +4,14 @@
 # Returns open issues that satisfy ALL of:
 #   - label matches the caller's bus label (default: tech)
 #   - label:bug
-#   - label:needs-human-review
-#   - label:safe-to-automate  (skipped when .bsg-autopilot.yml authorizes the agent)
+#   - label:human-reviewed       (skipped when .bsg-autopilot.yml authorizes the agent)
+#   - label:safe-to-automate     (skipped when .bsg-autopilot.yml authorizes the agent)
 #   - at least one epic:* label
 #   - has no open PR already referencing it (agent didn't start work yet)
 #
 # When .bsg-autopilot.yml exists, is enabled, and lists the calling agent,
-# the safe-to-automate label filter is dropped — the repo-level marker
-# replaces the per-issue gate. See #221.
+# both human-reviewed and safe-to-automate label filters are dropped —
+# the repo-level marker replaces per-issue gates. See #221.
 #
 # Usage:
 #   bash claude-skills/scripts/list-pilot-candidates.sh [--agent NAME] [--repo OWNER/NAME]
@@ -35,21 +35,24 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Determine whether to require safe-to-automate or use autopilot mode.
-REQUIRE_SAFE_TO_AUTOMATE=true
+# Determine whether autopilot mode is active for this agent.
+AUTOPILOT=false
 if [[ -f .bsg-autopilot.yml ]]; then
   enabled=$(grep -E '^\s*enabled\s*:' .bsg-autopilot.yml 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
   if [[ "$enabled" == "true" ]]; then
-    # Check if this agent is in the agents list.
     if grep -qE "^\s*-\s+$AGENT\s*$" .bsg-autopilot.yml 2>/dev/null; then
-      REQUIRE_SAFE_TO_AUTOMATE=false
+      AUTOPILOT=true
     fi
   fi
 fi
 
-LABEL_FLAGS=(--label "$AGENT" --label "bug" --label "needs-human-review")
-if [[ "$REQUIRE_SAFE_TO_AUTOMATE" == "true" ]]; then
-  LABEL_FLAGS+=(--label "safe-to-automate")
+LABEL_FLAGS=(--label "$AGENT" --label "bug")
+if [[ "$AUTOPILOT" == "false" ]]; then
+  LABEL_FLAGS+=(--label "human-reviewed" --label "safe-to-automate")
+else
+  # Autopilot: human-reviewed and safe-to-automate are optional.
+  # The repo-level opt-in replaces per-issue gates.
+  :
 fi
 
 # Pull open issues carrying all required labels. GitHub's search API

--- a/claude-skills/tests/test_pilot_candidates.sh
+++ b/claude-skills/tests/test_pilot_candidates.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test_pilot_candidates.sh — unit tests for list-pilot-candidates.sh label logic.
+#
+# Mocks `gh` and `.bsg-autopilot.yml` to verify the correct label flags
+# are passed in each mode. No network calls, no real GitHub API.
+#
+# Run locally:
+#   bash claude-skills/tests/test_pilot_candidates.sh
+#
+# Exit 0 = all pass, exit 1 = failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SUT="$REPO_ROOT/claude-skills/scripts/list-pilot-candidates.sh"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected to find: $needle"
+    echo "  in: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected NOT to find: $needle"
+    echo "  in: $haystack"
+  else
+    PASS=$((PASS + 1))
+  fi
+}
+
+# --- Mock gh: captures the arguments passed to `gh issue list` ---
+# The mock writes all args to a file and emits a canned JSON response.
+MOCK_GH="$TMPDIR_TEST/gh"
+GH_ARGS_FILE="$TMPDIR_TEST/gh_args"
+cat > "$MOCK_GH" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" > "$GH_ARGS_FILE"
+# Return one issue with an epic label so jq post-filter passes it through.
+cat <<'JSON'
+[{"number":67,"title":"test issue","url":"https://example.com/67","labels":[{"name":"bug"},{"name":"tech"},{"name":"epic:E2"}]}]
+JSON
+MOCK
+chmod +x "$MOCK_GH"
+export GH_ARGS_FILE
+
+# Put mock gh first in PATH.
+export PATH="$TMPDIR_TEST:$PATH"
+
+# ---------- Test 1: No autopilot file → requires human-reviewed + safe-to-automate ----------
+echo "--- Test 1: no autopilot, default agent (tech) ---"
+cd "$TMPDIR_TEST"
+rm -f .bsg-autopilot.yml
+bash "$SUT" --agent tech >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+
+assert_contains "T1: has --label tech" "$ARGS" "--label tech"
+assert_contains "T1: has --label bug" "$ARGS" "--label bug"
+assert_contains "T1: has --label human-reviewed" "$ARGS" "--label human-reviewed"
+assert_contains "T1: has --label safe-to-automate" "$ARGS" "--label safe-to-automate"
+assert_not_contains "T1: no needs-human-review" "$ARGS" "needs-human-review"
+
+# ---------- Test 2: Autopilot enabled for tech → drops both gates ----------
+echo "--- Test 2: autopilot enabled for tech ---"
+cat > "$TMPDIR_TEST/.bsg-autopilot.yml" <<'YAML'
+enabled: true
+agents:
+  - tech
+  - qa
+YAML
+bash "$SUT" --agent tech >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+
+assert_contains "T2: has --label tech" "$ARGS" "--label tech"
+assert_contains "T2: has --label bug" "$ARGS" "--label bug"
+assert_not_contains "T2: no human-reviewed" "$ARGS" "human-reviewed"
+assert_not_contains "T2: no safe-to-automate" "$ARGS" "safe-to-automate"
+assert_not_contains "T2: no needs-human-review" "$ARGS" "needs-human-review"
+
+# ---------- Test 3: Autopilot enabled but agent NOT listed → still gated ----------
+echo "--- Test 3: autopilot enabled, agent NOT listed (seo) ---"
+bash "$SUT" --agent seo >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+
+assert_contains "T3: has --label seo" "$ARGS" "--label seo"
+assert_contains "T3: has --label human-reviewed" "$ARGS" "--label human-reviewed"
+assert_contains "T3: has --label safe-to-automate" "$ARGS" "--label safe-to-automate"
+
+# ---------- Test 4: Autopilot file exists but enabled: false → still gated ----------
+echo "--- Test 4: autopilot disabled ---"
+cat > "$TMPDIR_TEST/.bsg-autopilot.yml" <<'YAML'
+enabled: false
+agents:
+  - tech
+YAML
+bash "$SUT" --agent tech >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+
+assert_contains "T4: has --label human-reviewed" "$ARGS" "--label human-reviewed"
+assert_contains "T4: has --label safe-to-automate" "$ARGS" "--label safe-to-automate"
+
+# ---------- Test 5: jq post-filter requires epic:* label ----------
+echo "--- Test 5: epic filter ---"
+# Mock gh returns an issue WITHOUT an epic label.
+cat > "$MOCK_GH" <<'MOCK2'
+#!/usr/bin/env bash
+echo "$@" > "$GH_ARGS_FILE"
+cat <<'JSON'
+[{"number":99,"title":"no epic","url":"https://example.com/99","labels":[{"name":"bug"},{"name":"tech"}]}]
+JSON
+MOCK2
+chmod +x "$MOCK_GH"
+
+OUTPUT="$(bash "$SUT" --agent tech 2>/dev/null)"
+if [[ -z "$OUTPUT" ]]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: T5: issue without epic should be filtered out, got: $OUTPUT"
+fi
+
+# ---------- Test 6: Regression — needs-human-review must NEVER appear ----------
+echo "--- Test 6: regression guard — needs-human-review never in label flags ---"
+# Restore normal mock.
+cat > "$MOCK_GH" <<'MOCK3'
+#!/usr/bin/env bash
+echo "$@" > "$GH_ARGS_FILE"
+echo '[]'
+MOCK3
+chmod +x "$MOCK_GH"
+
+rm -f "$TMPDIR_TEST/.bsg-autopilot.yml"
+bash "$SUT" --agent tech >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+assert_not_contains "T6a: no needs-human-review (no autopilot)" "$ARGS" "needs-human-review"
+
+cat > "$TMPDIR_TEST/.bsg-autopilot.yml" <<'YAML'
+enabled: true
+agents:
+  - tech
+YAML
+bash "$SUT" --agent tech >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+assert_not_contains "T6b: no needs-human-review (autopilot)" "$ARGS" "needs-human-review"
+
+# ---------- Summary ----------
+echo ""
+echo "=== $((PASS + FAIL)) tests: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- `list-pilot-candidates.sh` required `needs-human-review` ("awaiting triage") to pick up issues — semantically backwards. Issues that humans *had* reviewed carried `human-reviewed` and were invisible to agents, which is why no implementation work happened during tick sweeps.
- Now requires `human-reviewed` (proves a human triaged it) + `safe-to-automate` in non-autopilot mode.
- In autopilot mode, both per-issue gates (`human-reviewed`, `safe-to-automate`) are dropped — only `bug` + bus label + `epic:*` needed.
- Updated CLAUDE.md docs to match.

## Test plan

- [x] Ran `list-pilot-candidates.sh --agent tech` — #67 now visible as candidate
- [ ] Run `/tick-all` after merge to verify agents pick up eligible issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)