### PR TITLE
chore(autopilot): raise max_prs_per_day 5 → 50

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -22,7 +22,7 @@ agents:
 
 budget:
   max_prs_per_tick: 1
-  max_prs_per_day: 5
+  max_prs_per_day: 50
   max_loc_per_issue: 30
   max_files_per_issue: 3
   max_issues_per_tick: 3


### PR DESCRIPTION
## Summary

Raises \`budget.max_prs_per_day\` from 5 to 50 in \`.bsg-autopilot.yml\` to allow a 3-minute \`/loop /tick-all\` sweep to clear the Wave 2/3/4 backlog without hitting the circuit-breaker.

The 5-PR/day cap was sized for steady-state hygiene; today we're catching up on a multi-week queue, so a temporary higher ceiling is appropriate.

## Test plan

- [x] File still parses (single-line edit, same YAML structure)
- [ ] After merge: launch \`/loop 3m /tick-all\` and observe PR creation rate
- [ ] After backlog clears: revert to 5 in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)