### PR TITLE
feat(md-to-office): PPTX target + auto-detect from Gamma frontmatter

### DIFF
--- a/claude-skills/skills/md-to-office/SKILL.md
+++ b/claude-skills/skills/md-to-office/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: md-to-office
 description: >
-  Convert a markdown file into a brand-aligned Office document (DOCX first,
-  PPTX/XLSX in later PRs) using Office templates that live inside the
-  current repo at brand/templates/. Wraps pandoc; ships no binaries of
-  its own — each consuming repo owns its brand assets. Use when the user
-  asks to "turn this md into a Word doc", "export as Word", "génère un
+  Convert a markdown file into a brand-aligned Office document (DOCX or PPTX)
+  using Office templates that live inside the current repo at brand/templates/.
+  Wraps pandoc for DOCX and python-pptx for PPTX; ships no binaries of
+  its own — each consuming repo owns its brand assets. Auto-detects target
+  format from gamma frontmatter. Use when the user asks to "turn this md
+  into a Word doc", "export as PowerPoint", "convert to slides", "génère un
   Word à partir de ce .md", or "convert the report to docx".
-version: 0.1.0
+version: 0.2.0
 output: chat
 auto-implements: []
 never-auto-implements: []
@@ -31,11 +32,11 @@ runtime.
 1. **Templates live in the target repo, never in this skill.** The
    catalog ships pure rendering logic. A repo without `brand/` still
    gets a working (unbranded) output — that is a success, not an error.
-2. **Deterministic pipeline.** Rendering is pandoc + (later) python-pptx
-   + openpyxl. No LLM call during rendering. Claude orchestrates,
-   never draws.
-3. **Write next to the source.** `report.md` → `report.docx` in the
-   same directory, mirroring the `/ocr` convention.
+2. **Deterministic pipeline.** Rendering is pandoc (DOCX) + python-pptx
+   (PPTX). No LLM call during rendering. Claude orchestrates, never draws.
+3. **Write next to the source.** `report.md` → `report.docx` (or
+   `deck.md` → `deck.pptx`) in the same directory, mirroring the
+   `/ocr` convention.
 4. **Idempotent.** If the output exists and is newer than the source,
    skip unless `--force` is given.
 5. **Scripts do the work.** This SKILL.md narrates; `scripts/`
@@ -50,12 +51,9 @@ Every consuming repo is expected (but not required) to carry:
 └── brand/
     └── templates/
         ├── reference.docx    # pandoc reference-doc, used for DOCX output
-        ├── template.pptx     # (PR #3) PowerPoint master + layouts
+        ├── template.pptx     # PowerPoint master + layouts, used for PPTX output
         └── template.xlsx     # (PR #4) Excel styles + table sample
 ```
-
-Scope of PR #1: only `reference.docx` is read. PPTX and XLSX renderers
-will land in follow-up PRs per PRD-008.
 
 ## Template resolution
 
@@ -79,13 +77,15 @@ prefer it over calling the renderers directly.
 
 | Script | Purpose |
 |---|---|
-| `md-to-office.sh` | Orchestrator. `md-to-office.sh <file> [--target docx] [--template <path>] [--force]`. |
+| `md-to-office.sh` | Orchestrator. `md-to-office.sh <file> [--target docx\|pptx] [--template <path>] [--force]`. Also accepts a directory for batch mode. |
 | `resolve-template.sh` | Emits the resolved template path (or empty) for a given target. |
 | `render-docx.sh` | pandoc wrapper. `render-docx.sh <input.md> <output.docx> [--template <path>]`. |
+| `render-pptx.sh` | python-pptx wrapper. `render-pptx.sh <input.md> <output.pptx> [--template <path>]`. |
+| `render-pptx.py` | Markdown-to-slides parser + PPTX renderer. Called by `render-pptx.sh`. |
 | `init-brand.sh` | Brand bootstrap. `init-brand.sh [--force] [--tokens-only] [--dry-run]`. |
 | `scan-brand.py` | Repo signal scanner → `brand/tokens.json` + optional audit. |
 | `generate-templates.py` | Reads `tokens.json`, produces `reference.docx`, `template.pptx`, `template.xlsx`. |
-| `install-local.sh` | Installs `pandoc` via brew. `--dry-run` to print-only. |
+| `install-local.sh` | Installs `pandoc` + Python deps via brew/pip. `--dry-run` to print-only. |
 
 ## Brand initialization (`--init`)
 
@@ -117,23 +117,71 @@ brand/templates/template.pptx       ← PowerPoint with brand theme
 brand/templates/template.xlsx       ← Excel with brand-coloured header
 ```
 
+## Auto-detection from frontmatter
+
+When `--target` is omitted, the orchestrator reads YAML frontmatter to
+pick the output format:
+
+```yaml
+---
+gamma:
+  format: presentation   # → PPTX
+---
+```
+
+```yaml
+---
+gamma:
+  format: document       # → DOCX
+---
+```
+
+```yaml
+---
+target: pptx             # → PPTX (also works)
+---
+```
+
+If no frontmatter or no recognized field, defaults to DOCX.
+
 ## Usage
 
 ```bash
-# Auto-target (DOCX by default in PR #1):
-claude-skills/skills/md-to-office/scripts/md-to-office.sh report.md
+# Auto-detect from frontmatter (presentation → PPTX, document → DOCX):
+md-to-office.sh deck.md           # PPTX if gamma.format = presentation
+md-to-office.sh report.md         # DOCX (default)
+
+# Explicit target:
+md-to-office.sh deck.md --target pptx
+md-to-office.sh report.md --target docx
 
 # Explicit template override:
 md-to-office.sh report.md --template path/to/custom.docx
 
 # Force re-render:
 md-to-office.sh report.md --force
+
+# Batch mode (converts every .md in directory, auto-detecting each):
+md-to-office.sh content/funding/
 ```
+
+## PPTX slide conventions
+
+- `# Title` → title slide (layout 0)
+- `## Section` → content slide with title
+- `### Sub` → subheading within current slide
+- `---` → explicit slide break
+- Bullet lists → bulleted text frame with nesting
+- GFM pipe tables → PPTX table shape
+- `![alt](path)` → embedded picture
+- `**bold**` / `*italic*` → inline formatting
+- Fenced code blocks → monospace text
 
 ## Output convention
 
 ```
-report.md                 →  report.docx
+report.md                 →  report.docx      (default / gamma.format: document)
+deck.md                   →  deck.pptx        (gamma.format: presentation)
 /tmp/note.md              →  /tmp/note.docx
 po/reports/2026-04-24.md  →  po/reports/2026-04-24.docx
 ```
@@ -143,15 +191,16 @@ po/reports/2026-04-24.md  →  po/reports/2026-04-24.docx
 | Tool | Install |
 |---|---|
 | `pandoc` ≥ 3.0 | `brew install pandoc` |
+| `python-pptx` | `pip3 install python-pptx` |
 
-Run `scripts/install-local.sh` to install on macOS.
+Run `scripts/install-local.sh` to install all dependencies on macOS.
 
-## Limits (v0.1)
+## Limits (v0.2)
 
-- **DOCX only.** PPTX and XLSX renderers land in later PRs per PRD-008
-  §12.
-- **No multi-file input.** One `.md` at a time; batch conversion is
-  deferred.
+- **XLSX not yet implemented.** The XLSX renderer lands in a future PR
+  per PRD-008 §12.
+- **Batch mode is flat.** Directory conversion only processes `.md`
+  files at the top level, not recursively.
 
 ---
 

--- a/claude-skills/skills/md-to-office/references/markdown-conventions.md
+++ b/claude-skills/skills/md-to-office/references/markdown-conventions.md
@@ -14,15 +14,17 @@ Pandoc handles the common markdown subset cleanly. Stick to:
 - **Links**: `[text](url)`. Pandoc renders them as Word hyperlinks.
 - **Images**: `![alt](path/to/img.png)`. Use relative paths so pandoc can resolve them at render time.
 
-## PPTX (PR #3, not yet implemented)
+## PPTX
 
-When the pptx renderer lands, the convention will be:
-
-- `# Title` → title slide (layout: `title`)
-- `## Section` → section-header slide (layout: `section`)
-- `### Content` or plain H2 with bullets → content slide (layout: `content`)
+- `# Title` → title slide (layout 0: Title Slide). Body text becomes subtitle.
+- `## Section` → content slide (layout 1: Title and Content)
+- `### Sub` → bold subheading within current slide
 - `---` (horizontal rule) → explicit slide break
-- Tables and images inside a section go on the same content slide
+- Bullet lists (dash, asterisk, numbered) → bulleted text frame with nesting (up to 2 levels)
+- GFM pipe tables → PPTX table shape positioned below content
+- `![alt](path)` → embedded picture (relative paths resolved from source dir)
+- `**bold**` / `*italic*` → inline formatting in runs
+- Fenced code blocks → monospace (Courier New) text
 
 ## XLSX (PR #4, not yet implemented)
 
@@ -31,16 +33,23 @@ from the preceding H2 (if any) or fall back to `Sheet1`, `Sheet2`, …
 
 ## Frontmatter hint
 
-The auto-target detector (post v0.1) will look at optional YAML
-frontmatter:
+The auto-target detector reads optional YAML frontmatter:
 
 ```markdown
 ---
-target: pptx
+gamma:
+  format: presentation
 ---
 
 # Slide 1
 ...
 ```
 
-This pins the target without needing a CLI flag.
+Supported fields (first match wins):
+- `gamma.format: presentation` → PPTX
+- `gamma.format: document` → DOCX
+- `target: pptx` → PPTX
+- `target: docx` → DOCX
+
+This pins the target without needing a CLI flag. An explicit
+`--target` override always wins over frontmatter.

--- a/claude-skills/skills/md-to-office/scripts/md-to-office.sh
+++ b/claude-skills/skills/md-to-office/scripts/md-to-office.sh
@@ -2,7 +2,8 @@
 # md-to-office orchestrator.
 #
 # Usage:
-#   md-to-office.sh <input.md> [--target docx] [--template <path>] [--out <path>] [--force]
+#   md-to-office.sh <input.md> [--target docx|pptx] [--template <path>] [--out <path>] [--force]
+#   md-to-office.sh <directory>  [--force]
 #   md-to-office.sh --init [--force] [--tokens-only]
 #   md-to-office.sh --install [--dry-run]
 #
@@ -11,7 +12,15 @@
 #   are automatically branded. Safe to re-run with --force after editing
 #   brand/tokens.json.
 #
-# Writes <input>.docx next to the source by default (or --out if given).
+# When --target is omitted, auto-detects from YAML frontmatter:
+#   gamma.format: presentation  ->  pptx
+#   gamma.format: document      ->  docx
+#   target: pptx                ->  pptx
+#   (no frontmatter)            ->  docx (default)
+#
+# Directory argument converts every .md file, picking format per file.
+#
+# Writes <input>.{docx,pptx} next to the source by default (or --out).
 # Idempotent: if output exists and is newer than input, skip unless
 # --force is set.
 
@@ -25,7 +34,7 @@ usage() {
 }
 
 src=""
-target="docx"
+target=""
 template=""
 out=""
 force=0
@@ -58,12 +67,61 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$src" ]] || usage 2
+
+# Batch mode: if src is a directory, convert every .md file in it.
+if [[ -d "$src" ]]; then
+  found=0
+  errors=0
+  while IFS= read -r -d '' mdfile; do
+    found=$((found + 1))
+    batch_args=("$mdfile")
+    [[ -n "$template" ]] && batch_args+=(--template "$template")
+    [[ $force -eq 1 ]]   && batch_args+=(--force)
+    # In batch mode, --target and --out are not forwarded; each file auto-detects.
+    if bash "$0" "${batch_args[@]}"; then
+      :
+    else
+      errors=$((errors + 1))
+    fi
+  done < <(find "$src" -maxdepth 1 -name '*.md' -print0 | sort -z)
+  if [[ $found -eq 0 ]]; then
+    echo "No .md files found in $src" >&2
+    exit 2
+  fi
+  [[ $errors -eq 0 ]] && exit 0 || exit 1
+fi
+
 [[ -f "$src" ]] || { echo "File not found: $src" >&2; exit 2; }
 
+# Auto-detect target from YAML frontmatter when --target not given.
+if [[ -z "$target" ]]; then
+  target="$(python3 -c "
+import re, sys
+text = open(sys.argv[1]).read()
+if not text.startswith('---\n'): sys.exit(0)
+end = text.find('\n---\n', 4)
+if end == -1:
+    end = text.find('\n---', 4)
+    if end == -1 or end + 4 < len(text.rstrip()): sys.exit(0)
+fm = text[4:end]
+m = re.search(r'^gamma:\s*\n\s+format:\s*(\S+)', fm, re.MULTILINE)
+if m:
+    fmt = m.group(1).strip()
+    if fmt == 'presentation': print('pptx')
+    elif fmt == 'document': print('docx')
+    sys.exit(0)
+m = re.search(r'^target:\s*(\S+)', fm, re.MULTILINE)
+if m:
+    t = m.group(1).strip()
+    if t in ('docx', 'pptx', 'xlsx'): print(t)
+" "$src" 2>/dev/null)" || true
+  [[ -n "$target" ]] || target="docx"
+fi
+
 case "$target" in
-  docx) ;;
-  pptx|xlsx)
-    echo "Target '$target' is not implemented in v0.1 (PR #1 ships DOCX only). See PRD-008 §12." >&2
+  docx|pptx) ;;
+  xlsx)
+    echo "Target 'xlsx' is not implemented yet. See PRD-008 §12." >&2
     exit 4
     ;;
   *)

--- a/claude-skills/skills/md-to-office/scripts/render-pptx.py
+++ b/claude-skills/skills/md-to-office/scripts/render-pptx.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""
+Render markdown to PPTX via python-pptx.
+
+Slide structure conventions:
+  # Title        -> title slide (layout 0: Title Slide)
+  ## Section     -> content slide (layout 1: Title and Content)
+  ### Sub        -> subheading within current slide
+  ---            -> explicit slide break
+
+Body content:
+  - Bullets      -> text frame with bullet paragraphs
+  | Tables |     -> PPTX table shape
+  ![alt](path)  -> embedded picture
+  **bold**       -> bold runs
+  *italic*       -> italic runs
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Markdown parser
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Slide:
+    layout: str  # "title" | "content"
+    title: str = ""
+    blocks: list = field(default_factory=list)
+
+
+def strip_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---\n", 4)
+    if end != -1:
+        return text[end + 5:]
+    end = text.find("\n---", 4)
+    if end != -1 and end + 4 >= len(text.rstrip()):
+        return ""
+    return text
+
+
+def _parse_table(lines: list[str]) -> dict:
+    rows = []
+    for line in lines:
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        rows.append(cells)
+    headers = rows[0] if rows else []
+    data = [r for r in rows[1:] if not all(re.match(r"^[-:]+$", c) for c in r)]
+    return {"headers": headers, "rows": data}
+
+
+def parse_markdown(text: str) -> list[Slide]:
+    body = strip_frontmatter(text)
+    lines = body.split("\n")
+    slides: list[Slide] = []
+    current: Slide | None = None
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        if re.match(r"^---\s*$", line):
+            if current:
+                slides.append(current)
+                current = None
+            i += 1
+            continue
+
+        m = re.match(r"^#\s+(.+)$", line)
+        if m:
+            if current:
+                slides.append(current)
+            current = Slide(layout="title", title=m.group(1).strip())
+            i += 1
+            continue
+
+        m = re.match(r"^##\s+(.+)$", line)
+        if m:
+            if current:
+                slides.append(current)
+            current = Slide(layout="content", title=m.group(1).strip())
+            i += 1
+            continue
+
+        m = re.match(r"^###\s+(.+)$", line)
+        if m:
+            if not current:
+                current = Slide(layout="content")
+            current.blocks.append(("heading", m.group(1).strip()))
+            i += 1
+            continue
+
+        if re.match(r"^\|.+\|", line):
+            table_lines = []
+            while i < len(lines) and re.match(r"^\|.+\|", lines[i]):
+                table_lines.append(lines[i])
+                i += 1
+            if not current:
+                current = Slide(layout="content")
+            current.blocks.append(("table", _parse_table(table_lines)))
+            continue
+
+        m = re.match(r"^!\[([^\]]*)\]\(([^)]+)\)\s*$", line)
+        if m:
+            if not current:
+                current = Slide(layout="content")
+            current.blocks.append(("image", {"alt": m.group(1), "path": m.group(2)}))
+            i += 1
+            continue
+
+        if re.match(r"^(\s*[-*+]|\s*\d+\.)\s", line):
+            bullets: list[tuple[int, str]] = []
+            while i < len(lines):
+                bm = re.match(r"^(\s*)([-*+]|\d+\.)\s+(.+)$", lines[i])
+                if bm:
+                    level = min(len(bm.group(1)) // 2, 2)
+                    bullets.append((level, bm.group(3).strip()))
+                    i += 1
+                elif lines[i].startswith("  ") and bullets:
+                    bullets[-1] = (bullets[-1][0], bullets[-1][1] + " " + lines[i].strip())
+                    i += 1
+                else:
+                    break
+            if not current:
+                current = Slide(layout="content")
+            current.blocks.append(("bullets", bullets))
+            continue
+
+        if line.startswith("```"):
+            code_lines: list[str] = []
+            i += 1
+            while i < len(lines) and not lines[i].startswith("```"):
+                code_lines.append(lines[i])
+                i += 1
+            if i < len(lines):
+                i += 1
+            if not current:
+                current = Slide(layout="content")
+            current.blocks.append(("code", "\n".join(code_lines)))
+            continue
+
+        if line.strip():
+            if not current:
+                current = Slide(layout="content")
+            current.blocks.append(("text", line.strip()))
+
+        i += 1
+
+    if current:
+        slides.append(current)
+
+    return slides
+
+
+# ---------------------------------------------------------------------------
+# PPTX renderer
+# ---------------------------------------------------------------------------
+
+def _find_layout(prs, name_hints: list[str], fallback_index: int):
+    for layout in prs.slide_layouts:
+        if layout.name.lower() in [h.lower() for h in name_hints]:
+            return layout
+    if fallback_index < len(prs.slide_layouts):
+        return prs.slide_layouts[fallback_index]
+    return prs.slide_layouts[0]
+
+
+def _remove_template_slides(prs):
+    from pptx.oxml.ns import qn
+
+    for sldId in list(prs.slides._sldIdLst):
+        rId = sldId.get(qn("r:id"))
+        if rId:
+            prs.part.drop_rel(rId)
+        prs.slides._sldIdLst.remove(sldId)
+
+
+def _add_rich_runs(paragraph, text: str) -> None:
+    parts = re.split(r"(\*\*[^*]+\*\*|\*[^*]+\*)", text)
+    for part in parts:
+        if not part:
+            continue
+        run = paragraph.add_run()
+        if part.startswith("**") and part.endswith("**"):
+            run.text = part[2:-2]
+            run.font.bold = True
+        elif part.startswith("*") and part.endswith("*"):
+            run.text = part[1:-1]
+            run.font.italic = True
+        else:
+            run.text = part
+
+
+def _add_table(slide, table_data: dict) -> None:
+    from pptx.util import Inches, Pt
+
+    headers = table_data["headers"]
+    rows = table_data["rows"]
+    if not headers:
+        return
+
+    n_cols = len(headers)
+    n_rows = len(rows) + 1
+
+    left = Inches(0.5)
+    top = Inches(2.5)
+    width = Inches(9)
+    row_height = Inches(0.35)
+
+    table = slide.shapes.add_table(
+        n_rows, n_cols, left, top, width, row_height * n_rows
+    ).table
+
+    col_width = int(Inches(9) / n_cols)
+    for ci in range(n_cols):
+        table.columns[ci].width = col_width
+
+    for ci, header in enumerate(headers):
+        cell = table.cell(0, ci)
+        cell.text = header
+        for p in cell.text_frame.paragraphs:
+            for r in p.runs:
+                r.font.bold = True
+                r.font.size = Pt(11)
+
+    for ri, row in enumerate(rows):
+        for ci, cell_text in enumerate(row):
+            if ci < n_cols:
+                cell = table.cell(ri + 1, ci)
+                cell.text = cell_text
+                for p in cell.text_frame.paragraphs:
+                    for r in p.runs:
+                        r.font.size = Pt(10)
+
+
+def render_pptx(
+    slides: list[Slide],
+    template_path: str | None,
+    output_path: str,
+    source_dir: str = ".",
+) -> None:
+    from pptx import Presentation
+    from pptx.util import Emu, Inches, Pt
+
+    if template_path and Path(template_path).exists():
+        prs = Presentation(template_path)
+        _remove_template_slides(prs)
+    else:
+        prs = Presentation()
+
+    prs.slide_width = Emu(9144000)
+    prs.slide_height = Emu(5143500)
+
+    title_layout = _find_layout(prs, ["Title Slide", "title"], 0)
+    content_layout = _find_layout(prs, ["Title and Content", "Title, Content"], 1)
+
+    for slide_data in slides:
+        if slide_data.layout == "title":
+            slide = prs.slides.add_slide(title_layout)
+            if slide.shapes.title:
+                slide.shapes.title.text = slide_data.title
+            subtitle_parts = [
+                d for t, d in slide_data.blocks if t == "text"
+            ]
+            if subtitle_parts:
+                for ph in slide.placeholders:
+                    if ph.placeholder_format.idx == 1:
+                        ph.text = "\n".join(subtitle_parts)
+                        break
+        else:
+            slide = prs.slides.add_slide(content_layout)
+            if slide.shapes.title and slide_data.title:
+                slide.shapes.title.text = slide_data.title
+
+            body_ph = None
+            for ph in slide.placeholders:
+                if ph.placeholder_format.idx == 1:
+                    body_ph = ph
+                    break
+
+            if body_ph is not None:
+                tf = body_ph.text_frame
+                tf.clear()
+                first = True
+
+                for btype, bdata in slide_data.blocks:
+                    if btype == "heading":
+                        p = tf.paragraphs[0] if first else tf.add_paragraph()
+                        first = False
+                        run = p.add_run()
+                        run.text = bdata
+                        run.font.bold = True
+                        run.font.size = Pt(18)
+
+                    elif btype == "bullets":
+                        for level, text in bdata:
+                            p = tf.paragraphs[0] if first else tf.add_paragraph()
+                            first = False
+                            p.level = level
+                            _add_rich_runs(p, text)
+
+                    elif btype == "text":
+                        p = tf.paragraphs[0] if first else tf.add_paragraph()
+                        first = False
+                        _add_rich_runs(p, bdata)
+
+                    elif btype == "code":
+                        p = tf.paragraphs[0] if first else tf.add_paragraph()
+                        first = False
+                        run = p.add_run()
+                        run.text = bdata
+                        run.font.name = "Courier New"
+                        run.font.size = Pt(10)
+
+                    elif btype == "image":
+                        img_path = Path(source_dir) / bdata["path"]
+                        if img_path.exists():
+                            slide.shapes.add_picture(
+                                str(img_path),
+                                Inches(1),
+                                Inches(3),
+                                width=Inches(8),
+                            )
+
+                    elif btype == "table":
+                        _add_table(slide, bdata)
+
+    prs.save(output_path)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render markdown to PPTX")
+    parser.add_argument("input", help="Input markdown file")
+    parser.add_argument("output", help="Output PPTX file")
+    parser.add_argument("--template", help="PPTX template file")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Input not found: {args.input}", file=sys.stderr)
+        sys.exit(2)
+
+    text = input_path.read_text(errors="replace")
+    slides = parse_markdown(text)
+
+    if not slides:
+        slides = [Slide(layout="title", title="(empty presentation)")]
+
+    render_pptx(slides, args.template, args.output, str(input_path.parent))
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-skills/skills/md-to-office/scripts/render-pptx.sh
+++ b/claude-skills/skills/md-to-office/scripts/render-pptx.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Render a markdown file to PPTX via python-pptx.
+#
+# Usage:
+#   render-pptx.sh <input.md> <output.pptx> [--template <path>]
+#
+# If --template is provided and the file exists, python-pptx uses it as
+# the base presentation so slide masters and branding flow through.
+# Otherwise a blank default presentation is used.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+input=""
+output=""
+template=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --template) template="${2:-}"; shift 2 ;;
+    -*) echo "Unknown flag: $1" >&2; exit 2 ;;
+    *)
+      if [[ -z "$input" ]]; then input="$1"; shift
+      elif [[ -z "$output" ]]; then output="$1"; shift
+      else echo "Too many positional args: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+[[ -n "$input"  ]] || { echo "Missing input path"  >&2; exit 2; }
+[[ -n "$output" ]] || { echo "Missing output path" >&2; exit 2; }
+[[ -f "$input"  ]] || { echo "Input not found: $input" >&2; exit 2; }
+
+if ! python3 -c "import pptx" 2>/dev/null; then
+  echo "python-pptx not installed. Run scripts/install-local.sh first." >&2
+  exit 3
+fi
+
+args=("$here/render-pptx.py" "$input" "$output")
+if [[ -n "$template" && -f "$template" ]]; then
+  args+=(--template "$template")
+fi
+
+python3 "${args[@]}"
+echo "$output"

--- a/claude-skills/tests/test_md_to_office.py
+++ b/claude-skills/tests/test_md_to_office.py
@@ -30,6 +30,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import textwrap
 import time
@@ -40,12 +41,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_DIR = REPO_ROOT / "claude-skills" / "skills" / "md-to-office"
 SCRIPTS = SKILL_DIR / "scripts"
 
-RESOLVE      = SCRIPTS / "resolve-template.sh"
-ORCH         = SCRIPTS / "md-to-office.sh"
-RENDER_DOCX  = SCRIPTS / "render-docx.sh"
-SCAN_BRAND   = SCRIPTS / "scan-brand.py"
+RESOLVE       = SCRIPTS / "resolve-template.sh"
+ORCH          = SCRIPTS / "md-to-office.sh"
+RENDER_DOCX   = SCRIPTS / "render-docx.sh"
+RENDER_PPTX   = SCRIPTS / "render-pptx.sh"
+RENDER_PPTX_PY = SCRIPTS / "render-pptx.py"
+SCAN_BRAND    = SCRIPTS / "scan-brand.py"
 GEN_TEMPLATES = SCRIPTS / "generate-templates.py"
-INIT_BRAND   = SCRIPTS / "init-brand.sh"
+INIT_BRAND    = SCRIPTS / "init-brand.sh"
 
 # Magic bytes of a ZIP archive — DOCX/PPTX/XLSX all use the ZIP container.
 ZIP_MAGIC = b"PK\x03\x04"
@@ -265,17 +268,94 @@ class TestOrchestrator(unittest.TestCase):
 
     # ---- target gating -----------------------------------------------------
 
-    def test_pptx_target_is_not_implemented_in_v01(self) -> None:
+    def test_pptx_target_accepted(self) -> None:
+        """pptx is now a valid target; the orchestrator should not reject it."""
+        try:
+            __import__("pptx")
+        except ImportError:
+            self.skipTest("python-pptx not installed")
         result = self._run_orch(str(self.src), "--target", "pptx", check=False)
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("not implemented", result.stderr)
+        self.assertEqual(result.returncode, 0)
+        out = self.tmp / "report.pptx"
+        self.assertTrue(out.exists(), f"expected {out}; stderr={result.stderr}")
 
-    def test_xlsx_target_is_not_implemented_in_v01(self) -> None:
+    def test_xlsx_target_is_not_implemented(self) -> None:
         result = self._run_orch(str(self.src), "--target", "xlsx", check=False)
         self.assertNotEqual(result.returncode, 0)
 
     def test_unknown_target_is_error(self) -> None:
         result = self._run_orch(str(self.src), "--target", "html", check=False)
+        self.assertNotEqual(result.returncode, 0)
+
+    # ---- auto-detection from frontmatter -----------------------------------
+
+    def test_autodetect_gamma_presentation_produces_pptx(self) -> None:
+        try:
+            __import__("pptx")
+        except ImportError:
+            self.skipTest("python-pptx not installed")
+        src = self.tmp / "deck.md"
+        src.write_text("---\ngamma:\n  format: presentation\n---\n# Deck\n\nSlide content.\n")
+        result = self._run_orch(str(src), check=False)
+        self.assertEqual(result.returncode, 0, f"stderr={result.stderr}")
+        self.assertTrue((self.tmp / "deck.pptx").exists())
+
+    def test_autodetect_gamma_document_produces_docx(self) -> None:
+        src = self.tmp / "report.md"
+        src.write_text("---\ngamma:\n  format: document\n---\n# Report\n\nBody.\n")
+        result = self._run_orch(str(src))
+        self.assertTrue((self.tmp / "report.docx").exists())
+
+    def test_autodetect_target_field_in_frontmatter(self) -> None:
+        try:
+            __import__("pptx")
+        except ImportError:
+            self.skipTest("python-pptx not installed")
+        src = self.tmp / "slides.md"
+        src.write_text("---\ntarget: pptx\n---\n# Slides\n\nContent.\n")
+        result = self._run_orch(str(src), check=False)
+        self.assertEqual(result.returncode, 0, f"stderr={result.stderr}")
+        self.assertTrue((self.tmp / "slides.pptx").exists())
+
+    def test_autodetect_no_frontmatter_defaults_to_docx(self) -> None:
+        result = self._run_orch(str(self.src))
+        self.assertTrue((self.tmp / "report.docx").exists())
+
+    def test_explicit_target_overrides_frontmatter(self) -> None:
+        src = self.tmp / "deck.md"
+        src.write_text("---\ngamma:\n  format: presentation\n---\n# Deck\n")
+        result = self._run_orch(str(src), "--target", "docx")
+        self.assertTrue((self.tmp / "deck.docx").exists())
+
+    # ---- batch mode --------------------------------------------------------
+
+    def test_batch_converts_directory(self) -> None:
+        batch_dir = self.tmp / "docs"
+        batch_dir.mkdir()
+        (batch_dir / "a.md").write_text("# Doc A\n\nBody.\n")
+        (batch_dir / "b.md").write_text("# Doc B\n\nBody.\n")
+        result = self._run_orch(str(batch_dir))
+        self.assertTrue((batch_dir / "a.docx").exists())
+        self.assertTrue((batch_dir / "b.docx").exists())
+
+    def test_batch_autodetects_per_file(self) -> None:
+        try:
+            __import__("pptx")
+        except ImportError:
+            self.skipTest("python-pptx not installed")
+        batch_dir = self.tmp / "mixed"
+        batch_dir.mkdir()
+        (batch_dir / "deck.md").write_text("---\ngamma:\n  format: presentation\n---\n# Deck\n")
+        (batch_dir / "doc.md").write_text("---\ngamma:\n  format: document\n---\n# Doc\n")
+        result = self._run_orch(str(batch_dir), check=False)
+        self.assertEqual(result.returncode, 0, f"stderr={result.stderr}")
+        self.assertTrue((batch_dir / "deck.pptx").exists())
+        self.assertTrue((batch_dir / "doc.docx").exists())
+
+    def test_batch_empty_dir_is_error(self) -> None:
+        empty = self.tmp / "empty"
+        empty.mkdir()
+        result = self._run_orch(str(empty), check=False)
         self.assertNotEqual(result.returncode, 0)
 
     # ---- missing input -----------------------------------------------------
@@ -676,6 +756,176 @@ class TestRenderDocxSmoke(unittest.TestCase):
         run(["bash", str(ORCH), str(self.src)], cwd=self.tmp)
         self.assertTrue(out.exists())
         self.assertTrue(out.read_bytes().startswith(ZIP_MAGIC))
+
+
+class TestMarkdownParser(unittest.TestCase):
+    """Covers the markdown-to-slides parser in render-pptx.py. Pure Python, no deps."""
+
+    def setUp(self) -> None:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("render_pptx", str(RENDER_PPTX_PY))
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["render_pptx"] = mod
+        spec.loader.exec_module(mod)
+        self.mod = mod
+
+    def test_h1_creates_title_slide(self) -> None:
+        slides = self.mod.parse_markdown("# Hello World\n")
+        self.assertEqual(len(slides), 1)
+        self.assertEqual(slides[0].layout, "title")
+        self.assertEqual(slides[0].title, "Hello World")
+
+    def test_h2_creates_content_slide(self) -> None:
+        slides = self.mod.parse_markdown("## Section One\n\nBody text.\n")
+        self.assertEqual(len(slides), 1)
+        self.assertEqual(slides[0].layout, "content")
+        self.assertEqual(slides[0].title, "Section One")
+
+    def test_multiple_h2_create_multiple_slides(self) -> None:
+        md = "## Slide 1\n\nText.\n\n## Slide 2\n\nMore text.\n"
+        slides = self.mod.parse_markdown(md)
+        self.assertEqual(len(slides), 2)
+
+    def test_horizontal_rule_creates_slide_break(self) -> None:
+        md = "## Slide A\n\nContent.\n\n---\n\n## Slide B\n\nContent.\n"
+        slides = self.mod.parse_markdown(md)
+        self.assertEqual(len(slides), 2)
+
+    def test_bullets_parsed(self) -> None:
+        md = "## List Slide\n\n- Item one\n- Item two\n"
+        slides = self.mod.parse_markdown(md)
+        self.assertEqual(len(slides), 1)
+        bullets_block = [b for b in slides[0].blocks if b[0] == "bullets"]
+        self.assertEqual(len(bullets_block), 1)
+        self.assertEqual(len(bullets_block[0][1]), 2)
+
+    def test_nested_bullets_have_levels(self) -> None:
+        md = "## Nested\n\n- Top\n  - Nested\n"
+        slides = self.mod.parse_markdown(md)
+        bullets = [b for b in slides[0].blocks if b[0] == "bullets"][0][1]
+        self.assertEqual(bullets[0][0], 0)  # level 0
+        self.assertEqual(bullets[1][0], 1)  # level 1
+
+    def test_table_parsed(self) -> None:
+        md = "## Data\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"
+        slides = self.mod.parse_markdown(md)
+        table_block = [b for b in slides[0].blocks if b[0] == "table"]
+        self.assertEqual(len(table_block), 1)
+        self.assertEqual(table_block[0][1]["headers"], ["A", "B"])
+        self.assertEqual(len(table_block[0][1]["rows"]), 1)
+
+    def test_image_parsed(self) -> None:
+        md = "## Pic\n\n![logo](img/logo.png)\n"
+        slides = self.mod.parse_markdown(md)
+        img_block = [b for b in slides[0].blocks if b[0] == "image"]
+        self.assertEqual(len(img_block), 1)
+        self.assertEqual(img_block[0][1]["path"], "img/logo.png")
+
+    def test_code_block_parsed(self) -> None:
+        md = "## Code\n\n```python\nprint('hi')\n```\n"
+        slides = self.mod.parse_markdown(md)
+        code_block = [b for b in slides[0].blocks if b[0] == "code"]
+        self.assertEqual(len(code_block), 1)
+        self.assertIn("print", code_block[0][1])
+
+    def test_frontmatter_stripped(self) -> None:
+        md = "---\ngamma:\n  format: presentation\n---\n# Title\n"
+        body = self.mod.strip_frontmatter(md)
+        self.assertNotIn("gamma", body)
+        self.assertIn("# Title", body)
+
+    def test_h3_stays_in_current_slide(self) -> None:
+        md = "## Main\n\n### Sub\n\nText.\n"
+        slides = self.mod.parse_markdown(md)
+        self.assertEqual(len(slides), 1)
+        headings = [b for b in slides[0].blocks if b[0] == "heading"]
+        self.assertEqual(len(headings), 1)
+        self.assertEqual(headings[0][1], "Sub")
+
+    def test_mixed_content_slide(self) -> None:
+        md = (
+            "# Title\n\nSubtitle.\n\n## Content\n\n"
+            "- Bullet\n\n| A |\n|---|\n| 1 |\n\nParagraph.\n"
+        )
+        slides = self.mod.parse_markdown(md)
+        self.assertEqual(len(slides), 2)
+        self.assertEqual(slides[0].layout, "title")
+        self.assertEqual(slides[1].layout, "content")
+        block_types = [b[0] for b in slides[1].blocks]
+        self.assertIn("bullets", block_types)
+        self.assertIn("table", block_types)
+        self.assertIn("text", block_types)
+
+
+class TestRenderPptxSmoke(unittest.TestCase):
+    """End-to-end PPTX render. Skipped when python-pptx isn't installed."""
+
+    def setUp(self) -> None:
+        try:
+            __import__("pptx")
+        except ImportError:
+            self.skipTest("python-pptx not installed; run scripts/install-local.sh")
+        self.tmp = Path(tempfile.mkdtemp(prefix="bsg-pptx-"))
+        self.src = self.tmp / "deck.md"
+        self.src.write_text(
+            "# Presentation Title\n\nSubtitle here.\n\n"
+            "## Slide One\n\n- Bullet **one**\n- Bullet *two*\n\n"
+            "## Slide Two\n\n| Col A | Col B |\n|-------|-------|\n| val 1 | val 2 |\n\n"
+            "## Slide Three\n\n```python\nprint('hello')\n```\n"
+        )
+
+    def tearDown(self) -> None:
+        if hasattr(self, "tmp"):
+            shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_renders_unbranded_pptx(self) -> None:
+        out = self.tmp / "deck.pptx"
+        result = run(
+            ["bash", str(RENDER_PPTX), str(self.src), str(out)],
+            cwd=self.tmp,
+        )
+        self.assertTrue(out.exists())
+        self.assertTrue(out.stat().st_size > 0)
+        self.assertTrue(out.read_bytes().startswith(ZIP_MAGIC))
+        self.assertEqual(result.returncode, 0)
+
+    def test_pptx_has_correct_slide_count(self) -> None:
+        out = self.tmp / "deck.pptx"
+        run(["bash", str(RENDER_PPTX), str(self.src), str(out)], cwd=self.tmp)
+        from pptx import Presentation
+        prs = Presentation(str(out))
+        self.assertEqual(len(prs.slides), 4)
+
+    def test_renders_end_to_end_via_orchestrator(self) -> None:
+        out = self.tmp / "deck.pptx"
+        run(
+            ["bash", str(ORCH), str(self.src), "--target", "pptx"],
+            cwd=self.tmp,
+        )
+        self.assertTrue(out.exists())
+        self.assertTrue(out.read_bytes().startswith(ZIP_MAGIC))
+
+    def test_autodetect_via_orchestrator(self) -> None:
+        src = self.tmp / "auto.md"
+        src.write_text("---\ngamma:\n  format: presentation\n---\n# Auto\n\nBody.\n")
+        run(["bash", str(ORCH), str(src)], cwd=self.tmp)
+        self.assertTrue((self.tmp / "auto.pptx").exists())
+
+    def test_renders_with_template(self) -> None:
+        from pptx import Presentation
+        tmpl_dir = self.tmp / "brand" / "templates"
+        tmpl_dir.mkdir(parents=True)
+        prs = Presentation()
+        tmpl_path = tmpl_dir / "template.pptx"
+        prs.save(str(tmpl_path))
+        out = self.tmp / "deck.pptx"
+        run(
+            ["bash", str(RENDER_PPTX), str(self.src), str(out),
+             "--template", str(tmpl_path)],
+            cwd=self.tmp,
+        )
+        self.assertTrue(out.exists())
+        self.assertTrue(out.stat().st_size > 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements #250 — three features for `md-to-office`:

- **PPTX renderer** (`render-pptx.py` + `render-pptx.sh`): converts markdown to PowerPoint using `python-pptx`. Maps `# H1` → title slide, `## H2` → content slide, `---` → slide break, plus bullets, tables, images, code blocks, and inline formatting. Uses `brand/templates/template.pptx` when available.
- **Auto-detection from frontmatter**: when `--target` is omitted, parses YAML frontmatter — `gamma.format: presentation` → PPTX, `gamma.format: document` → DOCX, `target: pptx` → PPTX. Falls back to DOCX.
- **Batch mode**: `md-to-office.sh <directory>` converts every `.md` file in it, auto-detecting format per file.

Bumps skill version to 0.2.0. Test suite grows from 55 → 80 tests.

## Test plan

- [x] 80/80 tests pass locally (`python3 claude-skills/tests/test_md_to_office.py`)
- [x] Verified PPTX output opens correctly (title slides, content slides, tables, bullets)
- [x] Auto-detection: `gamma.format: presentation` → `.pptx`, `gamma.format: document` → `.docx`
- [x] Batch mode: directory with mixed frontmatter produces correct `.pptx` / `.docx` per file
- [x] Explicit `--target docx` overrides presentation frontmatter
- [x] Existing DOCX behavior unchanged (all prior tests still pass)
- [x] `--target xlsx` still returns "not implemented" error
- [ ] CI passes

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)