### PR TITLE
chore(autopilot): bump pilot budget — 200 LOC / 8 files / 3 PRs per tick

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -21,11 +21,11 @@ agents:
   - po
 
 budget:
-  max_prs_per_tick: 1
-  max_prs_per_day: 50
-  max_loc_per_issue: 30
-  max_files_per_issue: 3
-  max_issues_per_tick: 3
+  max_prs_per_tick: 3
+  max_prs_per_day: 200
+  max_loc_per_issue: 200
+  max_files_per_issue: 8
+  max_issues_per_tick: 10
 
 # Fully autonomous mode — agents squash-merge their own implementation PRs
 # instead of stopping at needs-human-review. Only safe when:


### PR DESCRIPTION
## Summary

- Bump des caps de l'autopilot pour refléter ce qui mergeait déjà proprement le 2026-04-30 (PRs #249, #267 au-dessus des limites configurées).
- Phase 0 du plan E10-label-simplification — gain immédiat, pas de dépendance.

## Changes

| Setting | Avant | Après |
|---|---|---|
| `max_prs_per_tick` | 1 | **3** |
| `max_prs_per_day` | 50 | **200** |
| `max_loc_per_issue` | 30 | **200** |
| `max_files_per_issue` | 3 | **8** |
| `max_issues_per_tick` | 3 | **10** |

## Closes

Closes #285.

## Test plan

- [ ] `pilot-circuit-breaker.sh` continue de fonctionner (format scalaire inchangé)
- [ ] Prochain tick `tech-lead` peut prendre une issue type #199 (~150 LOC, 6 fichiers prévus) sans hit le cap
- [ ] Aucune régression sur `list-pilot-candidates.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)