### PR TITLE
report(marketing): 2026-04-30-audit

### DIFF
--- a/marketing/reports/2026-04-30-audit.md
+++ b/marketing/reports/2026-04-30-audit.md
@@ -1,8 +1,8 @@
 <!-- fingerprint: none -->
 # Marketing Audit — 2026-04-30
 
-**Repository:** `agent-a1924bfa67ef363ee`
-**Generated:** 2026-04-30T08:46:18Z
+**Repository:** `agent-a1990a67eaa1a7513`
+**Generated:** 2026-04-30T09:12:36Z
 **Releases tracked:** 2
 **Milestones tracked:** 0
 


### PR DESCRIPTION
Automated marketing audit report for 2026-04-30.

## Silence-breakers fired

- **2 unmarketed shipped releases:** v2.1.0 (Drop Renovate compat stubs) and v2.0.0 (Stack reorganisation) — both released 2026-04-14 with no corresponding marketing content.
- **Calendar not found:** No `marketing/CALENDAR.md` content items detected (0 calendar items).

## Summary

| Signal | Count |
|--------|-------|
| Releases tracked | 2 |
| Unmarketed releases | 2 |
| Calendar items | 0 |
| Claimed-but-unshipped | 6 (all are audit report files / README sections — not real marketing claims) |

Auto-generated by `@marketing tick`.