### PR TITLE
feat(autopilot): add auto_merge flag for fully autonomous implementation

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -27,6 +27,15 @@ budget:
   max_files_per_issue: 3
   max_issues_per_tick: 3
 
+# Fully autonomous mode — agents squash-merge their own implementation PRs
+# instead of stopping at needs-human-review. Only safe when:
+#   - Branch protection on main requires no reviews
+#   - The 30 LOC / 3 file pilot budget is accepted as a sufficient gate
+#   - Peer review is treated as advisory, not blocking
+# bsg-stack is the demonstrator and opts in here. See CLAUDE.md →
+# "Autopilot mode → auto_merge".
+auto_merge: true
+
 peer_review:
   tech:
     reviews: [qa, seo]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,10 +279,39 @@ preventing a runaway `/loop` from flooding the repo.
 
 **What stays the same in autopilot mode:**
 - Agents still open PRs with `needs-human-review` — a human merges
+  (unless `auto_merge: true` is set, see below)
 - `never-auto-implements` deny-list still applies
 - 30 LOC / 3 files budget still applies
 - One issue per agent per tick
 - `output: pr` agents are unaffected
+
+### Fully autonomous mode (`auto_merge: true`)
+
+Adding `auto_merge: true` to `.bsg-autopilot.yml` flips the
+finalization behavior of the 3 `output: commit` agents (tech-lead,
+qa, seo). Instead of stopping at `needs-human-review` after `gh pr
+create`, they call `auto-merge-or-flag.sh <pr> <agent>` which
+squash-merges the PR, deletes the branch, and stamps
+`human-reviewed`.
+
+**This is the only documented path for an agent to apply
+`human-reviewed`.** It is repo-scoped, opt-in via the autopilot
+file, and contingent on the calling agent being listed under
+`agents:`. Without `auto_merge: true`, the original "only humans
+apply human-reviewed" invariant still holds.
+
+**What you accept when you flip this flag:**
+- Implementation PRs land on main without a human in the loop
+- The 30 LOC / 3 file pilot budget becomes your only quality gate
+  (CI excepted — auto-merge respects branch protection if any)
+- Peer review (when configured) is purely advisory; reviews don't
+  block merges
+- A buggy agent or a poorly-labeled issue can pour broken commits
+  into main faster than you can read PRs
+
+bsg-stack opts in as the demonstrator repo. Other repos using the
+cached agents stay on the human-review default unless they set the
+flag themselves.
 
 ### Audit-to-issue pipeline (#222)
 
@@ -451,9 +480,13 @@ disposition call on it:
 | Automation (CI bots, Renovate, Dependabot) | ❌ No |
 
 **Hard rule: only a human may apply `human-reviewed`.** Agents MUST NOT add
-this label under any circumstance. If a non-human actor ever applies it,
-that is a bug in the applying automation. The label marks the *fact* of
-review, not the outcome — merge, close, and defer all count.
+this label under any circumstance — with one explicit, opt-in exception:
+when a repo sets `auto_merge: true` in `.bsg-autopilot.yml`, the
+`auto-merge-or-flag.sh` helper applies `human-reviewed` after squash-merging
+an implementation PR (see "Fully autonomous mode" above). Outside that
+single helper invocation, any non-human use of the label is still a bug.
+The label marks the *fact* of review, not the outcome — merge, close, and
+defer all count.
 
 How a human applies it — use the shared helper so the merge and the
 label swap are one atomic action:

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -199,11 +199,19 @@ When the tick's phase (B) runs, the procedure is:
    described in the issue, plus the smallest fix that makes it pass.
    Run the project's test harness — open the PR only if it passes.
 
-6. **Open the PR with `needs-human-review`.** Title:
+6. **Open the PR, then finalize via the helper.** Title:
    `fix(qa-pilot): <issue-title> (#NN)`. Body: summary of what was
    added + `Fixes #NN` to auto-close the source issue on merge.
-   Do **not** auto-merge. Do **not** apply `human-reviewed` — a human
-   owns that.
+   After `gh pr create`, run:
+
+   ```bash
+   bash claude-skills/scripts/auto-merge-or-flag.sh <pr-number> qa
+   ```
+
+   The helper reads `.bsg-autopilot.yml`. By default it stamps
+   `needs-human-review` and stops. If the repo opts in with
+   `auto_merge: true`, it squash-merges the PR and stamps
+   `human-reviewed`. Either way, never apply the labels yourself.
 
 7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
 

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -194,11 +194,19 @@ When the tick's phase (B) runs, the procedure is:
    has a lint or test harness that covers SEO elements, run it and only
    open the PR if it passes.
 
-6. **Open the PR with `needs-human-review`.** Title:
+6. **Open the PR, then finalize via the helper.** Title:
    `fix(seo-pilot): <issue-title> (#NN)`. Body: summary of what was
    added + `Fixes #NN` to auto-close the source issue on merge.
-   Do **not** auto-merge. Do **not** apply `human-reviewed` — a human
-   owns that.
+   After `gh pr create`, run:
+
+   ```bash
+   bash claude-skills/scripts/auto-merge-or-flag.sh <pr-number> seo
+   ```
+
+   The helper reads `.bsg-autopilot.yml`. By default it stamps
+   `needs-human-review` and stops. If the repo opts in with
+   `auto_merge: true`, it squash-merges the PR and stamps
+   `human-reviewed`. Either way, never apply the labels yourself.
 
 7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
 

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -192,10 +192,18 @@ When the tick's phase (B) runs, the procedure is:
    has no test harness, skip: log `pilot: skipping #NN — no test harness`
    and proceed to the next tick.
 
-6. **Open the PR with `needs-human-review`.** Title:
+6. **Open the PR, then finalize via the helper.** Title:
    `fix(pilot): <issue-title> (#NN)`. Body: summary + test-plan
-   checklist + link back to issue. Do **not** auto-merge. Do **not**
-   apply `human-reviewed` — a human owns that.
+   checklist + link back to issue. After `gh pr create`, run:
+
+   ```bash
+   bash claude-skills/scripts/auto-merge-or-flag.sh <pr-number> tech
+   ```
+
+   The helper reads `.bsg-autopilot.yml`. By default it stamps
+   `needs-human-review` and stops. If the repo opts in with
+   `auto_merge: true`, it squash-merges the PR and stamps
+   `human-reviewed`. Either way, never apply the labels yourself.
 
 7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
 

--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# auto-merge-or-flag.sh — finalize an implementation PR opened by an
+# output:commit agent.
+#
+# Default behavior (safe): apply `needs-human-review` and stop. A human
+# decides when to merge via `mark-reviewed.sh`.
+#
+# Auto-merge behavior: if `.bsg-autopilot.yml` exists with
+# `enabled: true`, lists the calling agent under `agents:`, AND has
+# `auto_merge: true`, this script squash-merges the PR, deletes the
+# branch, and stamps `human-reviewed` instead. Use this only on
+# repos where:
+#   - Branch protection on main does not require reviews
+#   - The 30 LOC / 3 file pilot budget + peer review are accepted
+#     as the only quality gates
+#
+# bsg-stack opts in as the demonstrator repo. Other repos using the
+# cached agents stay on the human-review default unless they too set
+# auto_merge: true.
+#
+# Usage:
+#   bash claude-skills/scripts/auto-merge-or-flag.sh <pr-number> <agent>
+#
+# Example:
+#   bash claude-skills/scripts/auto-merge-or-flag.sh 249 tech
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <pr-number> <agent>" >&2
+  exit 2
+fi
+
+PR_NUMBER="$1"
+AGENT="$2"
+
+AUTOPILOT_FILE=".bsg-autopilot.yml"
+AUTO_MERGE=false
+
+if [[ -f "$AUTOPILOT_FILE" ]]; then
+  enabled=$(grep -E '^\s*enabled\s*:' "$AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  auto_merge=$(grep -E '^\s*auto_merge\s*:' "$AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  if [[ "$enabled" == "true" ]] && [[ "$auto_merge" == "true" ]]; then
+    if grep -qE "^\s*-\s+$AGENT\s*$" "$AUTOPILOT_FILE" 2>/dev/null; then
+      AUTO_MERGE=true
+    fi
+  fi
+fi
+
+if [[ "$AUTO_MERGE" == "true" ]]; then
+  echo "auto-merge-or-flag: PR #${PR_NUMBER} ← squash + human-reviewed (autopilot)"
+  gh pr merge "$PR_NUMBER" --squash --delete-branch >/dev/null
+  gh pr edit "$PR_NUMBER" --add-label human-reviewed >/dev/null 2>&1 || true
+  gh pr edit "$PR_NUMBER" --remove-label needs-human-review >/dev/null 2>&1 || true
+else
+  echo "auto-merge-or-flag: PR #${PR_NUMBER} ← needs-human-review (default)"
+  gh pr edit "$PR_NUMBER" --add-label needs-human-review >/dev/null
+fi


### PR DESCRIPTION
## Summary

Adds an opt-in \`auto_merge: true\` flag to \`.bsg-autopilot.yml\`. When enabled for a calling agent, the new \`auto-merge-or-flag.sh\` helper:

1. Squash-merges the agent's implementation PR
2. Deletes the branch
3. Stamps \`human-reviewed\` (the only documented exception to "humans only")

bsg-stack opts in here as the demonstrator. Other repos using the cached agents stay on the original \`needs-human-review\` default.

## Files

- **`.bsg-autopilot.yml`** — adds \`auto_merge: true\` with a header comment explaining the trade-off
- **\`claude-skills/scripts/auto-merge-or-flag.sh\`** — new helper, reads the autopilot config and either merges or stamps \`needs-human-review\`
- **\`claude-skills/agents/{tech-lead,qa,seo}.md\`** — step 6 now calls the helper instead of hardcoding the label
- **\`CLAUDE.md\`** — documents the flag, the trade-offs, and the single exception to the "only humans apply human-reviewed" rule

## What you accept by enabling auto_merge on a repo

- Implementation PRs land on main without a human in the loop
- The 30 LOC / 3 file pilot budget + CI become your only quality gates
- Peer review (when configured) is purely advisory; reviews don't block merges
- A buggy agent or poorly-labeled issue can pour broken commits into main

## Test plan

- [x] \`test_skills.py\` passes (13 tests)
- [x] Helper exits 2 with usage when missing args
- [ ] After merge: \`/loop 3m /tick-all\` to drive Wave 2/3/4 backlog with auto-merge active
- [ ] Watch \`max_prs_per_day: 50\` ceiling — revert to 5 once backlog clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)