### PR TITLE
report(pr-comms): 2026-04-30-events

### DIFF
--- a/comms/reports/2026-04-30-events.md
+++ b/comms/reports/2026-04-30-events.md
@@ -1,0 +1,52 @@
+<!-- fingerprint: none -->
+# PR / Comms Events — 2026-04-30
+
+**Repository:** `agent-a6e000a595a0c2f8b` (visibility: public)
+**Generated:** 2026-04-30T08:46:26Z
+**Releases tracked:** 0
+**Milestones tracked:** 0
+**Contributors:** 3 — **PRs merged (total):** 201
+
+---
+
+## Newsworthy Events
+
+**Summary:** 0 events — 0 unannounced major/minor, 0 unannounced milestone, 0 security advisories, 1 community milestones (0 patches skipped)
+
+
+
+
+
+
+
+
+
+### Community milestones
+
+- prsMerged crossed 100 (current: 201)
+
+---
+
+## Press Kit Health
+
+**Directory:** `comms/press-kit`; **assets:** 2, **stale:** 0, **missing recommended:** 4
+
+
+
+| File | Last updated | Age (days) | Stale? |
+|------|--------------|-----------:|--------|
+| contact.md | 2026-04-24 | 5 | no |
+| boilerplate.md | 2026-04-24 | 5 | no |
+
+
+
+**Missing recommended files:** `fact-sheet.md`, `leadership.md`, `milestones.md`, `faq.md`
+
+---
+
+## Draft Press Releases
+
+_No unannounced releases require drafting._
+
+
+


### PR DESCRIPTION
Automated report generated by @pr-comms.

File: `comms/reports/2026-04-30-events.md`

This PR is opened by `open-report-pr.sh` and auto-merges when the repo allows it.