### PR TITLE
fix(pilot): updater resilience — per-section isolation + dangling symlink handling (#67)

### DIFF
--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -195,7 +195,21 @@ def install_file(url: str, dest: Path, owned: set, rel_key: str) -> bool:
     the manifest, with one exception: this script is always allowed to
     overwrite itself (otherwise the very first run after install would
     refuse to claim the file the install flow just dropped on disk).
+
+    Dangling symlinks (broken symlinks where the target doesn't exist) are
+    treated as writable destinations — they are removed before writing so
+    that mkdir/replace don't raise FileExistsError (issue #67).
     """
+    # A dangling symlink: is_symlink() is True but exists() is False.
+    # Remove it so the path is clear for writing.
+    if dest.is_symlink() and not dest.exists():
+        try:
+            dest.unlink()
+            log(f"  removed dangling symlink {dest}")
+        except OSError as e:
+            log(f"  SKIP {dest} (dangling symlink, could not remove: {e})")
+            return False
+
     if dest.exists() and rel_key not in owned and not is_self(rel_key):
         log(f"  SKIP {dest} (exists, not owned by BSG manifest)")
         return False
@@ -264,9 +278,22 @@ def reconcile(manifest: dict) -> dict:
 
     for api_sub, dest, prefix in SECTIONS:
         log(f"fetching {api_sub}...")
-        entries, definitive = walk_remote(
-            f"claude-skills/{api_sub}", dest, prefix
-        )
+        try:
+            entries, definitive = walk_remote(
+                f"claude-skills/{api_sub}", dest, prefix
+            )
+        except Exception as e:  # noqa: BLE001
+            # Per-section isolation: one broken path must not prevent
+            # the remaining sections (agents/, scripts/) from syncing.
+            # Log the failure and leave existing files for this section alone.
+            log(f"  ERROR in {api_sub}: {e} — skipping section, existing files untouched")
+            # Preserve ownership of all files already owned under this prefix
+            # so they survive the deletion reconcile below.
+            for rel_key in owned:
+                if rel_key.split("/", 1)[0] == prefix:
+                    new_owned.add(rel_key)
+            continue
+
         if not entries and not definitive:
             log("  unreachable, leaving existing files alone")
         section_results[prefix] = (entries, definitive)

--- a/claude-skills/tests/test_updater_resilience.py
+++ b/claude-skills/tests/test_updater_resilience.py
@@ -1,0 +1,119 @@
+"""
+Tests for update-bsg-skills.py resilience (issue #67).
+
+Verifies:
+1. A dangling symlink under ~/.claude/skills/ does not abort the sync
+   — agents/ and scripts/ sections still run.
+2. install_file treats a broken symlink as a path it can overwrite
+   (same as owned-by-manifest), rather than crashing.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _load_updater(monkeypatch_env: dict | None = None) -> types.ModuleType:
+    """Load update-bsg-skills.py as a module without executing main()."""
+    script = (
+        Path(__file__).parent.parent / "scripts" / "update-bsg-skills.py"
+    )
+    spec = importlib.util.spec_from_file_location("update_bsg_skills", script)
+    mod = importlib.util.module_from_spec(spec)
+    # Patch CLAUDE_DIR before the module-level token discovery runs
+    if monkeypatch_env:
+        old = {k: os.environ.get(k) for k in monkeypatch_env}
+        os.environ.update(monkeypatch_env)
+    spec.loader.exec_module(mod)
+    if monkeypatch_env:
+        for k, v in old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    return mod
+
+
+class TestDanglingSymlinkDoesNotAbortSync(unittest.TestCase):
+    """
+    Regression test for #67: a dangling symlink in skills/ must not
+    prevent agents/ and scripts/ from syncing.
+    """
+
+    def test_per_section_isolation(self):
+        """
+        reconcile() must continue to the next section even when one
+        section's install_file raises an unexpected exception.
+        """
+        mod = _load_updater()
+
+        # Track which sections were attempted
+        attempted: list[str] = []
+
+        def fake_walk_remote(api_path, dest_dir, rel_prefix):
+            attempted.append(rel_prefix)
+            if rel_prefix == "skills":
+                # Simulate a FileExistsError raised by mkdir on a broken symlink
+                raise FileExistsError(
+                    17, "File exists", str(dest_dir / "github-compliance")
+                )
+            return [], True
+
+        manifest = {"files": []}
+        with patch.object(mod, "walk_remote", side_effect=fake_walk_remote):
+            # Should not raise; should complete all sections
+            try:
+                mod.reconcile(manifest)
+            except FileExistsError:
+                self.fail(
+                    "reconcile() propagated FileExistsError — "
+                    "per-section isolation is missing (issue #67)"
+                )
+
+        # agents and scripts must still have been attempted even though skills crashed
+        self.assertIn("agents", attempted, "agents section was skipped after skills crashed")
+        self.assertIn("scripts", attempted, "scripts section was skipped after skills crashed")
+
+    def test_broken_symlink_is_overwritable(self):
+        """
+        install_file must treat a broken symlink as a writable destination,
+        not skip it as 'exists, not owned by BSG manifest'.
+        """
+        mod = _load_updater()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir) / "subdir" / "target.md"
+            dest.parent.mkdir()
+            # Create a dangling symlink at dest
+            dangling_target = Path(tmpdir) / "nonexistent"
+            dest.symlink_to(dangling_target)
+            self.assertTrue(dest.is_symlink())
+            self.assertFalse(dest.exists())  # dangling
+
+            # File is NOT in the manifest (empty owned set)
+            owned: set = set()
+            fake_content = b"# hello from upstream"
+
+            with patch.object(mod, "http_get", return_value=fake_content):
+                result = mod.install_file(
+                    "https://example.com/fake", dest, owned, "skills/github-compliance/SKILL.md"
+                )
+
+            self.assertTrue(
+                result,
+                "install_file returned False for a dangling symlink — "
+                "it should overwrite the broken link, not skip it (issue #67)"
+            )
+            # The destination should now be a real file with the fetched content
+            self.assertTrue(dest.exists() and not dest.is_symlink())
+            self.assertEqual(dest.read_bytes(), fake_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tech/reports/2026-04-30-health.md
+++ b/tech/reports/2026-04-30-health.md
@@ -1,0 +1,48 @@
+<!-- fingerprint: none -->
+# Tech Health — 2026-04-30
+
+**Repository:** `agent-a6d23ee873c2144a4`
+**Generated:** 2026-04-30T08:46:08Z
+**Ecosystems:** 
+
+---
+
+## Dependency Health
+
+**Summary:** 0 tracked — 0 up-to-date, 0 patch-behind, 0 minor-behind, 0 major-behind
+
+_No major-version-behind dependencies._
+
+---
+
+## Code Quality
+
+**Summary:** 6 source files analyzed — 2 oversized (> 500 LOC), 2 function-dense (> 20), 0 circular-import cycles
+
+### Largest files
+
+| File | Lines | Functions |
+|------|-------|-----------|
+| claude-skills/tests/test_md_to_office.py | 682 | 71 |
+| claude-skills/tests/test_skills.py | 535 | 22 |
+
+
+
+---
+
+## Tech Debt Inventory
+
+**Summary:** 2 markers — TODO: 2, FIXME: 0, HACK: 0; oldest: 2026-04-22
+
+**Debt score:** 2 (no previous)
+
+_No stale TODOs (> 90 days)._
+
+---
+
+## Architecture Decision Records
+
+_No ADR directory found. Consider creating `adr/0001-start.md` to document the first architectural decision of this repo._
+
+
+


### PR DESCRIPTION
## Summary

- **Per-section isolation in `reconcile()`**: wrap each `SECTIONS` loop iteration in `try/except` so a `FileExistsError` (or any other exception) raised while processing `skills/` does not abort the remaining `agents/` and `scripts/` sections. Owned files under the failed section are preserved in the manifest.
- **Dangling symlink handling in `install_file()`**: before the `dest.exists()` check, detect broken symlinks via `dest.is_symlink() and not dest.exists()` and remove them — matching the issue's recommended approach. This lets the subsequent `mkdir` + `replace` succeed instead of raising `FileExistsError`.

Fixes #67

## Test plan

- [x] `test_per_section_isolation` — `FileExistsError` in `skills/` section does not propagate; `agents` and `scripts` sections are still attempted
- [x] `test_broken_symlink_is_overwritable` — `install_file` overwrites a dangling symlink (not in manifest) and returns `True`
- [x] Existing `test_skills.py` suite (13 tests, 117 subtests) — all pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)