### PR TITLE
fix(storytelling): emit valid JSON when narrative bible lacks vocab/anchor keys

### DIFF
--- a/claude-skills/skills/storytelling-report/scripts/collect.sh
+++ b/claude-skills/skills/storytelling-report/scripts/collect.sh
@@ -59,14 +59,14 @@ if [[ -f "$NARRATIVE_PATH" ]]; then
   DIFFERENTIATORS_JSON=$(extract_section_bullets "Value Proposition" | jq -Rn '[inputs | select(length>0)]' 2>/dev/null || echo '[]')
 
   BANNED_RAW=$(extract_kv_sublines "Voice Guidelines" "Banned vocabulary" || true)
-  BANNED_TERMS_JSON=$(echo "$BANNED_RAW" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | grep -v '^$' | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+  BANNED_TERMS_JSON=$(echo "$BANNED_RAW" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | jq -Rn '[inputs | select(length>0)]' 2>/dev/null || echo '[]')
 
   PREF_RAW=$(extract_kv_sublines "Voice Guidelines" "Preferred vocabulary" || true)
-  PREFERRED_TERMS_JSON=$(echo "$PREF_RAW" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | grep -v '^$' | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+  PREFERRED_TERMS_JSON=$(echo "$PREF_RAW" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | jq -Rn '[inputs | select(length>0)]' 2>/dev/null || echo '[]')
 
   CATEGORY=$(extract_kv_sublines "Positioning" "Category" | head -1 || true)
   AUDIENCE=$(extract_kv_sublines "Positioning" "Target audience" | head -1 || true)
-  FEATURE_ANCHORS_JSON=$(extract_kv_sublines "Positioning" "Feature anchors" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | grep -v '^$' | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+  FEATURE_ANCHORS_JSON=$(extract_kv_sublines "Positioning" "Feature anchors" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | jq -Rn '[inputs | select(length>0)]' 2>/dev/null || echo '[]')
 fi
 
 # --------------------------------------------- jargon baseline


### PR DESCRIPTION
## Summary

- Three jq pipelines in `claude-skills/skills/storytelling-report/scripts/collect.sh` built `bannedTerms` / `preferredTerms` / `featureAnchors` from `## Voice Guidelines` and `## Positioning` sub-keys. When a key was absent, the pipeline produced `[]\n[]` (invalid JSON), and `generate-report.sh` aborted with `jq: invalid JSON text passed to --argjson`.
- Root cause: `grep -v '^$'` on empty input exits 1 under `pipefail`, tripping `|| echo '[]'`, but `jq` had already emitted `[]` from empty stdin first — so the captured value was the concatenation of both.
- Fix: drop the `grep` and let `jq` filter empties via `select(length>0)`, matching the pattern already used for `keyMessages` and `differentiators` two lines above.

This was discovered while running `/storytelling-report audit` — see report PR #238 (which only landed because the cached copy was hot-patched locally).

## Follow-up (not in this PR)

The script's narrative-bible parser also expects `## Voice Guidelines` / `## Key Messages` / `## Value Proposition`, but the live `brand/NARRATIVE.md` uses `## Voice` / `## Key messages` / `## Positioning`. Today's audit therefore reports 0 key messages / 0 value-prop bullets / empty positioning even though the bible has all that content. That's a schema-vs-parser decision worth its own issue.

## Test plan

- [x] `python3 -m pytest claude-skills/tests/` — 69 passed, 8 skipped
- [x] Smoke-tested `collect.sh` against a minimal `brand/NARRATIVE.md` — `bannedTerms`, `preferredTerms`, `featureAnchors` now emit `[]` cleanly instead of `[]\n[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)