### PR TITLE
fix(autopilot): swap labels before merge to avoid race

### DIFF
--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -59,9 +59,10 @@ LINKED_ISSUE=$(gh pr view "$PR_NUMBER" --json body --jq '.body' \
 
 if [[ "$AUTO_MERGE" == "true" ]]; then
   echo "auto-merge-or-flag: PR #${PR_NUMBER} ← squash + human-reviewed (autopilot)"
+  # Swap labels BEFORE merging — `gh pr edit` after `--delete-branch` can hit
+  # a transient eventual-consistency window where the edit silently no-ops.
+  gh pr edit "$PR_NUMBER" --add-label human-reviewed --remove-label needs-human-review >/dev/null 2>&1 || true
   gh pr merge "$PR_NUMBER" --squash --delete-branch >/dev/null
-  gh pr edit "$PR_NUMBER" --add-label human-reviewed >/dev/null 2>&1 || true
-  gh pr edit "$PR_NUMBER" --remove-label needs-human-review >/dev/null 2>&1 || true
   [[ -n "$LINKED_ISSUE" ]] && bus_unlock "$LINKED_ISSUE" "$AGENT" || true
 else
   echo "auto-merge-or-flag: PR #${PR_NUMBER} ← needs-human-review (default)"


### PR DESCRIPTION
## Summary

PR #273 merged without `human-reviewed` because `gh pr edit --add-label` runs after `gh pr merge --delete-branch` in `auto-merge-or-flag.sh`. That ordering hits a brief eventual-consistency window where the edit silently no-ops, and the existing `2>&1 || true` swallows the failure.

Move the label swap **before** the merge so the PR is stable when labeled. Combine add+remove into one `gh pr edit` call.

## Verification

- `bash claude-skills/tests/test_github_bus.sh` → 3/3 pass
- This PR is itself merged via the new code path (`auto-merge-or-flag.sh` from this branch), self-validating

## Context

Found while breaking #199 into pilot-budget slices. PRs #271 and #272 happened to land cleanly, #273 missed the label. The retroactive label swap on #273 and issue #270 has already been applied manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)