### PR TITLE
fix(tick): don't short-circuit phases (B) and (C) on unchanged audit

### DIFF
--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -15,7 +15,7 @@ output: commit
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim qa` to fetch any inbox items — today this returns empty because no `needs:qa` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh qa qa)"`.
-  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (A) Run the full QA audit (coverage + risk + flaky), archive the snapshot to
   qa/history/, land the report as qa/reports/YYYY-MM-DD-audit.md via
@@ -41,7 +41,7 @@ tick: >
   coverage and regression risk. Add a review comment and apply
   `peer-reviewed:qa` label. If issues found, also apply `needs-rework`.
   Never merge, never apply `human-reviewed`.
-  In chat, reply with one line: audit PR URL + pilot outcome (attempted / skipped / blocked).
+  In chat, reply with one line combining audit status and pilot outcome. Examples: "Tick: unchanged — see PR #X · pilot: no candidates", "Tick: 2 sb — PR #X · pilot: attempted #NN — PR #MM", "Tick: unchanged — see PR #X · pilot: blocked by circuit-breaker". The pilot segment must always be present and must be one of: `pilot: attempted #NN — PR #MM`, `pilot: no candidates`, `pilot: blocked by circuit-breaker`, `pilot: not authorized`.
 auto-implements:
   - "label:bug + label:qa + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes qa)"
   - "estimated fix size <= 30 LOC and touches <= 3 files"

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -16,7 +16,7 @@ output: commit
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim seo` to fetch any inbox items — today this returns empty because no `needs:seo` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh seo seo)"`.
-  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (A) Run the full SEO audit (meta + links + content + sitemap), land it
   as seo/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
@@ -44,7 +44,7 @@ tick: >
   regressions (removed meta tags, broken canonical, dropped structured data).
   Add a review comment and apply `peer-reviewed:seo` label. If issues found,
   also apply `needs-rework`. Never merge, never apply `human-reviewed`.
-  In chat, reply with one line: audit PR URL + pilot outcome (attempted / skipped / blocked).
+  In chat, reply with one line combining audit status and pilot outcome. Examples: "Tick: unchanged — see PR #X · pilot: no candidates", "Tick: 2 sb — PR #X · pilot: attempted #NN — PR #MM", "Tick: unchanged — see PR #X · pilot: blocked by circuit-breaker". The pilot segment must always be present and must be one of: `pilot: attempted #NN — PR #MM`, `pilot: no candidates`, `pilot: blocked by circuit-breaker`, `pilot: not authorized`.
 auto-implements:
   - "label:bug + label:seo + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes seo)"
   - "estimated fix size <= 30 LOC and touches <= 3 files"

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -15,7 +15,7 @@ output: commit
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim tech` to fetch any inbox items — today this returns empty because no `needs:tech` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh tech-lead tech)"`.
-  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
+  If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (A) Run the full architecture health check (deps + quality + debt + ADR gap
   detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md
@@ -41,7 +41,7 @@ tick: >
   quality issues, architecture fit, and naming conventions. Add a review
   comment and apply `peer-reviewed:tech` label. If issues found, also apply
   `needs-rework`. Never merge, never apply `human-reviewed`.
-  In chat, reply with one line: audit PR URL + pilot outcome (attempted / skipped / blocked).
+  In chat, reply with one line combining audit status and pilot outcome. Examples: "Tick: unchanged — see PR #X · pilot: no candidates", "Tick: 2 sb — PR #X · pilot: attempted #NN — PR #MM", "Tick: unchanged — see PR #X · pilot: blocked by circuit-breaker". The pilot segment must always be present and must be one of: `pilot: attempted #NN — PR #MM`, `pilot: no candidates`, `pilot: blocked by circuit-breaker`, `pilot: not authorized`.
 auto-implements:
   - "label:bug + label:tech + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes tech)"
   - "estimated fix size <= 30 LOC and touches <= 3 files"

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -462,6 +462,34 @@ class TestSharedSkills(unittest.TestCase):
                     f"frontmatter says output={scalars.get('output')}.",
                 )
 
+    # --------------------------------- tick short-circuit scope (#261)
+
+    def test_commit_agents_tick_does_not_short_circuit_phase_b(self) -> None:
+        """output: commit agents must not skip phase (B) on audit short-circuit.
+
+        The tick-fingerprint short-circuit only means the audit (A) is
+        unchanged. Phases (B) implementation pilot and (C) peer review have
+        independent triggers and must always run. See #261.
+        """
+        for path in list_agents():
+            with self.subTest(agent=path.stem):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match)
+                frontmatter = fm_match.group(1)
+                scalars = dict(FRONTMATTER_SCALAR_RE.findall(frontmatter))
+                if scalars.get("output") != "commit":
+                    continue
+                tick_body = self._extract_tick_body(frontmatter)
+                self.assertNotRegex(
+                    tick_body,
+                    r"SHORT_CIRCUIT.*and stop",
+                    f"{path.relative_to(REPO_ROOT)}: tick field instructs a "
+                    f"full stop on audit short-circuit, which blocks phase "
+                    f"(B) implementation pilot from running. The short-circuit "
+                    f"should only skip phases (A) and (A.5). See #261.",
+                )
+
     # ----------------------------------------- output:pr agents have exclusions
 
     def test_pr_agents_have_never_auto_implements_clauses(self) -> None:


### PR DESCRIPTION
## Summary

- **Step (0.5) in all 3 `output: commit` agents** (tech-lead, qa, seo) was saying "and stop" when `TICK_SHORT_CIRCUIT=1`, which killed the entire tick — phases (B) implementation pilot and (C) peer review never ran even though they have independent triggers
- Changed to "skip to (B)" so only phases (A) and (A.5) are gated by audit freshness; (B) and (C) always execute
- Updated receipt format to always include a `pilot:` segment (e.g. `Tick: unchanged — see PR #X · pilot: no candidates`)
- Added structural test in `test_skills.py` that catches the "SHORT_CIRCUIT.*and stop" anti-pattern for `output: commit` agents

Fixes #261

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — all 14 tests pass including the new `test_commit_agents_tick_does_not_short_circuit_phase_b`
- [ ] Run `@tech-lead tick` on a repo where today's report already exists and verify phase (B) runs `list-pilot-candidates.sh`
- [ ] Verify receipt includes both audit status and pilot outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)