### PR TITLE
feat(md-to-office): --init auto-extracts brand from repo (#235)

### DIFF
--- a/claude-skills/skills/md-to-office/SKILL.md
+++ b/claude-skills/skills/md-to-office/SKILL.md
@@ -77,7 +77,40 @@ prefer it over calling the renderers directly.
 | `md-to-office.sh` | Orchestrator. `md-to-office.sh <file> [--target docx] [--template <path>] [--force]`. |
 | `resolve-template.sh` | Emits the resolved template path (or empty) for a given target. |
 | `render-docx.sh` | pandoc wrapper. `render-docx.sh <input.md> <output.docx> [--template <path>]`. |
+| `init-brand.sh` | Brand bootstrap. `init-brand.sh [--force] [--tokens-only] [--dry-run]`. |
+| `scan-brand.py` | Repo signal scanner → `brand/tokens.json` + optional audit. |
+| `generate-templates.py` | Reads `tokens.json`, produces `reference.docx`, `template.pptx`, `template.xlsx`. |
 | `install-local.sh` | Installs `pandoc` via brew. `--dry-run` to print-only. |
+
+## Brand initialization (`--init`)
+
+`--init` mines the repo for brand signals and synthesizes them into
+branded Office templates. Signals detected:
+
+| Signal | Where it looks |
+|---|---|
+| **Colors** | CSS custom properties, `tailwind.config.*`, design-token JSON |
+| **Typography** | CSS `--font-*` variables, `@font-face`, Google Fonts imports |
+| **Logo** | `public/`, `brand/`, `images/`, `assets/` — files with "logo" in name |
+| **Voice & identity** | `brand/NARRATIVE.md`, `DESIGN.md`, `*identity*.md` |
+| **Existing templates** | `.docx`, `.pptx`, `.xlsx` already in the repo |
+
+```bash
+md-to-office.sh --init                    # scan repo, generate templates
+md-to-office.sh --init --dry-run          # show what would be extracted
+md-to-office.sh --init --force            # overwrite existing templates
+md-to-office.sh --init --tokens-only      # scan only, skip template gen
+```
+
+Output:
+
+```
+brand/tokens.json                   ← extracted tokens (name, colors, fonts, logos, …)
+brand/templates/brand-audit.md      ← what was found and what was chosen
+brand/templates/reference.docx      ← pandoc reference-doc with brand styles
+brand/templates/template.pptx       ← PowerPoint with brand theme
+brand/templates/template.xlsx       ← Excel with brand-coloured header
+```
 
 ## Usage
 
@@ -112,8 +145,6 @@ Run `scripts/install-local.sh` to install on macOS.
 
 - **DOCX only.** PPTX and XLSX renderers land in later PRs per PRD-008
   §12.
-- **No `--init`.** The bootstrap command that scaffolds placeholder
-  templates in `brand/templates/` is a follow-up PR.
 - **No multi-file input.** One `.md` at a time; batch conversion is
   deferred.
 

--- a/claude-skills/skills/md-to-office/scripts/init-brand.sh
+++ b/claude-skills/skills/md-to-office/scripts/init-brand.sh
@@ -2,18 +2,22 @@
 # Brand initialization orchestrator.
 #
 # Usage:
-#   init-brand.sh [--force] [--tokens-only]
+#   init-brand.sh [--force] [--tokens-only] [--dry-run]
 #
 # --force         Overwrite existing brand/tokens.json and templates.
 # --tokens-only   Only run the repo scan; skip template generation.
 #                 Useful to review what was detected before committing.
+# --dry-run       Scan and show what would be extracted without writing
+#                 templates. Writes tokens.json and brand-audit.md only.
 #
 # Flow:
 #   1. Scan the repo for brand signals  → brand/tokens.json
-#   2. Generate Office templates        → brand/templates/{reference.docx,template.pptx,template.xlsx}
+#   2. Generate brand audit             → brand/templates/brand-audit.md
+#   3. Generate Office templates        → brand/templates/{reference.docx,template.pptx,template.xlsx}
 #
 # Templates are discovered from:
 #   CSS custom properties, tailwind.config.*, design-token JSON files,
+#   @font-face / Google Fonts imports, logo files, identity documents,
 #   package.json / pyproject.toml / stack.yaml / README.md, git remote.
 
 set -euo pipefail
@@ -22,11 +26,13 @@ here="$(cd "$(dirname "$0")" && pwd)"
 
 force=0
 tokens_only=0
+dry_run=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --force)       force=1;       shift ;;
     --tokens-only) tokens_only=1; shift ;;
+    --dry-run)     dry_run=1;     shift ;;
     -*) echo "Unknown flag: $1" >&2; exit 2 ;;
     *)  echo "Unexpected argument: $1" >&2; exit 2 ;;
   esac
@@ -35,9 +41,10 @@ done
 brand_dir="./brand"
 tokens_path="${brand_dir}/tokens.json"
 templates_dir="${brand_dir}/templates"
+audit_path="${templates_dir}/brand-audit.md"
 
-# Guard: require --force if already initialized.
-if [[ -d "$templates_dir" ]] && [[ -n "$(ls -A "$templates_dir" 2>/dev/null)" ]] && [[ $force -eq 0 ]]; then
+# Guard: require --force if already initialized (skip for --dry-run).
+if [[ $dry_run -eq 0 ]] && [[ -d "$templates_dir" ]] && [[ -n "$(ls -A "$templates_dir" 2>/dev/null)" ]] && [[ $force -eq 0 ]]; then
   echo "Brand templates already exist at ${templates_dir}/."
   echo "Use --force to overwrite."
   exit 0
@@ -51,9 +58,20 @@ fi
 mkdir -p "$brand_dir"
 
 echo "Scanning repo for brand signals…"
-python3 "$here/scan-brand.py" > "$tokens_path"
+
+scan_args=(--audit "$audit_path")
+python3 "$here/scan-brand.py" "${scan_args[@]}" > "$tokens_path"
 echo ""
 echo "Tokens written to ${tokens_path}"
+
+if [[ $dry_run -eq 1 ]]; then
+  echo ""
+  echo "Dry run — no templates generated."
+  echo "Review:"
+  echo "  ${tokens_path}  (extracted tokens)"
+  echo "  ${audit_path}   (full audit of what was found)"
+  exit 0
+fi
 
 if [[ $tokens_only -eq 1 ]]; then
   echo ""
@@ -70,7 +88,8 @@ echo "Brand standard initialized."
 echo ""
 echo "Next steps:"
 echo "  1. Review brand/tokens.json (edit primary colour, font, etc.)"
-echo "  2. Open brand/templates/ files and apply your team's final brand"
+echo "  2. Review brand/templates/brand-audit.md for discovery details"
+echo "  3. Open brand/templates/ files and apply your team's final brand"
 echo "     (logo, exact palette, slide backgrounds, footer text)"
-echo "  3. Re-run with --force after editing tokens.json to regenerate"
-echo "  4. git add brand/ && git commit -m 'brand: initialize office templates'"
+echo "  4. Re-run with --force after editing tokens.json to regenerate"
+echo "  5. git add brand/ && git commit -m 'brand: initialize office templates'"

--- a/claude-skills/skills/md-to-office/scripts/scan-brand.py
+++ b/claude-skills/skills/md-to-office/scripts/scan-brand.py
@@ -10,18 +10,39 @@ Resolution priority per signal type:
   primary: brand/tokens.json (existing partial) >
            CSS custom properties > tailwind.config.* >
            design-token JSON files > default #1a1a2e
-  font:    CSS font-family > default "Helvetica Neue"
+  font:    CSS font-family > @font-face > Google Fonts import >
+           default "Helvetica Neue"
+
+Optional --audit <path> writes a markdown summary of all signals found.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import subprocess
 import sys
+from datetime import date
 from pathlib import Path
 
 ROOT = Path.cwd()
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+_audit_log: list[tuple[str, str, str]] = []
+_defaults_applied: list[str] = []
+
+
+def _audit(signal: str, source: str, value: str) -> None:
+    _audit_log.append((signal, source, value))
+
+
+def _default_applied(signal: str) -> None:
+    _defaults_applied.append(signal)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -43,7 +64,10 @@ def _normalize_hex(raw: str) -> str:
     return f"#{h.lower()}" if len(h) == 6 else f"#{h}"
 
 
-def _iter_files(*globs: str, skip_dirs: tuple[str, ...] = (".git", "node_modules", ".venv", "__pycache__")):
+_SKIP_DIRS = (".git", "node_modules", ".venv", "__pycache__", "dist", "build", ".next")
+
+
+def _iter_files(*globs: str, skip_dirs: tuple[str, ...] = _SKIP_DIRS):
     for pattern in globs:
         for path in ROOT.rglob(pattern):
             if any(d in path.parts for d in skip_dirs):
@@ -52,33 +76,39 @@ def _iter_files(*globs: str, skip_dirs: tuple[str, ...] = (".git", "node_modules
                 yield path
 
 
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
 # ---------------------------------------------------------------------------
 # Name detection
 # ---------------------------------------------------------------------------
 
 def _scan_name() -> str:
-    # 1. brand/NARRATIVE.md first H1
     narrative = ROOT / "brand" / "NARRATIVE.md"
     if narrative.exists():
         m = re.search(r"^#\s+(.+)$", narrative.read_text(errors="replace"), re.MULTILINE)
         if m:
-            return m.group(1).strip()
+            val = m.group(1).strip()
+            _audit("name", "brand/NARRATIVE.md H1", val)
+            return val
 
-    # 2. package.json
     pkg = ROOT / "package.json"
     if pkg.exists():
         try:
             data = json.loads(pkg.read_text())
             if "name" in data and data["name"]:
+                _audit("name", "package.json", data["name"])
                 return data["name"]
         except Exception:
             pass
 
-    # 3. pyproject.toml
     pyp = ROOT / "pyproject.toml"
     if pyp.exists():
         text = pyp.read_text(errors="replace")
-        # Try tomllib (Python ≥3.11) first, then regex.
         try:
             import tomllib  # type: ignore
             data = tomllib.loads(text)
@@ -87,27 +117,30 @@ def _scan_name() -> str:
                 or data.get("tool", {}).get("poetry", {}).get("name")
             )
             if name:
+                _audit("name", "pyproject.toml", name)
                 return name
         except (ImportError, Exception):
             m = re.search(r'^name\s*=\s*"([^"]+)"', text, re.MULTILINE)
             if m:
+                _audit("name", "pyproject.toml", m.group(1))
                 return m.group(1)
 
-    # 4. stack.yaml
     stack = ROOT / "stack.yaml"
     if stack.exists():
         m = re.search(r"^name\s*:\s*(.+)$", stack.read_text(errors="replace"), re.MULTILINE)
         if m:
-            return m.group(1).strip()
+            val = m.group(1).strip()
+            _audit("name", "stack.yaml", val)
+            return val
 
-    # 5. README.md first H1
     readme = ROOT / "README.md"
     if readme.exists():
         m = re.search(r"^#\s+(.+)$", readme.read_text(errors="replace"), re.MULTILINE)
         if m:
-            return m.group(1).strip()
+            val = m.group(1).strip()
+            _audit("name", "README.md H1", val)
+            return val
 
-    # 6. Git remote repo name
     try:
         remote = subprocess.check_output(
             ["git", "remote", "get-url", "origin"],
@@ -116,10 +149,12 @@ def _scan_name() -> str:
         ).strip()
         name = re.sub(r"\.git$", "", re.split(r"[/:]", remote)[-1])
         if name:
+            _audit("name", "git remote", name)
             return name
     except Exception:
         pass
 
+    _default_applied("name")
     return "project"
 
 
@@ -138,27 +173,27 @@ _CSS_PATTERNS = [
 
 
 def _scan_primary() -> str:
-    # CSS / SCSS / Less files
     for f in _iter_files("*.css", "*.scss", "*.less"):
         text = f.read_text(errors="replace")
         for pat in _CSS_PATTERNS:
             m = re.search(pat, text, re.IGNORECASE)
             if m:
-                return _normalize_hex(m.group(1))
+                val = _normalize_hex(m.group(1))
+                _audit("primary", f"CSS variable in {_rel(f)}", val)
+                return val
 
-    # tailwind.config.{js,ts,cjs,mjs}
     for tc in ROOT.glob("tailwind.config.*"):
         if tc.suffix not in (".js", ".ts", ".cjs", ".mjs"):
             continue
         text = tc.read_text(errors="replace")
-        # theme.colors.primary: '#xxx' or "xxx"
         m = re.search(
             r"primary\s*:\s*['\"]#?([0-9a-fA-F]{3,6})['\"]", text, re.IGNORECASE
         )
         if m:
-            return _normalize_hex(m.group(1))
+            val = _normalize_hex(m.group(1))
+            _audit("primary", f"Tailwind config {_rel(tc)}", val)
+            return val
 
-    # Design-token / theme JSON files
     TOKEN_GLOBS = ("tokens.json", "theme.json", "colors.json", "brand.json")
     TOKEN_PATHS = [
         ["colors", "primary"],
@@ -182,11 +217,13 @@ def _scan_primary() -> str:
                     if isinstance(val, str) and re.match(
                         r"#?[0-9a-fA-F]{3,6}$", val.strip()
                     ):
-                        return _normalize_hex(val.strip())
+                        result = _normalize_hex(val.strip())
+                        _audit("primary", f"design token in {_rel(f)}", result)
+                        return result
             except Exception:
                 continue
 
-    # Default: BSG dark navy
+    _default_applied("primary")
     return "#1a1a2e"
 
 
@@ -204,11 +241,189 @@ def _scan_font() -> str:
         for pat in _FONT_PATTERNS:
             m = re.search(pat, text, re.IGNORECASE)
             if m:
-                # Take only the first font in a stack, strip quotes and whitespace.
                 family = m.group(1).strip().split(",")[0].strip(" '\"")
                 if 2 < len(family) < 60 and family not in ("inherit", "initial", "unset"):
+                    _audit("font", f"CSS variable in {_rel(f)}", family)
                     return family
+
+    for f in _iter_files("*.css", "*.scss"):
+        text = f.read_text(errors="replace")
+        m = re.search(r"@font-face\s*\{[^}]*font-family\s*:\s*['\"]?([^'\";\}]+)", text)
+        if m:
+            family = m.group(1).strip()
+            if 2 < len(family) < 60:
+                _audit("font", f"@font-face in {_rel(f)}", family)
+                return family
+
+    for f in _iter_files("*.css", "*.scss", "*.html"):
+        text = f.read_text(errors="replace")
+        m = re.search(r"fonts\.googleapis\.com/css2?\?family=([^&\"'\s)]+)", text)
+        if m:
+            family = m.group(1).replace("+", " ").split(":")[0]
+            if family:
+                _audit("font", f"Google Fonts import in {_rel(f)}", family)
+                return family
+
+    _default_applied("font")
     return "Helvetica Neue"
+
+
+# ---------------------------------------------------------------------------
+# Logo detection
+# ---------------------------------------------------------------------------
+
+def _scan_logos() -> list[str]:
+    logo_dirs = ("public", "brand", "images", "assets", "static", "img")
+    logo_exts = (".svg", ".png", ".jpg", ".jpeg", ".webp")
+    results: list[str] = []
+
+    for d in logo_dirs:
+        dir_path = ROOT / d
+        if not dir_path.is_dir():
+            continue
+        for f in dir_path.rglob("*"):
+            if any(skip in f.parts for skip in _SKIP_DIRS):
+                continue
+            if not f.is_file():
+                continue
+            if f.suffix.lower() not in logo_exts:
+                continue
+            if "logo" in f.stem.lower():
+                results.append(_rel(f))
+
+    for ext in logo_exts:
+        for f in ROOT.glob(f"*logo*{ext}"):
+            if f.is_file():
+                rel = _rel(f)
+                if rel not in results:
+                    results.append(rel)
+
+    results.sort()
+    for r in results:
+        _audit("logo", r, "found")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Identity / voice documents
+# ---------------------------------------------------------------------------
+
+def _scan_identity_docs() -> list[str]:
+    candidates = [
+        "brand/NARRATIVE.md",
+        "brand/identity.md",
+        "DESIGN.md",
+    ]
+    results: list[str] = []
+
+    for c in candidates:
+        if (ROOT / c).exists():
+            results.append(c)
+
+    for f in _iter_files("*identity*.md", "*DESIGN*.md", "*design-system*.md"):
+        rel = _rel(f)
+        if rel not in results:
+            results.append(rel)
+
+    results.sort()
+    for r in results:
+        _audit("identity", r, "found")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Existing Office templates
+# ---------------------------------------------------------------------------
+
+def _scan_existing_templates() -> list[str]:
+    results: list[str] = []
+    for f in _iter_files("*.docx", "*.pptx", "*.xlsx"):
+        results.append(_rel(f))
+    results.sort()
+    for r in results:
+        _audit("existing_template", r, "found")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Audit report
+# ---------------------------------------------------------------------------
+
+def _generate_audit(tokens: dict, audit_path: Path) -> None:
+    lines: list[str] = []
+    name = tokens["name"]
+    lines.append(f"# Brand Audit — {name}")
+    lines.append("")
+    lines.append(f"Generated by `md-to-office --init` on {date.today().isoformat()}.")
+    lines.append("")
+
+    lines.append("## Chosen tokens")
+    lines.append("")
+    lines.append("| Token | Value | Source |")
+    lines.append("|---|---|---|")
+
+    source_map: dict[str, str] = {}
+    for signal, source, _value in _audit_log:
+        if signal not in source_map:
+            source_map[signal] = source
+
+    name_src = source_map.get("name", "default")
+    primary_src = source_map.get("primary", "default")
+    font_src = source_map.get("font", "default")
+
+    lines.append(f"| Name | {tokens['name']} | {name_src} |")
+    lines.append(f"| Primary color | `{tokens['colors']['primary']}` | {primary_src} |")
+    lines.append(f"| Font | {tokens['fonts']['primary']} | {font_src} |")
+    lines.append("")
+
+    lines.append("## Discovery details")
+    lines.append("")
+
+    sections: dict[str, list[tuple[str, str]]] = {}
+    for signal, source, value in _audit_log:
+        sections.setdefault(signal, []).append((source, value))
+
+    section_labels = {
+        "name": "Project name",
+        "primary": "Primary color",
+        "font": "Typography",
+        "logo": "Logo files",
+        "identity": "Identity documents",
+        "existing_template": "Existing Office templates",
+    }
+
+    for key in ("name", "primary", "font", "logo", "identity", "existing_template"):
+        label = section_labels.get(key, key)
+        lines.append(f"### {label}")
+        lines.append("")
+        entries = sections.get(key, [])
+        if entries:
+            for source, value in entries:
+                lines.append(f"- {source}" + (f" → `{value}`" if value != "found" else ""))
+        else:
+            lines.append("- (none found)")
+        lines.append("")
+
+    if _defaults_applied:
+        lines.append("## Defaults applied")
+        lines.append("")
+        default_labels = {
+            "name": "Name → `project`",
+            "primary": "Primary color → `#1a1a2e` (BSG dark navy)",
+            "font": "Font → `Helvetica Neue`",
+        }
+        for d in _defaults_applied:
+            lines.append(f"- {default_labels.get(d, d)}")
+        lines.append("")
+    else:
+        lines.append("## Defaults applied")
+        lines.append("")
+        lines.append("(none — all signals found in repo)")
+        lines.append("")
+
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text("\n".join(lines))
+    print(f"  Audit written to {_rel(audit_path)}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +431,10 @@ def _scan_font() -> str:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    # Merge with existing partial tokens.json if present.
+    parser = argparse.ArgumentParser(description="Scan repo for brand signals")
+    parser.add_argument("--audit", metavar="PATH", help="Write brand audit markdown to PATH")
+    args = parser.parse_args()
+
     existing: dict = {}
     tokens_path = ROOT / "brand" / "tokens.json"
     if tokens_path.exists():
@@ -230,16 +448,26 @@ def main() -> None:
     primary = existing.get("colors", {}).get("primary") or _scan_primary()
     font    = existing.get("fonts",  {}).get("primary") or _scan_font()
 
+    logos = _scan_logos()
+    identity_docs = _scan_identity_docs()
+    existing_templates = _scan_existing_templates()
+
     tokens = {
         "name":   name,
         "colors": {"primary": primary},
         "fonts":  {"primary": font},
+        "logos":  logos,
+        "identity_docs": identity_docs,
+        "existing_templates": existing_templates,
     }
 
     print(json.dumps(tokens, indent=2, ensure_ascii=False))
     print(f"  name:    {name}",    file=sys.stderr)
     print(f"  primary: {primary}", file=sys.stderr)
     print(f"  font:    {font}",    file=sys.stderr)
+
+    if args.audit:
+        _generate_audit(tokens, Path(args.audit))
 
 
 if __name__ == "__main__":

--- a/claude-skills/tests/test_md_to_office.py
+++ b/claude-skills/tests/test_md_to_office.py
@@ -399,6 +399,100 @@ class TestScanBrand(unittest.TestCase):
         self.assertEqual(tokens["name"], "My Project")   # from existing
         self.assertEqual(tokens["colors"]["primary"], "#aabbcc")  # from CSS
 
+    # ---- @font-face detection ------------------------------------------------
+
+    def test_font_from_font_face(self) -> None:
+        css = self.tmp / "fonts.css"
+        css.write_text(
+            "@font-face {\n"
+            "  font-family: 'Cabinet Grotesk';\n"
+            "  src: url('cabinet.woff2');\n"
+            "}\n"
+        )
+        self.assertEqual(self._scan()["fonts"]["primary"], "Cabinet Grotesk")
+
+    def test_font_from_google_fonts_import(self) -> None:
+        css = self.tmp / "global.css"
+        css.write_text(
+            "@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700');\n"
+        )
+        self.assertEqual(self._scan()["fonts"]["primary"], "Poppins")
+
+    def test_css_variable_font_wins_over_font_face(self) -> None:
+        css = self.tmp / "all.css"
+        css.write_text(
+            ":root { --font-family-primary: 'Manrope', sans-serif; }\n"
+            "@font-face { font-family: 'Cabinet Grotesk'; src: url('c.woff2'); }\n"
+        )
+        self.assertIn("Manrope", self._scan()["fonts"]["primary"])
+
+    # ---- logo detection ------------------------------------------------------
+
+    def test_logos_found_in_public_dir(self) -> None:
+        pub = self.tmp / "public"
+        pub.mkdir()
+        (pub / "logo.svg").write_text("<svg/>")
+        (pub / "logo-dark.png").write_bytes(b"\x89PNG")
+        tokens = self._scan()
+        self.assertIn("logos", tokens)
+        self.assertEqual(len(tokens["logos"]), 2)
+        self.assertTrue(any("logo.svg" in l for l in tokens["logos"]))
+
+    def test_logos_empty_when_none_found(self) -> None:
+        tokens = self._scan()
+        self.assertEqual(tokens["logos"], [])
+
+    # ---- identity doc detection ----------------------------------------------
+
+    def test_identity_docs_found(self) -> None:
+        brand = self.tmp / "brand"
+        brand.mkdir()
+        (brand / "NARRATIVE.md").write_text("# Brand\n\nVoice.\n")
+        (self.tmp / "DESIGN.md").write_text("# Design System\n")
+        tokens = self._scan()
+        self.assertIn("identity_docs", tokens)
+        self.assertTrue(len(tokens["identity_docs"]) >= 2)
+
+    def test_identity_docs_empty_when_none(self) -> None:
+        tokens = self._scan()
+        self.assertEqual(tokens["identity_docs"], [])
+
+    # ---- existing template detection -----------------------------------------
+
+    def test_existing_templates_found(self) -> None:
+        (self.tmp / "old-report.docx").write_bytes(b"PK\x03\x04stub")
+        tokens = self._scan()
+        self.assertIn("existing_templates", tokens)
+        self.assertTrue(any("old-report.docx" in t for t in tokens["existing_templates"]))
+
+    # ---- audit generation ----------------------------------------------------
+
+    def test_audit_flag_writes_markdown(self) -> None:
+        (self.tmp / "README.md").write_text("# Audit Test\n\nDesc.\n")
+        css = self.tmp / "style.css"
+        css.write_text(":root { --primary-color: #abcdef; }\n")
+        audit_path = self.tmp / "brand" / "templates" / "brand-audit.md"
+        result = run(
+            ["python3", str(SCAN_BRAND), "--audit", str(audit_path)],
+            cwd=self.tmp,
+        )
+        self.assertTrue(audit_path.exists(), f"audit not written; stderr={result.stderr}")
+        content = audit_path.read_text()
+        self.assertIn("# Brand Audit", content)
+        self.assertIn("Audit Test", content)
+        self.assertIn("#abcdef", content)
+        self.assertIn("Chosen tokens", content)
+        self.assertIn("Discovery details", content)
+
+    def test_audit_shows_defaults_when_empty_repo(self) -> None:
+        audit_path = self.tmp / "audit.md"
+        run(
+            ["python3", str(SCAN_BRAND), "--audit", str(audit_path)],
+            cwd=self.tmp,
+        )
+        content = audit_path.read_text()
+        self.assertIn("Defaults applied", content)
+
     # ---- orchestrator onboarding banner ------------------------------------
 
     def _make_fake_pandoc(self, bin_dir: Path) -> None:
@@ -507,7 +601,39 @@ class TestInitBrandSmoke(unittest.TestCase):
     def test_tokens_only_skips_template_generation(self) -> None:
         run(["bash", str(INIT_BRAND), "--tokens-only"], cwd=self.tmp)
         self.assertTrue((self.tmp / "brand" / "tokens.json").exists())
-        self.assertFalse((self.tmp / "brand" / "templates").exists())
+        # tokens-only should not create Office templates, but brand-audit.md is OK
+        for fname in ("reference.docx", "template.pptx", "template.xlsx"):
+            self.assertFalse(
+                (self.tmp / "brand" / "templates" / fname).exists(),
+                f"{fname} should not exist with --tokens-only",
+            )
+
+    def test_dry_run_writes_tokens_and_audit_only(self) -> None:
+        run(["bash", str(INIT_BRAND), "--dry-run"], cwd=self.tmp)
+        self.assertTrue((self.tmp / "brand" / "tokens.json").exists())
+        self.assertTrue((self.tmp / "brand" / "templates" / "brand-audit.md").exists())
+        for fname in ("reference.docx", "template.pptx", "template.xlsx"):
+            self.assertFalse(
+                (self.tmp / "brand" / "templates" / fname).exists(),
+                f"{fname} should not exist with --dry-run",
+            )
+
+    def test_dry_run_skips_idempotency_guard(self) -> None:
+        """--dry-run should work even when templates already exist."""
+        run(["bash", str(INIT_BRAND)], cwd=self.tmp)
+        # Without --force, a second full run would exit early.
+        # But --dry-run should still scan and produce the audit.
+        result = run(["bash", str(INIT_BRAND), "--dry-run"], cwd=self.tmp)
+        self.assertIn("Dry run", result.stdout)
+        self.assertTrue((self.tmp / "brand" / "templates" / "brand-audit.md").exists())
+
+    def test_init_creates_brand_audit_md(self) -> None:
+        run(["bash", str(INIT_BRAND)], cwd=self.tmp)
+        audit = self.tmp / "brand" / "templates" / "brand-audit.md"
+        self.assertTrue(audit.exists())
+        content = audit.read_text()
+        self.assertIn("Brand Audit", content)
+        self.assertIn("Init Test Repo", content)
 
 
 class TestRenderDocxSmoke(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **Enhanced brand scanner** (`scan-brand.py`): detects logos, `@font-face` declarations, Google Fonts imports, identity/voice documents, and existing Office templates — all surfaced in `tokens.json`
- **Brand audit report**: `--init` now generates `brand/templates/brand-audit.md` documenting every signal found, the chosen token values, and which defaults were applied
- **`--dry-run` flag**: `md-to-office.sh --init --dry-run` scans and writes tokens + audit only, without generating Office templates — for previewing extraction before committing

Closes #235

## Test plan

- [x] All 55 existing + new unit tests pass locally (8 skipped for missing optional deps)
- [ ] CI passes `test_md_to_office.py` (layers 1–3 always, layer 4 when deps present)
- [ ] `--dry-run` creates `brand/tokens.json` + `brand-audit.md` but no `.docx/.pptx/.xlsx`
- [ ] `@font-face` and Google Fonts detection picks correct font family
- [ ] Logo files found in `public/`, `brand/`, `images/`, `assets/`
- [ ] Identity docs found (`NARRATIVE.md`, `DESIGN.md`, `*identity*.md`)
- [ ] Audit markdown includes "Defaults applied" section for empty repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)