### PR TITLE
feat(autopilot): expand auto-implements to include label:enhancement (#282)

### DIFF
--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -53,6 +53,7 @@ tick: >
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:qa + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes qa)"
+  - "label:enhancement + label:qa + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes qa) + estimated fix size <= 30 LOC and touches <= 3 files"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
   - "finding is a missing test for a regression (reproduces failure, then asserts fix)"
 never-auto-implements:

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -56,6 +56,7 @@ tick: >
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:seo + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes seo)"
+  - "label:enhancement + label:seo + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes seo) + estimated fix size <= 30 LOC and touches <= 3 files"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
   - "finding is a missing HTML element (canonical tag, meta description, alt text, structured data)"
 never-auto-implements:

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -53,6 +53,7 @@ tick: >
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:tech + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes tech)"
+  - "label:enhancement + label:tech + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes tech) + estimated fix size <= 30 LOC and touches <= 3 files"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
   - "bug description contains reproducible failure case or explicit expected/actual behaviour"
 never-auto-implements:

--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -3,7 +3,7 @@
 #
 # Returns open issues that satisfy ALL of:
 #   - label matches the caller's bus label (default: tech)
-#   - label:bug
+#   - label:bug OR label:enhancement
 #   - label:human-reviewed       (skipped when .bsg-autopilot.yml authorizes the agent)
 #   - label:safe-to-automate     (skipped when .bsg-autopilot.yml authorizes the agent)
 #   - at least one epic:* label
@@ -55,7 +55,7 @@ if [[ -f .bsg-autopilot.yml ]]; then
   fi
 fi
 
-LABEL_FLAGS=(--label "$AGENT" --label "bug")
+LABEL_FLAGS=(--label "$AGENT")
 if [[ "$AUTOPILOT" == "false" ]]; then
   LABEL_FLAGS+=(--label "human-reviewed" --label "safe-to-automate")
 else
@@ -65,7 +65,8 @@ else
 fi
 
 # Pull open issues carrying all required labels. GitHub's search API
-# AND-s labels when multiple --label flags are passed.
+# AND-s labels when multiple --label flags are passed, so the bug /
+# enhancement OR-filter is applied below in jq instead of via --label.
 candidates_json=$(gh issue list "${REPO_FLAG[@]}" \
   --state open \
   "${LABEL_FLAGS[@]}" \
@@ -73,11 +74,13 @@ candidates_json=$(gh issue list "${REPO_FLAG[@]}" \
   2>/dev/null || echo "[]")
 
 # Post-filter for:
+#   - label:bug OR label:enhancement (#282)
 #   - at least one epic:* label
 #   - no open PR already touching this issue (avoid re-attempting)
 # Emit one JSON object per line.
 filtered=$(jq -c '
   .[]
+  | select(.labels | any(.name == "bug" or .name == "enhancement"))
   | select(.labels | any(.name | startswith("epic:")))
   | {
       number,

--- a/claude-skills/tests/test_pilot_candidates.sh
+++ b/claude-skills/tests/test_pilot_candidates.sh
@@ -76,7 +76,7 @@ bash "$SUT" --agent tech >/dev/null 2>&1
 ARGS="$(cat "$GH_ARGS_FILE")"
 
 assert_contains "T1: has --label tech" "$ARGS" "--label tech"
-assert_contains "T1: has --label bug" "$ARGS" "--label bug"
+assert_not_contains "T1: no --label bug (filter moved to jq)" "$ARGS" "--label bug"
 assert_contains "T1: has --label human-reviewed" "$ARGS" "--label human-reviewed"
 assert_contains "T1: has --label safe-to-automate" "$ARGS" "--label safe-to-automate"
 assert_not_contains "T1: no needs-human-review" "$ARGS" "needs-human-review"
@@ -93,7 +93,7 @@ bash "$SUT" --agent tech >/dev/null 2>&1
 ARGS="$(cat "$GH_ARGS_FILE")"
 
 assert_contains "T2: has --label tech" "$ARGS" "--label tech"
-assert_contains "T2: has --label bug" "$ARGS" "--label bug"
+assert_not_contains "T2: no --label bug (filter moved to jq)" "$ARGS" "--label bug"
 assert_not_contains "T2: no human-reviewed" "$ARGS" "human-reviewed"
 assert_not_contains "T2: no safe-to-automate" "$ARGS" "safe-to-automate"
 assert_not_contains "T2: no needs-human-review" "$ARGS" "needs-human-review"
@@ -190,6 +190,44 @@ bash "$SUT" --agent tech >/dev/null 2>&1
 LOCK_ARGS="$(cat "$GH_LOCK_FILE" 2>/dev/null || echo "")"
 assert_contains "T7: bus_lock adds agent:lock:tech" "$LOCK_ARGS" "agent:lock:tech"
 assert_contains "T7: bus_lock targets issue 42" "$LOCK_ARGS" "42"
+
+# ---------- Test 8: enhancement issues are eligible (#282) ----------
+echo "--- Test 8: enhancement-only issue surfaces as candidate ---"
+cat > "$MOCK_GH" <<'MOCK8'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
+[{"number":62,"title":"enh","url":"https://example.com/62","labels":[{"name":"enhancement"},{"name":"tech"},{"name":"epic:E1"}]}]
+JSON
+fi
+MOCK8
+chmod +x "$MOCK_GH"
+
+rm -f "$TMPDIR_TEST/.bsg-autopilot.yml"
+OUTPUT="$(bash "$SUT" --agent tech 2>/dev/null)"
+assert_contains "T8: enhancement issue surfaces" "$OUTPUT" '"number":62'
+
+# ---------- Test 9: issue with neither bug nor enhancement is rejected ----------
+echo "--- Test 9: issue without bug/enhancement is filtered out ---"
+cat > "$MOCK_GH" <<'MOCK9'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
+[{"number":77,"title":"docs","url":"https://example.com/77","labels":[{"name":"documentation"},{"name":"tech"},{"name":"epic:E1"}]}]
+JSON
+fi
+MOCK9
+chmod +x "$MOCK_GH"
+
+OUTPUT="$(bash "$SUT" --agent tech 2>/dev/null)"
+if [[ -z "$OUTPUT" ]]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: T9: docs-only issue should be filtered out, got: $OUTPUT"
+fi
 
 # ---------- Summary ----------
 echo ""


### PR DESCRIPTION
## Summary
- Adds an enhancement clause to the `auto-implements` lists of `tech-lead`, `qa`, and `seo`, on the same bus + epic + budget conditions as the existing bug clause.
- Updates `list-pilot-candidates.sh` to honor `label:bug OR label:enhancement` (the GitHub `--label` AND-semantic forced the OR into a jq post-filter).
- Adds two new pilot-candidate tests covering enhancement eligibility and rejection of issues with neither label.

Closes #282.

## Test plan
- [x] `bash claude-skills/tests/test_pilot_candidates.sh` — 22/22 pass
- [x] `python3 -m unittest claude-skills.tests.test_skills` — 15/15 pass
- [x] `bash claude-skills/tests/test_github_bus.sh` — 3/3 pass
- [x] `bash claude-skills/tests/test_tick_fingerprint.sh` — 7/7 pass
- [ ] Next `/tick-all` tech-lead tick attempts an enhancement candidate (manual verification once merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)