### PR TITLE
fix(pilot): lock chosen candidate in list-pilot-candidates.sh (#269)

### DIFF
--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -13,6 +13,10 @@
 # both human-reviewed and safe-to-automate label filters are dropped —
 # the repo-level marker replaces per-issue gates. See #221.
 #
+# After emitting the candidate list, the first (top) candidate is locked
+# via bus_lock so concurrent ticks don't race on the same issue. The lock
+# is best-effort — a failure never aborts the script. See #269.
+#
 # Usage:
 #   bash claude-skills/scripts/list-pilot-candidates.sh [--agent NAME] [--repo OWNER/NAME]
 #
@@ -20,6 +24,11 @@
 # Exit 0 always (no candidate is not an error).
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source bus primitives (best-effort — missing file is non-fatal).
+# shellcheck source=claude-skills/scripts/github-bus.sh
+source "$SCRIPT_DIR/github-bus.sh" 2>/dev/null || true
 
 AGENT="tech"
 REPO_FLAG=()
@@ -67,7 +76,7 @@ candidates_json=$(gh issue list "${REPO_FLAG[@]}" \
 #   - at least one epic:* label
 #   - no open PR already touching this issue (avoid re-attempting)
 # Emit one JSON object per line.
-jq -c '
+filtered=$(jq -c '
   .[]
   | select(.labels | any(.name | startswith("epic:")))
   | {
@@ -76,4 +85,12 @@ jq -c '
       url,
       epics: [.labels[].name | select(startswith("epic:"))]
     }
-' <<<"$candidates_json"
+' <<<"$candidates_json")
+
+echo "$filtered"
+
+# Lock the first candidate best-effort so concurrent ticks don't race. #269
+if [[ -n "$filtered" ]]; then
+  first_num=$(echo "$filtered" | head -1 | jq -r '.number')
+  bus_lock "$first_num" "$AGENT" 2>/dev/null || true
+fi

--- a/claude-skills/tests/test_pilot_candidates.sh
+++ b/claude-skills/tests/test_pilot_candidates.sh
@@ -46,16 +46,21 @@ assert_not_contains() {
 }
 
 # --- Mock gh: captures the arguments passed to `gh issue list` ---
-# The mock writes all args to a file and emits a canned JSON response.
+# Only records args for `issue list` calls; silently ignores `issue edit`
+# (bus_lock) so those don't overwrite the captured list-call args.
 MOCK_GH="$TMPDIR_TEST/gh"
 GH_ARGS_FILE="$TMPDIR_TEST/gh_args"
 cat > "$MOCK_GH" <<'MOCK'
 #!/usr/bin/env bash
-echo "$@" > "$GH_ARGS_FILE"
-# Return one issue with an epic label so jq post-filter passes it through.
-cat <<'JSON'
+# Only capture args for `gh issue list` calls.
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  # Return one issue with an epic label so jq post-filter passes it through.
+  cat <<'JSON'
 [{"number":67,"title":"test issue","url":"https://example.com/67","labels":[{"name":"bug"},{"name":"tech"},{"name":"epic:E2"}]}]
 JSON
+fi
+# bus_lock calls `gh issue edit` — succeed silently.
 MOCK
 chmod +x "$MOCK_GH"
 export GH_ARGS_FILE
@@ -120,10 +125,12 @@ echo "--- Test 5: epic filter ---"
 # Mock gh returns an issue WITHOUT an epic label.
 cat > "$MOCK_GH" <<'MOCK2'
 #!/usr/bin/env bash
-echo "$@" > "$GH_ARGS_FILE"
-cat <<'JSON'
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
 [{"number":99,"title":"no epic","url":"https://example.com/99","labels":[{"name":"bug"},{"name":"tech"}]}]
 JSON
+fi
 MOCK2
 chmod +x "$MOCK_GH"
 
@@ -140,8 +147,10 @@ echo "--- Test 6: regression guard — needs-human-review never in label flags -
 # Restore normal mock.
 cat > "$MOCK_GH" <<'MOCK3'
 #!/usr/bin/env bash
-echo "$@" > "$GH_ARGS_FILE"
-echo '[]'
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  echo '[]'
+fi
 MOCK3
 chmod +x "$MOCK_GH"
 
@@ -158,6 +167,29 @@ YAML
 bash "$SUT" --agent tech >/dev/null 2>&1
 ARGS="$(cat "$GH_ARGS_FILE")"
 assert_not_contains "T6b: no needs-human-review (autopilot)" "$ARGS" "needs-human-review"
+
+# ---------- Test 7: bus_lock called on first candidate ----------
+echo "--- Test 7: bus_lock invoked on first candidate ---"
+GH_LOCK_FILE="$TMPDIR_TEST/gh_lock_args"
+cat > "$MOCK_GH" <<'MOCK4'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
+[{"number":42,"title":"lock me","url":"https://example.com/42","labels":[{"name":"bug"},{"name":"tech"},{"name":"epic:E1"}]}]
+JSON
+elif [[ "${2:-}" == "edit" ]]; then
+  echo "$@" > "$GH_LOCK_FILE"
+fi
+MOCK4
+chmod +x "$MOCK_GH"
+export GH_LOCK_FILE
+
+rm -f "$TMPDIR_TEST/.bsg-autopilot.yml"
+bash "$SUT" --agent tech >/dev/null 2>&1
+LOCK_ARGS="$(cat "$GH_LOCK_FILE" 2>/dev/null || echo "")"
+assert_contains "T7: bus_lock adds agent:lock:tech" "$LOCK_ARGS" "agent:lock:tech"
+assert_contains "T7: bus_lock targets issue 42" "$LOCK_ARGS" "42"
 
 # ---------- Summary ----------
 echo ""


### PR DESCRIPTION
## Summary

- Sources `github-bus.sh` in `list-pilot-candidates.sh` and calls `bus_lock <number> <agent>` on the first returned candidate after emitting the list.
- Lock is best-effort (`|| true`) — a labeling failure never aborts the script or breaks callers.
- Extends `test_pilot_candidates.sh` with T7 to verify the `bus_lock` call reaches `gh issue edit` with the correct issue number and label.

## Test plan

- [x] `bash claude-skills/tests/test_pilot_candidates.sh` — 20/20 pass (T7 new)
- [x] `bash claude-skills/tests/test_github_bus.sh` — 2/2 pass (unchanged)
- [x] Diff: 21 LOC in script + 38 LOC in test, 2 files (within 30 LOC / 3 files budget for the script change itself)

Fixes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)