### PR TITLE
feat(agents): enforce custom-doc + init frontmatter fields

### DIFF
--- a/claude-skills/agents/marketing.md
+++ b/claude-skills/agents/marketing.md
@@ -26,6 +26,11 @@ tick: >
 auto-implements: []
 never-auto-implements:
   - "marketing copy and content decisions require human voice and editorial judgement — never auto-generated"
+custom-doc: .bsg/CALENDAR.md
+init: >
+  Scans releases, blog posts, and PR history to generate a draft
+  CALENDAR.md with editorial calendar entries aligned to shipped
+  features. Opens as PR for human review.
 ---
 
 You are the **Marketing Agent** for this repository. Your job:

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -45,6 +45,11 @@ delegates-to: [tech, qa, seo]
 auto-implements: []
 never-auto-implements:
   - "triage and plan decisions require human judgement — po-manager delegates work, it does not implement"
+custom-doc: .bsg/PLAN.md
+init: >
+  Scans milestones, open issues, labels, and README to generate a draft
+  PLAN.md with objectives, epic bindings, and milestone links. Opens as
+  PR for human review.
 ---
 
 You are the **PO Manager** for this repository. Your job: give the user a

--- a/claude-skills/agents/pr-comms.md
+++ b/claude-skills/agents/pr-comms.md
@@ -27,6 +27,11 @@ tick: >
 auto-implements: []
 never-auto-implements:
   - "press copy and public communications require human approval by definition — never auto-generated"
+custom-doc: .bsg/ANNOUNCED.md
+init: >
+  Scans releases, CHANGELOG, and prior announcements to generate a
+  draft ANNOUNCED.md listing already-communicated events. Opens as PR
+  for human review.
 ---
 
 You are the **PR / Comms Agent** for this repository. Your job:

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -52,6 +52,11 @@ never-auto-implements:
   - "dependency version bumps (owned by Renovate)"
   - "test harness or CI pipeline changes (meta-tooling needs humans)"
   - "changes that require a new dependency to be added"
+custom-doc: .bsg/reports/qa/
+init: >
+  Scans existing test files and CI coverage artifacts to generate a
+  baseline QA snapshot with coverage stats and risk hotspots. Opens as
+  PR for human review.
 ---
 
 You are the **QA Agent** for this repository. Your job: surface quality

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -30,6 +30,11 @@ tick: >
 auto-implements: []
 never-auto-implements:
   - "security fixes must be written and reviewed by humans — never by an agent"
+custom-doc: .bsg/SECURITYIGNORE
+init: >
+  Scans test fixtures, sample data, and CI config to generate a draft
+  SECURITYIGNORE listing known false-positive paths to exclude from
+  audit. Opens as PR for human review.
 ---
 
 You are the **Security Agent** for this repository. Your job: produce a

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -55,6 +55,11 @@ never-auto-implements:
   - "dependency version bumps (owned by Renovate)"
   - "content rewrites or copywriting (SEO agent audits, not authors)"
   - "changes that require a new dependency to be added"
+custom-doc: .bsg/KEYWORDS.md
+init: >
+  Scans README, docs/, page titles, and meta tags to generate a draft
+  KEYWORDS.md with target keyword list and coverage baseline. Opens as
+  PR for human review.
 ---
 
 You are the **SEO Agent** for this repository. Your job: surface

--- a/claude-skills/agents/storytelling.md
+++ b/claude-skills/agents/storytelling.md
@@ -27,6 +27,11 @@ tick: >
 auto-implements: []
 never-auto-implements:
   - "brand voice and narrative decisions require human judgement — never auto-generated"
+custom-doc: .bsg/NARRATIVE.md
+init: >
+  Scans README, landing pages, and existing copy to generate a draft
+  NARRATIVE.md with voice guidelines, key messages, and positioning.
+  Opens as PR for human review.
 ---
 
 You are the **Storytelling Agent** for this repository. Your job:

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -52,6 +52,11 @@ never-auto-implements:
   - "dependency version bumps (owned by Renovate)"
   - "changes that require a new dependency to be added"
   - "refactors without a bug to fix (Don't decide, document — principle #5)"
+custom-doc: .bsg/adr/
+init: >
+  Scans architecture signals, major dependencies, and CI setup to
+  bootstrap initial ADRs documenting key technical decisions. Opens as
+  PR for human review.
 ---
 
 You are the **Tech Lead** for this repository. Your job: surface

--- a/claude-skills/skills/md-to-office/SKILL.md
+++ b/claude-skills/skills/md-to-office/SKILL.md
@@ -11,6 +11,11 @@ version: 0.1.0
 output: chat
 auto-implements: []
 never-auto-implements: []
+custom-doc: .bsg/DESIGN.md
+init: >
+  Scans CSS custom properties, Tailwind config, design tokens, and logo
+  files to generate DESIGN.md following the Google Stitch spec, and
+  derives branded Office templates. Opens as PR for human review.
 ---
 
 # md-to-office Skill

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -326,6 +326,114 @@ class TestSharedSkills(unittest.TestCase):
                         f"must list at least one `never-auto-implements` clause.",
                     )
 
+    # ---------------------------------------- custom-doc + init (#237)
+
+    def test_every_agent_declares_custom_doc(self) -> None:
+        """Every agent must declare a `custom-doc:` field listing the
+        per-repo document(s) it reads/writes under .bsg/.
+
+        See CLAUDE.md → "Unified .bsg/ directory convention" and #237.
+        """
+        agents = list_agents()
+        self.assertGreater(len(agents), 0, "no agents discovered")
+        for path in agents:
+            with self.subTest(agent=path.stem):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match)
+                frontmatter = fm_match.group(1)
+                scalars = dict(FRONTMATTER_SCALAR_RE.findall(frontmatter))
+                self.assertIn(
+                    "custom-doc",
+                    scalars,
+                    f"{path.relative_to(REPO_ROOT)}: agent frontmatter is "
+                    f"missing a `custom-doc:` field. Every BSG agent must "
+                    f"declare the per-repo document it reads/writes — see "
+                    f"#237 for the schema.",
+                )
+                self.assertTrue(
+                    scalars["custom-doc"].strip(),
+                    f"{path.relative_to(REPO_ROOT)}: `custom-doc:` is empty. "
+                    f"Specify the .bsg/ path this agent owns.",
+                )
+
+    def test_every_agent_declares_init_action(self) -> None:
+        """Every agent must declare an `init:` field in frontmatter
+        describing what --init generates and from what sources.
+
+        See CLAUDE.md → "Mandatory --init on every agent" and #237.
+        """
+        agents = list_agents()
+        self.assertGreater(len(agents), 0, "no agents discovered")
+        for path in agents:
+            with self.subTest(agent=path.stem):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match)
+                frontmatter = fm_match.group(1)
+                keys = set(TOP_LEVEL_KEY_RE.findall(frontmatter))
+                self.assertIn(
+                    "init",
+                    keys,
+                    f"{path.relative_to(REPO_ROOT)}: agent frontmatter is "
+                    f"missing an `init:` field. Every BSG agent must declare "
+                    f"what its --init generates — see #237.",
+                )
+                init_body = self._extract_folded_body(frontmatter, "init")
+                self.assertTrue(
+                    init_body.strip(),
+                    f"{path.relative_to(REPO_ROOT)}: `init:` field is empty. "
+                    f"Describe what --init generates and from what sources.",
+                )
+
+    def test_every_skill_with_custom_doc_has_init(self) -> None:
+        """Skills that declare a custom-doc must also declare init."""
+        skills = list_skill_entrypoints()
+        for path in skills:
+            with self.subTest(skill=path.parent.name):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                if not fm_match:
+                    continue
+                frontmatter = fm_match.group(1)
+                scalars = dict(FRONTMATTER_SCALAR_RE.findall(frontmatter))
+                if "custom-doc" not in scalars:
+                    continue
+                keys = set(TOP_LEVEL_KEY_RE.findall(frontmatter))
+                self.assertIn(
+                    "init",
+                    keys,
+                    f"{path.relative_to(REPO_ROOT)}: skill declares "
+                    f"`custom-doc: {scalars['custom-doc']}` but has no "
+                    f"`init:` field. Skills with a custom doc must declare "
+                    f"how --init generates it — see #237.",
+                )
+                init_body = self._extract_folded_body(frontmatter, "init")
+                self.assertTrue(
+                    init_body.strip(),
+                    f"{path.relative_to(REPO_ROOT)}: `init:` field is empty.",
+                )
+
+    @staticmethod
+    def _extract_folded_body(frontmatter: str, key: str) -> str:
+        """Return the value of a YAML key (inline or folded block)."""
+        lines = frontmatter.splitlines()
+        body: list[str] = []
+        in_block = False
+        for line in lines:
+            if not in_block:
+                m = re.match(rf"^{re.escape(key)}\s*:\s*(.*)$", line)
+                if m:
+                    in_block = True
+                    inline = m.group(1).strip()
+                    if inline and inline not in (">", "|", ">-", "|-"):
+                        body.append(inline)
+                continue
+            if re.match(r"^[A-Za-z_][A-Za-z0-9_-]*\s*:", line):
+                break
+            body.append(line)
+        return "\n".join(body)
+
     # ---------------------------------------- registry/frontmatter alignment
 
     def test_registry_output_matches_frontmatter(self) -> None:


### PR DESCRIPTION
## Summary

- Add `custom-doc:` and `init:` frontmatter fields to all 8 agents and the md-to-office skill
- Add 3 new tests in `test_skills.py` enforcing these fields (same pattern as tick/output/scope contract tests)
- This is **PR 1 of #237** (test-first enforcement) — later PRs will migrate paths to `.bsg/`, implement the actual `--init` scripts, and build the `/bsg-stack` doctor skill

### New frontmatter fields per agent

| Agent | `custom-doc` | `init` scan sources |
|---|---|---|
| po-manager | `.bsg/PLAN.md` | Milestones, issues, labels, README |
| storytelling | `.bsg/NARRATIVE.md` | README, landing pages, existing copy |
| marketing | `.bsg/CALENDAR.md` | Releases, blog posts, PR history |
| seo | `.bsg/KEYWORDS.md` | README, docs/, page titles, meta tags |
| security | `.bsg/SECURITYIGNORE` | Test fixtures, sample data, CI config |
| pr-comms | `.bsg/ANNOUNCED.md` | Releases, CHANGELOG, prior announcements |
| tech-lead | `.bsg/adr/` | Architecture signals, major deps, CI setup |
| qa | `.bsg/reports/qa/` | Test files, CI coverage artifacts |
| md-to-office | `.bsg/DESIGN.md` | CSS vars, Tailwind, design tokens, logos |

### New tests

- `test_every_agent_declares_custom_doc` — every agent must have a non-empty `custom-doc:` field
- `test_every_agent_declares_init_action` — every agent must have a non-empty `init:` field
- `test_every_skill_with_custom_doc_has_init` — skills declaring `custom-doc:` must also declare `init:`

Closes part of #237

## Test plan

- [x] All 13 tests pass (`python3 claude-skills/tests/test_skills.py`)
- [x] Verified tests fail before adding frontmatter fields (16 failures: 8 missing custom-doc + 8 missing init)
- [ ] Verify no regressions in agent behavior (frontmatter-only change, no script modifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)