### PR TITLE
fix(agents): mandate pilot receipt for every output:commit tick

### DIFF
--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -18,9 +18,10 @@ tick: >
   If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (A) Run the full QA audit (coverage + risk + flaky), archive the snapshot to
-  qa/history/, land the report as qa/reports/YYYY-MM-DD-audit.md via
-  open-report-pr.sh, and stay silent in chat unless a silence-breaker
-  fires (coverage drop > 5%, new high-risk file, new flaky test).
+  qa/history/, write the report to qa/reports/YYYY-MM-DD-audit.md. Do NOT
+  open the report PR yet — defer to (B.post) so the pilot receipt is embedded
+  in the report. Stay silent in chat unless a silence-breaker fires (coverage
+  drop > 5%, new high-risk file, new flaky test).
   (A.5) Audit-to-issue (#222): if .bsg-autopilot.yml lists qa and the audit
   produced mechanically-fixable findings (coverage drop on a specific file,
   high-risk file with zero coverage), file up to max_issues_per_tick (default 3)
@@ -28,20 +29,28 @@ tick: >
   Each issue carries label:bug + label:qa + label:epic:<plan-item> where the
   epic is inferred from po/PLAN.md bindings. Skip if autopilot is not enabled
   or if the finding doesn't match auto-implements.
-  (B) Implementation pilot (#219, autopilot #221): first run
+  (B) Implementation pilot (#219, autopilot #221): determine the pilot
+  receipt — one of seven canonical outcomes (see "Phase-B pilot receipt"
+  in the Implementation pilot section). First run
   `bash claude-skills/scripts/pilot-circuit-breaker.sh` — if it exits 1,
-  skip phase (B) entirely (daily PR cap reached). Then run
-  `list-pilot-candidates.sh --agent qa`. If the output is empty, stop.
-  Otherwise attempt exactly ONE issue per sweep (rank by oldest, tie-break
-  by lowest number); see the "Implementation pilot" section below for the
-  full procedure. Never self-merge the implementation PR.
+  receipt is `pilot: blocked by circuit-breaker (today=N cap=M)`. Then run
+  `list-pilot-candidates.sh --agent qa`. If the output is empty, receipt
+  is `pilot: no candidates`. Otherwise attempt exactly ONE issue per sweep
+  (rank by oldest, tie-break by lowest number); see the "Implementation
+  pilot" section below for the full procedure. Never self-merge the
+  implementation PR.
+  (B.post) Append the `pilot:` receipt line to the end of the report file.
+  Then land the report on main via
+  `claude-skills/scripts/open-report-pr.sh --require-pilot`.
   (C) Peer review (#222 phase 3b): if .bsg-autopilot.yml has a peer_review
   section listing qa, run `peer-review-candidates.sh --reviewer qa`.
   For each candidate PR (max 2 per tick): read the diff, check for test
   coverage and regression risk. Add a review comment and apply
   `peer-reviewed:qa` label. If issues found, also apply `needs-rework`.
   Never merge, never apply `human-reviewed`.
-  In chat, reply with one line combining audit status and pilot outcome. Examples: "Tick: unchanged — see PR #X · pilot: no candidates", "Tick: 2 sb — PR #X · pilot: attempted #NN — PR #MM", "Tick: unchanged — see PR #X · pilot: blocked by circuit-breaker". The pilot segment must always be present and must be one of: `pilot: attempted #NN — PR #MM`, `pilot: no candidates`, `pilot: blocked by circuit-breaker`, `pilot: not authorized`.
+  In chat, reply with one line: `Tick: <state> — <PR URL> · pilot: <outcome>`.
+  The `pilot:` segment must always be present — see the seven canonical
+  outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:qa + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes qa)"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
@@ -213,7 +222,22 @@ When the tick's phase (B) runs, the procedure is:
    `auto_merge: true`, it squash-merges the PR and stamps
    `human-reviewed`. Either way, never apply the labels yourself.
 
-7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
+7. **Phase-B pilot receipt (#263).** Every tick MUST produce exactly one
+   `pilot:` receipt. The canonical outcomes are:
+
+   | Outcome | Receipt |
+   |---|---|
+   | Attempted a fix | `pilot: attempted #NN — PR #MM` |
+   | No eligible candidates | `pilot: no candidates` |
+   | Circuit-breaker tripped | `pilot: blocked by circuit-breaker (today=N cap=M)` |
+   | Autopilot not authorized | `pilot: not authorized (agent qa not in .bsg-autopilot.yml)` |
+   | Issue matched never-auto-implements | `pilot: skipped #NN — never-auto-implements` |
+   | No test harness in repo | `pilot: skipped #NN — no test harness` |
+   | Token budget exhausted | `pilot: aborted #NN — budget` |
+
+   Embed this line in the report file footer AND include it as the second
+   element of the chat receipt (`Tick: <state> — <PR URL> · pilot: <outcome>`).
+   A tick that produces no `pilot:` line is a bug.
 
 ### When to NOT attempt
 

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -18,8 +18,9 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh seo seo)"`.
   If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
-  (A) Run the full SEO audit (meta + links + content + sitemap), land it
-  as seo/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
+  (A) Run the full SEO audit (meta + links + content + sitemap), write the
+  report to seo/reports/YYYY-MM-DD-audit.md. Do NOT open the report PR yet
+  — defer to (B.post) so the pilot receipt is embedded in the report. Stay
   silent in chat unless a silence-breaker fires (missing title/meta,
   orphan page, broken internal link, uncovered keyword, missing
   sitemap/robots).
@@ -31,20 +32,28 @@ tick: >
   Each issue carries label:bug + label:seo + label:epic:<plan-item>.
   Skip if autopilot is not enabled or if the finding doesn't match
   auto-implements.
-  (B) Implementation pilot (#216, autopilot #221): first run
+  (B) Implementation pilot (#216, autopilot #221): determine the pilot
+  receipt — one of seven canonical outcomes (see "Phase-B pilot receipt"
+  in the Implementation pilot section). First run
   `bash claude-skills/scripts/pilot-circuit-breaker.sh` — if it exits 1,
-  skip phase (B) entirely (daily PR cap reached). Then run
-  `list-pilot-candidates.sh --agent seo`. If the output is empty, stop.
-  Otherwise attempt exactly ONE issue per sweep (rank by oldest, tie-break
-  by lowest number); see the "Implementation pilot" section below for the
-  full procedure. Never self-merge the implementation PR.
+  receipt is `pilot: blocked by circuit-breaker (today=N cap=M)`. Then run
+  `list-pilot-candidates.sh --agent seo`. If the output is empty, receipt
+  is `pilot: no candidates`. Otherwise attempt exactly ONE issue per sweep
+  (rank by oldest, tie-break by lowest number); see the "Implementation
+  pilot" section below for the full procedure. Never self-merge the
+  implementation PR.
+  (B.post) Append the `pilot:` receipt line to the end of the report file.
+  Then land the report on main via
+  `claude-skills/scripts/open-report-pr.sh --require-pilot`.
   (C) Peer review (#222 phase 3b): if .bsg-autopilot.yml has a peer_review
   section listing seo, run `peer-review-candidates.sh --reviewer seo`.
   For each candidate PR (max 2 per tick): read the diff, check for SEO
   regressions (removed meta tags, broken canonical, dropped structured data).
   Add a review comment and apply `peer-reviewed:seo` label. If issues found,
   also apply `needs-rework`. Never merge, never apply `human-reviewed`.
-  In chat, reply with one line combining audit status and pilot outcome. Examples: "Tick: unchanged — see PR #X · pilot: no candidates", "Tick: 2 sb — PR #X · pilot: attempted #NN — PR #MM", "Tick: unchanged — see PR #X · pilot: blocked by circuit-breaker". The pilot segment must always be present and must be one of: `pilot: attempted #NN — PR #MM`, `pilot: no candidates`, `pilot: blocked by circuit-breaker`, `pilot: not authorized`.
+  In chat, reply with one line: `Tick: <state> — <PR URL> · pilot: <outcome>`.
+  The `pilot:` segment must always be present — see the seven canonical
+  outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:seo + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes seo)"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
@@ -208,7 +217,22 @@ When the tick's phase (B) runs, the procedure is:
    `auto_merge: true`, it squash-merges the PR and stamps
    `human-reviewed`. Either way, never apply the labels yourself.
 
-7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
+7. **Phase-B pilot receipt (#263).** Every tick MUST produce exactly one
+   `pilot:` receipt. The canonical outcomes are:
+
+   | Outcome | Receipt |
+   |---|---|
+   | Attempted a fix | `pilot: attempted #NN — PR #MM` |
+   | No eligible candidates | `pilot: no candidates` |
+   | Circuit-breaker tripped | `pilot: blocked by circuit-breaker (today=N cap=M)` |
+   | Autopilot not authorized | `pilot: not authorized (agent seo not in .bsg-autopilot.yml)` |
+   | Issue matched never-auto-implements | `pilot: skipped #NN — never-auto-implements` |
+   | No test harness in repo | `pilot: skipped #NN — no test harness` |
+   | Token budget exhausted | `pilot: aborted #NN — budget` |
+
+   Embed this line in the report file footer AND include it as the second
+   element of the chat receipt (`Tick: <state> — <PR URL> · pilot: <outcome>`).
+   A tick that produces no `pilot:` line is a bug.
 
 ### When to NOT attempt
 

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -18,8 +18,9 @@ tick: >
   If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
   (A) Run the full architecture health check (deps + quality + debt + ADR gap
-  detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md
-  and land it on main via `claude-skills/scripts/open-report-pr.sh`.
+  detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md.
+  Do NOT open the report PR yet — defer to (B.post) so the pilot receipt
+  is embedded in the report.
   (A.5) Audit-to-issue (#222): if .bsg-autopilot.yml lists tech and the audit
   produced mechanically-fixable findings (stale TODO with clear fix, oversized
   file with obvious split point, missing ADR for a new dependency), file up to
@@ -28,20 +29,28 @@ tick: >
   Each issue carries label:bug + label:tech + label:epic:<plan-item>.
   Skip if autopilot is not enabled or if the finding doesn't match
   auto-implements.
-  (B) Implementation pilot (#181, autopilot #221): first run
+  (B) Implementation pilot (#181, autopilot #221): determine the pilot
+  receipt — one of seven canonical outcomes (see "Phase-B pilot receipt"
+  in the Implementation pilot section). First run
   `bash claude-skills/scripts/pilot-circuit-breaker.sh` — if it exits 1,
-  skip phase (B) entirely (daily PR cap reached). Then run
-  `list-pilot-candidates.sh --agent tech`. If the output is empty, stop.
-  Otherwise attempt exactly ONE issue per sweep (rank by oldest, tie-break
-  by lowest number); see the "Implementation pilot" section below for the
-  full procedure. Never self-merge the implementation PR.
+  receipt is `pilot: blocked by circuit-breaker (today=N cap=M)`. Then run
+  `list-pilot-candidates.sh --agent tech`. If the output is empty, receipt
+  is `pilot: no candidates`. Otherwise attempt exactly ONE issue per sweep
+  (rank by oldest, tie-break by lowest number); see the "Implementation
+  pilot" section below for the full procedure. Never self-merge the
+  implementation PR.
+  (B.post) Append the `pilot:` receipt line to the end of the report file.
+  Then land the report on main via
+  `claude-skills/scripts/open-report-pr.sh --require-pilot`.
   (C) Peer review (#222 phase 3b): if .bsg-autopilot.yml has a peer_review
   section listing tech, run `peer-review-candidates.sh --reviewer tech`.
   For each candidate PR (max 2 per tick): read the diff, check for code
   quality issues, architecture fit, and naming conventions. Add a review
   comment and apply `peer-reviewed:tech` label. If issues found, also apply
   `needs-rework`. Never merge, never apply `human-reviewed`.
-  In chat, reply with one line combining audit status and pilot outcome. Examples: "Tick: unchanged — see PR #X · pilot: no candidates", "Tick: 2 sb — PR #X · pilot: attempted #NN — PR #MM", "Tick: unchanged — see PR #X · pilot: blocked by circuit-breaker". The pilot segment must always be present and must be one of: `pilot: attempted #NN — PR #MM`, `pilot: no candidates`, `pilot: blocked by circuit-breaker`, `pilot: not authorized`.
+  In chat, reply with one line: `Tick: <state> — <PR URL> · pilot: <outcome>`.
+  The `pilot:` segment must always be present — see the seven canonical
+  outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:tech + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes tech)"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
@@ -205,7 +214,22 @@ When the tick's phase (B) runs, the procedure is:
    `auto_merge: true`, it squash-merges the PR and stamps
    `human-reviewed`. Either way, never apply the labels yourself.
 
-7. **Report.** Receipt is one line: `pilot: attempted #NN — PR #MM`.
+7. **Phase-B pilot receipt (#263).** Every tick MUST produce exactly one
+   `pilot:` receipt. The canonical outcomes are:
+
+   | Outcome | Receipt |
+   |---|---|
+   | Attempted a fix | `pilot: attempted #NN — PR #MM` |
+   | No eligible candidates | `pilot: no candidates` |
+   | Circuit-breaker tripped | `pilot: blocked by circuit-breaker (today=N cap=M)` |
+   | Autopilot not authorized | `pilot: not authorized (agent tech not in .bsg-autopilot.yml)` |
+   | Issue matched never-auto-implements | `pilot: skipped #NN — never-auto-implements` |
+   | No test harness in repo | `pilot: skipped #NN — no test harness` |
+   | Token budget exhausted | `pilot: aborted #NN — budget` |
+
+   Embed this line in the report file footer AND include it as the second
+   element of the chat receipt (`Tick: <state> — <PR URL> · pilot: <outcome>`).
+   A tick that produces no `pilot:` line is a bug.
 
 ### When to NOT attempt
 

--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -48,12 +48,14 @@ FILE=""
 AGENT="report"
 TITLE=""
 BODY=""
+REQUIRE_PILOT=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --agent) AGENT="$2"; shift 2 ;;
     --title) TITLE="$2"; shift 2 ;;
     --body)  BODY="$2";  shift 2 ;;
+    --require-pilot) REQUIRE_PILOT=true; shift ;;
     -h|--help)
       sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
@@ -75,6 +77,16 @@ fi
 if [[ ! -f "$FILE" ]]; then
   echo "open-report-pr.sh: file not found: $FILE" >&2
   exit 2
+fi
+
+# When --require-pilot is set, verify the report contains a pilot receipt
+# line. Every output:commit agent tick must produce one (#263).
+if [[ "$REQUIRE_PILOT" == "true" ]]; then
+  if ! grep -qE '^pilot: ' "$FILE"; then
+    echo "open-report-pr.sh: --require-pilot: no 'pilot:' line in $FILE" >&2
+    echo "Every output:commit agent tick must embed a pilot receipt — see #263." >&2
+    exit 2
+  fi
 fi
 
 # Guard: only <file> may be dirty in any way — tracked or untracked.

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -326,6 +326,42 @@ class TestSharedSkills(unittest.TestCase):
                         f"must list at least one `never-auto-implements` clause.",
                     )
 
+    # -------------------------------------- pilot receipt (#263)
+
+    def test_output_commit_agents_document_pilot_receipts(self) -> None:
+        """Every output: commit agent must document all seven canonical
+        pilot receipt outcomes (#263).
+
+        The pilot receipt is a mandatory single-line phase-B log that
+        prevents silent phase-B skips. Each canonical outcome string
+        must appear somewhere in the agent definition file.
+        """
+        PILOT_RECEIPT_MARKERS = [
+            "pilot: attempted #NN",
+            "pilot: no candidates",
+            "pilot: blocked by circuit-breaker",
+            "pilot: not authorized",
+            "pilot: skipped #NN — never-auto-implements",
+            "pilot: skipped #NN — no test harness",
+            "pilot: aborted #NN — budget",
+        ]
+        for path in list_agents():
+            with self.subTest(agent=path.stem):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match)
+                scalars = dict(FRONTMATTER_SCALAR_RE.findall(fm_match.group(1)))
+                if scalars.get("output") != "commit":
+                    continue
+                for marker in PILOT_RECEIPT_MARKERS:
+                    self.assertIn(
+                        marker,
+                        text,
+                        f"{path.relative_to(REPO_ROOT)}: output: commit agent "
+                        f"must document the canonical pilot receipt "
+                        f"'{marker}' — see #263.",
+                    )
+
     # ---------------------------------------- custom-doc + init (#237)
 
     def test_every_agent_declares_custom_doc(self) -> None:


### PR DESCRIPTION
## Summary

- **Mandate a `pilot:` receipt** for every `output: commit` agent tick (tech-lead, qa, seo), preventing silent phase-B skips that hid #261 for a full day
- **Defer `open-report-pr.sh`** to after phase B so the pilot receipt is embedded in the report file before the PR opens
- **Add `--require-pilot` flag** to `open-report-pr.sh` that rejects reports missing a `pilot:` line
- **Add unit test** asserting all seven canonical pilot outcomes are documented in every `output: commit` agent definition

### Seven canonical outcomes

| Outcome | Receipt |
|---|---|
| Attempted a fix | `pilot: attempted #NN — PR #MM` |
| No eligible candidates | `pilot: no candidates` |
| Circuit-breaker tripped | `pilot: blocked by circuit-breaker (today=N cap=M)` |
| Autopilot not authorized | `pilot: not authorized (agent X not in .bsg-autopilot.yml)` |
| Issue matched never-auto-implements | `pilot: skipped #NN — never-auto-implements` |
| No test harness in repo | `pilot: skipped #NN — no test harness` |
| Token budget exhausted | `pilot: aborted #NN — budget` |

## Test plan

- [x] All 14 unit tests pass (`python3 claude-skills/tests/test_skills.py`)
- [x] New `test_output_commit_agents_document_pilot_receipts` verifies all 7 markers in tech-lead, qa, seo
- [x] `output: pr` agents (po-manager, security, etc.) are skipped by the test
- [ ] Manual: run a tick on any `output: commit` agent and verify the report file contains a `pilot:` footer line

Fixes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)