### PR TITLE
fix(pilot): release pilot lock in auto-merge-or-flag.sh (#270)

### DIFF
--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -26,6 +26,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=claude-skills/scripts/github-bus.sh
+source "$SCRIPT_DIR/github-bus.sh"
+
 if [[ $# -lt 2 ]]; then
   echo "usage: $0 <pr-number> <agent>" >&2
   exit 2
@@ -47,12 +51,20 @@ if [[ -f "$AUTOPILOT_FILE" ]]; then
   fi
 fi
 
+# Resolve the linked issue from the PR body (Fixes/Closes/Refs #NN).
+LINKED_ISSUE=""
+LINKED_ISSUE=$(gh pr view "$PR_NUMBER" --json body --jq '.body' \
+  | grep -oE '(Fixes|Closes|Refs) #[0-9]+' | head -1 \
+  | grep -oE '[0-9]+') || true
+
 if [[ "$AUTO_MERGE" == "true" ]]; then
   echo "auto-merge-or-flag: PR #${PR_NUMBER} ← squash + human-reviewed (autopilot)"
   gh pr merge "$PR_NUMBER" --squash --delete-branch >/dev/null
   gh pr edit "$PR_NUMBER" --add-label human-reviewed >/dev/null 2>&1 || true
   gh pr edit "$PR_NUMBER" --remove-label needs-human-review >/dev/null 2>&1 || true
+  [[ -n "$LINKED_ISSUE" ]] && bus_unlock "$LINKED_ISSUE" "$AGENT" || true
 else
   echo "auto-merge-or-flag: PR #${PR_NUMBER} ← needs-human-review (default)"
   gh pr edit "$PR_NUMBER" --add-label needs-human-review >/dev/null
+  [[ -n "$LINKED_ISSUE" ]] && bus_unlock "$LINKED_ISSUE" "$AGENT" || true
 fi

--- a/claude-skills/tests/test_github_bus.sh
+++ b/claude-skills/tests/test_github_bus.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SUT="$REPO_ROOT/claude-skills/scripts/github-bus.sh"
+AMOF="$REPO_ROOT/claude-skills/scripts/auto-merge-or-flag.sh"
 
 TMPDIR_TEST="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
@@ -36,15 +37,30 @@ assert_json_eq() {
   fi
 }
 
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected to contain: $needle"
+    echo "  got: $haystack"
+  fi
+}
+
 # ── Mock gh ──────────────────────────────────────────────────────────────────
 MOCK_GH="$TMPDIR_TEST/gh"
 GH_RESPONSE_FILE="$TMPDIR_TEST/gh_response"
+GH_CALLS_FILE="$TMPDIR_TEST/gh_calls"
 cat > "$MOCK_GH" <<'MOCK'
 #!/usr/bin/env bash
-cat "$GH_RESPONSE_FILE"
+echo "$*" >> "$GH_CALLS_FILE"
+cat "$GH_RESPONSE_FILE" 2>/dev/null || true
 MOCK
 chmod +x "$MOCK_GH"
 export GH_RESPONSE_FILE
+export GH_CALLS_FILE
 export PATH="$TMPDIR_TEST:$PATH"
 
 # ── Test 1 (positive): unlocked issue → bus_claim returns its number ─────────
@@ -64,6 +80,34 @@ JSON
 
 RESULT=$(bash -c "source \"$SUT\"; bus_claim tech" 2>/dev/null)
 assert_json_eq "T2: locked issue excluded" "$RESULT" "[]"
+
+# ── Test 3: auto-merge-or-flag calls bus_unlock when PR body has Fixes #NN ───
+echo "--- Test 3: bus_unlock called on auto-merge path when Fixes #NN present ---"
+> "$GH_CALLS_FILE"
+
+# Isolated working dir with its own .bsg-autopilot.yml
+WORKDIR="$TMPDIR_TEST/workdir"
+mkdir -p "$WORKDIR"
+cat > "$WORKDIR/.bsg-autopilot.yml" <<'YAML'
+enabled: true
+auto_merge: true
+agents:
+  - tech
+YAML
+
+# gh mock: pr view returns body with Fixes #270; all other calls succeed silently
+cat > "$GH_RESPONSE_FILE" <<'JSON'
+{"body":"fix(pilot): Release pilot lock (#270)\n\nFixes #270\n"}
+JSON
+
+(
+  cd "$WORKDIR"
+  bash "$AMOF" 99 tech 2>/dev/null || true
+)
+
+assert_contains "T3: bus_unlock removes lock label" \
+  "$(cat "$GH_CALLS_FILE")" \
+  "issue edit 270 --remove-label agent:lock:tech"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- Source `github-bus.sh` in `auto-merge-or-flag.sh` so `bus_unlock` is available.
- Parse `Fixes/Closes/Refs #NN` from the PR body to identify the linked issue.
- Call `bus_unlock <issue> <agent> || true` on **both** exit paths: after squash-merge (autopilot) and after flagging with `needs-human-review` (default).
- Add Test 3 to `test_github_bus.sh`: stubs `gh`, runs `auto-merge-or-flag.sh` in autopilot mode with a `Fixes #270` body, asserts `issue edit 270 --remove-label agent:lock:tech` is captured.

Fixes #270

## Test plan

- [x] `bash claude-skills/tests/test_github_bus.sh` — 3 tests pass (T1, T2, T3)
- [x] `bash claude-skills/tests/test_pilot_candidates.sh` — 20 tests pass, no regressions
- [x] `bus_unlock` is wrapped `|| true` — a missing label never breaks the merge script
- [x] No linked issue → `LINKED_ISSUE` is empty string → no-op (no unlock call)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)