### PR TITLE
feat(test): pipeline regression harness scaffold (I1-I4)

### DIFF
--- a/claude-skills/scripts/test/README.md
+++ b/claude-skills/scripts/test/README.md
@@ -1,0 +1,95 @@
+# Pipeline regression harness
+
+Compressed-run test harness for the bsg-stack autopilot pipeline.
+30 minutes at 60-second cadence ≈ 30 ticks ≈ ~15 days of prod at the
+standard `/loop 30m /tick-all` cadence — without burning prod tokens.
+
+Tracked in #292.
+
+## Quick start
+
+```bash
+bash claude-skills/scripts/test/run-pipeline-test.sh \
+  --repo beyond-scale-group/bsg-stack-test-harness \
+  --duration 30m \
+  --cadence 60s
+```
+
+The runner clones the harness repo to `/tmp/harness-clone-$EPOCH`,
+resets state, seeds a fresh synthetic backlog, fires `claude -p
+"/tick-all"` on a loop, then asserts invariants. Exits 0 if green.
+
+## Files
+
+| File | Role |
+|---|---|
+| `seed-test-backlog.sh` | populate the test repo with synthetic issues (60% tech, 25% qa, 15% seo) |
+| `run-pipeline-test.sh` | reset + seed + loop + collect + assert |
+| `assert-invariants.sh` | check invariants I1–I4 against collected logs |
+
+## Invariants checked (v1)
+
+| ID | Name | Catches |
+|---|---|---|
+| **I1** | distribution | monopoly (cf. 2026-04-30 — tech-lead opened 8/8 PRs) |
+| **I2** | idempotency | duplicate report PRs (cf. `TICK_FINGERPRINT` bug, #262) |
+| **I3** | lock cleanup | leaked `agent:lock:*` labels (cf. #270, #273) |
+| **I4** | budget compliance | merged PR exceeds `max_loc_per_issue` / `max_files_per_issue` |
+
+I5–I8 (issue-dedup fingerprints, phase-B reactivity, token budget,
+auto-merge label race) ship in a v2 of this harness — they require a
+baseline store that doesn't exist yet.
+
+## Reset semantics
+
+`run-pipeline-test.sh` (without `--no-reset`) does the following on
+the harness repo:
+
+1. Closes every open issue carrying `label:test-fixture`
+2. Removes every open `agent:lock:*` label across all 8 agents
+3. Closes every open PR (with `--delete-branch`)
+
+State on `main` is **not** force-pushed — agents commit through
+report/feature branches, never directly to main, so a clean main is
+preserved across runs without intervention. If a buggy agent ever
+pushes to main, reset main manually:
+
+```bash
+gh api -X PATCH repos/beyond-scale-group/bsg-stack-test-harness/git/refs/heads/main \
+  -f sha="$(gh api repos/beyond-scale-group/bsg-stack/git/refs/heads/main --jq .object.sha)" \
+  -F force=true
+```
+
+## Baselines
+
+`tests/pipeline-baselines/` holds JSON snapshots of green runs on
+main. Used to detect drift on quantitative invariants once I7 (token
+budget) lands.
+
+## Where this differs from regular `/tick-all`
+
+- Runs against `bsg-stack-test-harness`, never on a productive repo.
+- Resets state between runs.
+- Synthetic backlog from `seed-test-backlog.sh` instead of real backlog.
+- Asserts machine-readable pass/fail at the end.
+
+## Adding a new invariant
+
+1. Add the assertion to `assert-invariants.sh` (jq query against
+   `prs.json` / `issues.json` in the log dir).
+2. Document what regression it catches — link to the PR that
+   introduced the fix it would have caught.
+3. Run on the harness; commit the new baseline if it passes.
+
+## Why this is allowed despite the "no CI cron" rule
+
+`CLAUDE.md` forbids CI automation for productive agent runs (no
+scheduled `/tick-all`, no `repo_dispatch` orchestrators). This
+harness is a **test of the pipeline itself**, run on PRs that touch
+the pipeline — closer to a unit test that needs to spawn processes.
+A future workflow may gate it on `paths:` matching
+`claude-skills/scripts/**`, `claude-skills/agents/**`,
+`claude-skills/commands/tick-all.md`, or `.bsg-autopilot.yml`.
+
+The exception is narrow: the harness never runs against a productive
+repo. Productive ticks remain human-initiated.

--- a/claude-skills/scripts/test/assert-invariants.sh
+++ b/claude-skills/scripts/test/assert-invariants.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# assert-invariants.sh — verify pipeline regression invariants I1-I4
+# from the artifacts collected by run-pipeline-test.sh (#292).
+#
+# I1 distribution      ≥ 2 different bus_labels opened ≥ 1 PR
+# I2 idempotency       no duplicate report PRs (same agent, same day)
+# I3 lock cleanup      zero agent:lock:* labels left (live query)
+# I4 budget compliance no merged PR exceeds 200 LOC / 8 files
+#
+# Inputs: --logs DIR (must contain prs.json and issues.json)
+# Optional: --repo OWNER/NAME (required for I3)
+# Optional env: MAX_LOC (default 200), MAX_FILES (default 8)
+#
+# Exits 0 if all pass, 1 if any failed.
+
+set -euo pipefail
+
+LOG_DIR=""
+REPO=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --logs) LOG_DIR="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "assert-invariants: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$LOG_DIR" || ! -d "$LOG_DIR" ]] && { echo "missing --logs DIR" >&2; exit 2; }
+
+PRS="$LOG_DIR/prs.json"
+ISSUES="$LOG_DIR/issues.json"
+[[ ! -f "$PRS" || ! -f "$ISSUES" ]] && { echo "missing prs.json or issues.json in $LOG_DIR" >&2; exit 2; }
+
+MAX_LOC=${MAX_LOC:-200}
+MAX_FILES=${MAX_FILES:-8}
+
+PASS=0
+FAIL=0
+SKIP=0
+report() { # $1=name $2=status (PASS|FAIL|SKIP) $3=detail
+  case "$2" in
+    PASS) printf "  %-26s ✓  %s\n" "$1" "$3"; PASS=$((PASS + 1)) ;;
+    FAIL) printf "  %-26s ✗  %s\n" "$1" "$3"; FAIL=$((FAIL + 1)) ;;
+    SKIP) printf "  %-26s ·  %s\n" "$1" "$3"; SKIP=$((SKIP + 1)) ;;
+  esac
+}
+
+# ---------- I1 — distribution ----------
+buses_with_prs=$(jq -r '
+  [ .[]
+    | (.labels // []) | map(.name)
+    | map(select(. == "tech" or . == "qa" or . == "seo" or . == "po" or . == "security"))
+    | .[]
+  ] | unique | length
+' "$PRS")
+if [[ "$buses_with_prs" -ge 2 ]]; then
+  report "I1 distribution" PASS "$buses_with_prs buses opened PRs"
+else
+  report "I1 distribution" FAIL "only $buses_with_prs bus(es) opened PRs (expected ≥ 2)"
+fi
+
+# ---------- I2 — idempotency ----------
+dups=$(jq -r '
+  [ .[]
+    | select(.title | test("^report\\("))
+    | { agent: ((.title | capture("^report\\((?<a>[^)]+)\\)") // {}).a // "_"),
+        day:    (.createdAt[:10]) }
+  ]
+  | group_by(.agent + "|" + .day)
+  | map(select(length > 1))
+  | length
+' "$PRS")
+if [[ "$dups" -eq 0 ]]; then
+  report "I2 idempotency" PASS "no duplicate report PRs"
+else
+  report "I2 idempotency" FAIL "$dups duplicate report PR group(s)"
+fi
+
+# ---------- I3 — lock cleanup ----------
+if [[ -n "$REPO" ]]; then
+  leftover=0
+  for agent in po security qa tech seo marketing storytelling pr-comms; do
+    n=$(gh issue list --repo "$REPO" --label "agent:lock:$agent" --state open --json number --jq length 2>/dev/null || echo 0)
+    leftover=$((leftover + n))
+  done
+  if [[ "$leftover" -eq 0 ]]; then
+    report "I3 lock cleanup" PASS "no leftover agent:lock:* labels"
+  else
+    report "I3 lock cleanup" FAIL "$leftover issue(s) still locked"
+  fi
+else
+  report "I3 lock cleanup" SKIP "needs --repo"
+fi
+
+# ---------- I4 — budget compliance ----------
+violations=$(jq --argjson loc "$MAX_LOC" --argjson files "$MAX_FILES" '
+  [ .[]
+    | select(.state == "MERGED")
+    | select( ((.additions + .deletions) > $loc) or (.changedFiles > $files) )
+  ] | length
+' "$PRS")
+if [[ "$violations" -eq 0 ]]; then
+  merged=$(jq '[.[] | select(.state == "MERGED")] | length' "$PRS")
+  report "I4 budget compliance" PASS "$merged merged PR(s) within $MAX_LOC LOC / $MAX_FILES files"
+else
+  report "I4 budget compliance" FAIL "$violations merged PR(s) exceed budget"
+fi
+
+echo
+echo "summary: $PASS passed, $FAIL failed, $SKIP skipped"
+exit $((FAIL == 0 ? 0 : 1))

--- a/claude-skills/scripts/test/run-pipeline-test.sh
+++ b/claude-skills/scripts/test/run-pipeline-test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# run-pipeline-test.sh — compressed-run regression harness for the
+# bsg-stack autopilot pipeline (#292).
+#
+# Workflow:
+#   1. Reset state on the test repo (close test-fixture issues, clear
+#      agent:lock:* labels, close any open PRs from prior runs)
+#   2. Seed a fresh synthetic backlog via seed-test-backlog.sh
+#   3. Loop `claude -p "/tick-all"` for --duration at --cadence
+#   4. Collect PR + issue snapshots
+#   5. Assert invariants I1-I4 via assert-invariants.sh
+#
+# Exits 0 if all invariants pass, 1 otherwise.
+#
+# Usage:
+#   bash claude-skills/scripts/test/run-pipeline-test.sh \
+#     --repo beyond-scale-group/bsg-stack-test-harness \
+#     --duration 30m --cadence 60s
+
+set -euo pipefail
+
+REPO="beyond-scale-group/bsg-stack-test-harness"
+DURATION="30m"
+CADENCE="60s"
+RESET=true
+SEED=true
+CLONE_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)      REPO="$2"; shift 2 ;;
+    --duration)  DURATION="$2"; shift 2 ;;
+    --cadence)   CADENCE="$2"; shift 2 ;;
+    --no-reset)  RESET=false; shift ;;
+    --no-seed)   SEED=false; shift ;;
+    --clone-dir) CLONE_DIR="$2"; shift 2 ;;
+    -h|--help)   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "run-pipeline-test: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+START_TIME=$(date -u +%s)
+LOG_DIR="/tmp/pipeline-test-$START_TIME"
+mkdir -p "$LOG_DIR"
+
+duration_to_secs() {
+  local s="$1"
+  case "$s" in
+    *m) echo $((${s%m} * 60)) ;;
+    *h) echo $((${s%h} * 3600)) ;;
+    *s) echo "${s%s}" ;;
+    *)  echo "$s" ;;
+  esac
+}
+DUR_SECS=$(duration_to_secs "$DURATION")
+CAD_SECS=$(duration_to_secs "$CADENCE")
+
+iso_from_epoch() {
+  if date --version >/dev/null 2>&1; then
+    date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ
+  else
+    date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ
+  fi
+}
+START_ISO=$(iso_from_epoch "$START_TIME")
+
+[[ -z "$CLONE_DIR" ]] && CLONE_DIR="/tmp/harness-clone-$START_TIME"
+
+echo "== Pipeline regression test =="
+echo "repo:     $REPO"
+echo "duration: $DURATION ($DUR_SECS s)"
+echo "cadence:  $CADENCE ($CAD_SECS s)"
+echo "logs:     $LOG_DIR"
+echo
+
+# === Clone the harness repo (claude tick-all needs cwd to be a git repo) ===
+if [[ ! -d "$CLONE_DIR/.git" ]]; then
+  echo "clone: $REPO -> $CLONE_DIR"
+  gh repo clone "$REPO" "$CLONE_DIR" >/dev/null 2>&1
+fi
+cd "$CLONE_DIR"
+
+# === Reset ===
+if [[ "$RESET" == "true" ]]; then
+  echo "reset: closing test-fixture issues + clearing locks + closing stale PRs"
+
+  gh issue list --repo "$REPO" --label test-fixture --state open --json number --jq '.[].number' \
+    | while read -r n; do gh issue close --repo "$REPO" "$n" >/dev/null 2>&1 || true; done
+
+  for agent in po security qa tech seo marketing storytelling pr-comms; do
+    gh issue list --repo "$REPO" --label "agent:lock:$agent" --state open --json number --jq '.[].number' 2>/dev/null \
+      | while read -r n; do gh issue edit --repo "$REPO" "$n" --remove-label "agent:lock:$agent" >/dev/null 2>&1 || true; done
+  done
+
+  gh pr list --repo "$REPO" --state open --json number --jq '.[].number' \
+    | while read -r n; do gh pr close --repo "$REPO" "$n" --delete-branch >/dev/null 2>&1 || true; done
+fi
+
+# === Seed ===
+if [[ "$SEED" == "true" ]]; then
+  bash "$SCRIPT_DIR/seed-test-backlog.sh" --repo "$REPO" --force
+fi
+
+# === Run ===
+target_ticks=$((DUR_SECS / CAD_SECS))
+echo "run: target $target_ticks ticks"
+end_time=$((START_TIME + DUR_SECS))
+tick_count=0
+errored=0
+while [[ $(date -u +%s) -lt $end_time ]]; do
+  tick_count=$((tick_count + 1))
+  ts=$(date -u +%H:%M:%S)
+  echo "  tick $tick_count/$target_ticks at $ts"
+  if claude -p "/tick-all" > "$LOG_DIR/tick-$tick_count.log" 2>&1; then
+    :
+  else
+    errored=$((errored + 1))
+    echo "    errored — see $LOG_DIR/tick-$tick_count.log"
+  fi
+  sleep "$CAD_SECS"
+done
+
+# === Collect ===
+echo "collect: snapshotting PR + issue state since $START_ISO"
+gh pr list --repo "$REPO" --state all --search "created:>=$START_ISO" \
+  --json number,title,state,labels,additions,deletions,changedFiles,mergedAt,createdAt \
+  > "$LOG_DIR/prs.json"
+gh issue list --repo "$REPO" --state all --search "created:>=$START_ISO" \
+  --json number,title,state,labels,createdAt \
+  > "$LOG_DIR/issues.json"
+
+# === Assert ===
+echo "assert: running invariants I1-I4"
+echo
+bash "$SCRIPT_DIR/assert-invariants.sh" --logs "$LOG_DIR" --repo "$REPO"
+result=$?
+
+elapsed=$(( $(date -u +%s) - START_TIME ))
+echo
+echo "done: $tick_count ticks in ${elapsed}s ($errored errored). logs: $LOG_DIR"
+exit $result

--- a/claude-skills/scripts/test/seed-test-backlog.sh
+++ b/claude-skills/scripts/test/seed-test-backlog.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# seed-test-backlog.sh — populate a test repo with N synthetic issues
+# for the pipeline regression harness (#292).
+#
+# Each issue carries: bug or enhancement, a bus label (tech/qa/seo),
+# label `test-fixture` (for cleanup), title prefix `[test-fixture]`,
+# milestone (default `E-test`), and a deterministic micro-action body
+# the agent can execute in <= 1 LOC / 1 file.
+#
+# Distribution: 60% tech, 25% qa, 15% seo.
+#
+# Usage:
+#   bash claude-skills/scripts/test/seed-test-backlog.sh \
+#     --repo beyond-scale-group/bsg-stack-test-harness \
+#     --count 30
+#
+# Idempotent: refuses to seed when test-fixture issues already exist
+# (use --force to override) so re-runs don't double the backlog.
+
+set -euo pipefail
+
+REPO="beyond-scale-group/bsg-stack-test-harness"
+COUNT=30
+MILESTONE="E-test"
+FORCE=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)      REPO="$2"; shift 2 ;;
+    --count)     COUNT="$2"; shift 2 ;;
+    --milestone) MILESTONE="$2"; shift 2 ;;
+    --force)     FORCE=true; shift ;;
+    --dry-run)   DRY_RUN=true; shift ;;
+    -h|--help)   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "seed-test-backlog: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+existing=$(gh issue list --repo "$REPO" --label test-fixture --state open --json number --jq length)
+if [[ "$existing" -gt 0 && "$FORCE" != "true" ]]; then
+  echo "seed: $existing existing test-fixture issues — pass --force to re-seed" >&2
+  exit 1
+fi
+
+# Ensure milestone exists (idempotent).
+ms_exists=$(gh api "repos/$REPO/milestones?state=all" --jq "[.[] | select(.title == \"$MILESTONE\")] | length")
+if [[ "$ms_exists" -eq 0 ]]; then
+  gh api -X POST "repos/$REPO/milestones" \
+    -f title="$MILESTONE" \
+    -f description="Synthetic backlog for pipeline regression test (#292)" >/dev/null
+fi
+
+# Bootstrap labels (idempotent — gh label create exits 0 if it exists with --force).
+for label in test-fixture tech qa seo bug enhancement; do
+  gh label create --repo "$REPO" "$label" --color cccccc --force >/dev/null 2>&1 || true
+done
+
+# Distribution 60/25/15.
+mix=()
+for i in $(seq 1 "$COUNT"); do
+  r=$((RANDOM % 100))
+  if   [[ $r -lt 60 ]]; then mix+=(tech)
+  elif [[ $r -lt 85 ]]; then mix+=(qa)
+  else                        mix+=(seo)
+  fi
+done
+
+# Pick markdown files in the repo as targets (deterministic per index).
+mapfile -t FILES < <(find . -maxdepth 3 -name "*.md" -not -path "./.git/*" -not -path "./node_modules/*" 2>/dev/null | sort | head -20)
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "seed: no .md files found to target — run from a clone of the harness repo" >&2
+  exit 2
+fi
+NUM_FILES=${#FILES[@]}
+
+created=0
+for i in $(seq 0 $((COUNT - 1))); do
+  bus="${mix[$i]}"
+  type=$([ $((RANDOM % 5)) -eq 0 ] && echo enhancement || echo bug)
+  file="${FILES[$((i % NUM_FILES))]}"
+  title="[test-fixture] add fix-me marker to $(basename "$file") (#$((i + 1)))"
+  body=$(cat <<EOM
+## Synthetic test fixture
+
+Add a single line at the top of \`$file\`:
+
+\`\`\`
+<!-- TODO(test-fixture-$((i + 1))): fix-me -->
+\`\`\`
+
+**Estimated effort:** 1 LOC, 1 file.
+**Bus:** \`$bus\`
+
+---
+This issue was created by \`claude-skills/scripts/test/seed-test-backlog.sh\`
+for the pipeline regression harness (#292). Auto-removable via
+\`run-pipeline-test.sh --reset\`.
+EOM
+)
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY: $title  [$bus, $type, milestone=$MILESTONE]"
+    continue
+  fi
+  gh issue create --repo "$REPO" \
+    --title "$title" \
+    --body "$body" \
+    --label "test-fixture,$bus,$type" \
+    --milestone "$MILESTONE" >/dev/null
+  created=$((created + 1))
+done
+
+echo "seed: $created issue(s) created on $REPO under milestone '$MILESTONE'"


### PR DESCRIPTION
## Summary

- Scaffolde le harness de régression du pipeline autopilot (#292) — 4 fichiers, 462 LOC.
- Couvre les invariants binaires **I1-I4** : distribution, idempotency, lock cleanup, budget compliance.
- I5-I8 (fingerprint dedup, phase-B reactivity, token budget, auto-merge race) suivent dans une v2 — ils demandent une baseline de tokens qui n'existe pas encore.

## Files

| File | LOC | Role |
|---|---|---|
| `claude-skills/scripts/test/seed-test-backlog.sh` | 113 | crée N issues fictives, mix 60/25/15 tech/qa/seo |
| `claude-skills/scripts/test/run-pipeline-test.sh` | 142 | reset + seed + loop + collect + assert |
| `claude-skills/scripts/test/assert-invariants.sh` | 112 | I1-I4 en bash + jq |
| `claude-skills/scripts/test/README.md` | 95 | usage, sémantique, exception no-CI documentée |
| `tests/pipeline-baselines/.gitkeep` | 0 | dossier pour les snapshots futurs |

## Refs

Refs #292 (umbrella). Bloque la merge des #286-#290 — l'idée est que ce harness valide la session de bascule E10 d'un coup.

## Where to run it

```bash
bash claude-skills/scripts/test/run-pipeline-test.sh \
  --repo beyond-scale-group/bsg-stack-test-harness \
  --duration 30m \
  --cadence 60s
```

Le repo `bsg-stack-test-harness` a été créé dans cette session (private, auto-merge ON, Actions OFF).

## Test plan

- [ ] `bash -n` sur les 3 scripts → OK ✓ (déjà vérifié dans la session)
- [ ] `shellcheck --severity=warning` → 0 warnings ✓
- [ ] `--help` sur chaque script → affiche le block-comment ✓
- [ ] Run E2E sur le harness avec `--duration 5m --cadence 60s` (5 ticks) — à valider une fois mergé
- [ ] Premier run vert → snapshot dans `tests/pipeline-baselines/2026-04-30-pre-e10.json`

## Invariants implémentés

| ID | Catches |
|---|---|
| I1 distribution | monopole tech-lead (cf. 2026-04-30 — 8/8 PRs) |
| I2 idempotency | duplicate report PRs (`TICK_FINGERPRINT` bug, #262) |
| I3 lock cleanup | leaked `agent:lock:*` labels (#270, #273) |
| I4 budget compliance | merged PR > 200 LOC ou > 8 fichiers |

🤖 Generated with [Claude Code](https://claude.com/claude-code)