### PR TITLE
feat(autopilot): drop safe-to-automate and human-reviewed as eligibility gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,8 @@ and won't attempt automatically when running in `output: commit` mode:
 
 ```yaml
 auto-implements:
-  - "label:bug + label:epic:* + label:safe-to-automate"
-  - "LOC estimate <= 30"
+  - "label:bug + label:epic:* + .bsg-autopilot.yml authorizes this agent"
+  - "LOC estimate <= 200"
 never-auto-implements:
   - "files under security/*"
   - "dependency version bumps (belongs to Renovate)"
@@ -171,9 +171,11 @@ never-auto-implements:
 
 Three agents are now `output: commit` with live auto-implementation
 pilots: **tech-lead** (#181), **seo** (#216), and **qa** (#219). Each
-one picks up at most one `safe-to-automate` issue per tick, applies a
-scoped fix (≤ 30 LOC / ≤ 3 files), and opens a PR with
-`needs-human-review` — never self-merging. The remaining five agents
+one picks up at most one issue per tick when the repo opts into
+autopilot via `.bsg-autopilot.yml`, applies a scoped fix
+(≤ 200 LOC / ≤ 8 files), and opens a PR — auto-merging when the
+repo sets `auto_merge: true`, otherwise stamping
+`needs-human-review` for human disposition. The remaining five agents
 (`po-manager`, `security`, `marketing`, `storytelling`, `pr-comms`)
 stay `output: pr` with explicit `never-auto-implements` clauses
 documenting *why* auto-implementation is out of scope for their domain.
@@ -189,6 +191,13 @@ carries at least one clause explaining the exclusion.
 
 ### Enabling auto-implementation on a target repository
 
+Auto-implementation is opt-in at the **repo level** via
+`.bsg-autopilot.yml`. The previous per-issue gates
+(`safe-to-automate`, `human-reviewed`) were dropped in E10 (#286) —
+the repo-level marker is the single source of truth. Without the
+file, `output: commit` agents tick in audit-only mode and never
+auto-implement, regardless of issue labels.
+
 To let `output: commit` agents (tech-lead, seo, qa) auto-implement
 fixes in a repository, a human must:
 
@@ -196,11 +205,6 @@ fixes in a repository, a human must:
 
    ```bash
    # Inside the target repo:
-   gh label create safe-to-automate \
-     --color c2e0c6 \
-     --description "Human-applied: this item is safe for an agent's output:commit tick to attempt"
-
-   # Plus the standard BSG labels if not already present:
    gh label create needs-human-review \
      --color fbca04 \
      --description "Awaiting a human decision (triage, merge, or scope)"
@@ -212,16 +216,23 @@ fixes in a repository, a human must:
    done
    ```
 
-2. **Feed the backlog.** File or label issues with:
-   - `label:bug` — only bugs are eligible today
+2. **Drop a `.bsg-autopilot.yml` at the repo root** (see "Autopilot
+   mode" below for the full schema):
+
+   ```yaml
+   enabled: true
+   agents:
+     - tech
+     - seo
+     - qa
+   ```
+
+3. **Feed the backlog.** File or label issues with:
+   - `label:bug` or `label:enhancement`
    - The agent's bus label (`tech`, `seo`, or `qa`)
-   - `label:human-reviewed` — proves a human triaged this (unless
-     autopilot mode is enabled, see below)
-   - `label:safe-to-automate` — **human-only gate** (unless autopilot
-     mode is enabled, see below)
    - At least one `epic:*` label binding the issue to a plan item
 
-3. **Run the tick** (or let `/loop` / `/schedule` drive it):
+4. **Run the tick** (or let `/loop` / `/schedule` drive it):
 
    ```bash
    # Single agent:
@@ -233,21 +244,24 @@ fixes in a repository, a human must:
 
    The agent's phase (B) calls `list-pilot-candidates.sh --agent <name>`
    to find eligible issues. If a candidate exists, the agent attempts
-   exactly one fix per sweep, opens a PR with `Fixes #NN` and
-   `needs-human-review`, and reports a one-line receipt.
+   exactly one fix per sweep and opens a PR. With `auto_merge: true`
+   in the autopilot file, the PR squash-merges and gets stamped
+   `human-reviewed`. Otherwise it stamps `needs-human-review` for
+   human disposition.
 
-4. **Review and merge.** The human reviews the PR, merges (or closes),
-   and applies `human-reviewed` via `mark-reviewed.sh <pr-number>`.
+5. **Review and merge.** When `auto_merge` is off, the human reviews
+   the PR, merges (or closes), and applies `human-reviewed` via
+   `mark-reviewed.sh <pr-number>`.
 
 The `--repo OWNER/NAME` flag on `list-pilot-candidates.sh` allows
 running against a different repository than the current working
 directory — useful for cross-repo sweeps from a central session.
 
-### Autopilot mode (`.bsg-autopilot.yml`) — #221
+### Autopilot mode (`.bsg-autopilot.yml`) — #221, #286
 
-For repos with a steady stream of labeled issues, the per-issue
-`safe-to-automate` gate adds friction. **Autopilot mode** replaces the
-per-issue gate with a repo-level opt-in.
+`.bsg-autopilot.yml` is the single repo-level opt-in for
+auto-implementation. The file is the gate: without it, no
+auto-implementation happens regardless of issue labels.
 
 Drop a `.bsg-autopilot.yml` at the repo root:
 
@@ -258,19 +272,22 @@ agents:
   - seo
   - qa
 budget:
-  max_prs_per_tick: 1
-  max_prs_per_day: 3
-  max_loc_per_issue: 30
-  max_files_per_issue: 3
+  max_prs_per_tick: 3
+  max_prs_per_day: 200
+  max_loc_per_issue: 200
+  max_files_per_issue: 8
 ```
 
-When this file exists, is `enabled: true`, and lists the calling agent
-in `agents:`, `list-pilot-candidates.sh` drops both the `human-reviewed`
-and `safe-to-automate` label filters. Issues only need `label:bug` +
-bus label + `label:epic:*` to be eligible.
+When this file exists, is `enabled: true`, and lists the calling
+agent in `agents:`, `list-pilot-candidates.sh` returns issues that
+have `label:bug` or `label:enhancement` + bus label + `label:epic:*`.
+Without it, the script returns no candidates.
 
-The per-issue labels (`human-reviewed`, `safe-to-automate`) still work
-as gates on repos without the file or for agents not listed in `agents:`.
+`needs-human-review` and `human-reviewed` are no longer eligibility
+gates — they only mark the **disposition state of PRs** (awaiting
+human merge / merged-and-reviewed). `human-reviewed` is also posted
+as the final stamp by `auto-merge-or-flag.sh` after a successful
+auto-merge.
 
 **Daily circuit-breaker.** `pilot-circuit-breaker.sh` counts
 implementation PRs opened today and compares against `max_prs_per_day`

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -52,8 +52,8 @@ tick: >
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
-  - "label:bug + label:qa + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes qa)"
-  - "label:enhancement + label:qa + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes qa) + estimated fix size <= 30 LOC and touches <= 3 files"
+  - "label:bug + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa"
+  - "label:enhancement + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa + estimated fix size <= 30 LOC and touches <= 3 files"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
   - "finding is a missing test for a regression (reproduces failure, then asserts fix)"
 never-auto-implements:
@@ -72,7 +72,8 @@ init: >
 You are the **QA Agent** for this repository. Your job: surface quality
 signals that developers can act on. Under the #219 implementation pilot
 you may additionally write missing regression tests when — and only
-when — a human has gated the issue with `label:safe-to-automate`. You
+when — the repo opts into autopilot via `.bsg-autopilot.yml`
+(`enabled: true` and `qa` listed under `agents:`). You
 do not execute the full test suite, you do not merge your own work. If
 the user asks for broader implementation work, hand it back to the main
 agent with a summary of the gap you found.
@@ -187,8 +188,8 @@ When the tick's phase (B) runs, the procedure is:
 1. **Enumerate candidates** with
    `bash claude-skills/scripts/list-pilot-candidates.sh --agent qa`.
    The script enforces the label filter
-   (`label:bug + label:qa + label:needs-human-review + label:epic:*`
-   plus `label:safe-to-automate` unless `.bsg-autopilot.yml` authorizes qa).
+   (`label:bug` or `label:enhancement` + `label:qa` + at least one
+   `label:epic:*`, only when `.bsg-autopilot.yml` authorizes qa).
    Empty output → stop.
 
 2. **Pick exactly one candidate** — oldest-first, tie-break by lowest

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -55,8 +55,8 @@ tick: >
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
-  - "label:bug + label:seo + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes seo)"
-  - "label:enhancement + label:seo + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes seo) + estimated fix size <= 30 LOC and touches <= 3 files"
+  - "label:bug + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo"
+  - "label:enhancement + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo + estimated fix size <= 30 LOC and touches <= 3 files"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
   - "finding is a missing HTML element (canonical tag, meta description, alt text, structured data)"
 never-auto-implements:
@@ -76,8 +76,9 @@ You are the **SEO Agent** for this repository. Your job: surface
 technical-SEO issues from source files before they hit production.
 Under the #216 implementation pilot you may additionally apply
 mechanical fixes (missing canonical tags, meta descriptions, alt
-attributes, structured data) when — and only when — a human has
-gated the issue with `label:safe-to-automate`. You do not author
+attributes, structured data) when — and only when — the repo opts
+into autopilot via `.bsg-autopilot.yml` (`enabled: true` and `seo`
+listed under `agents:`). You do not author
 content, you do not rewrite copy, you do not merge your own work.
 
 ## Operating principles
@@ -181,8 +182,8 @@ When the tick's phase (B) runs, the procedure is:
 1. **Enumerate candidates** with
    `bash claude-skills/scripts/list-pilot-candidates.sh --agent seo`.
    The script enforces the label filter
-   (`label:bug + label:seo + label:needs-human-review + label:epic:*`
-   plus `label:safe-to-automate` unless `.bsg-autopilot.yml` authorizes seo).
+   (`label:bug` or `label:enhancement` + `label:seo` + at least one
+   `label:epic:*`, only when `.bsg-autopilot.yml` authorizes seo).
    Empty output → stop.
 
 2. **Pick exactly one candidate** — oldest-first, tie-break by lowest

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -52,8 +52,8 @@ tick: >
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
-  - "label:bug + label:tech + label:needs-human-review + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes tech)"
-  - "label:enhancement + label:tech + label:epic:* + (label:safe-to-automate OR .bsg-autopilot.yml authorizes tech) + estimated fix size <= 30 LOC and touches <= 3 files"
+  - "label:bug + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech"
+  - "label:enhancement + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech + estimated fix size <= 30 LOC and touches <= 3 files"
   - "estimated fix size <= 30 LOC and touches <= 3 files"
   - "bug description contains reproducible failure case or explicit expected/actual behaviour"
 never-auto-implements:
@@ -74,9 +74,10 @@ architecture health signals (dependency lag, complexity hotspots,
 undocumented decisions, stale tech debt) so a real tech lead can
 decide where to invest engineering time. Under the #181 implementation
 pilot you may additionally attempt scoped bug fixes when — and only
-when — a human has gated the issue with `label:safe-to-automate`. You
-do not choose frameworks, you do not perform code reviews, you do not
-merge your own work.
+when — the repo opts into autopilot via `.bsg-autopilot.yml`
+(`enabled: true` and `tech` listed under `agents:`). You do not choose
+frameworks, you do not perform code reviews, you do not merge your
+own work.
 
 ## Operating principles
 
@@ -178,10 +179,9 @@ When the tick's phase (B) runs, the procedure is:
 
 1. **Enumerate candidates** with
    `bash claude-skills/scripts/list-pilot-candidates.sh --agent tech`.
-   The script enforces the label filter
-   (`label:bug + label:tech + label:needs-human-review + label:epic:*`
-   plus `label:safe-to-automate` unless `.bsg-autopilot.yml` authorizes tech).
-   Empty output → stop.
+   The script returns issues with `label:bug` or `label:enhancement`
+   plus `label:tech` plus at least one `label:epic:*`, only when the
+   repo opts into autopilot via `.bsg-autopilot.yml`. Empty output → stop.
 
 2. **Pick exactly one candidate** — oldest-first, tie-break by lowest
    issue number. Never attempt a second issue in the same sweep.

--- a/claude-skills/scripts/audit-labels.sh
+++ b/claude-skills/scripts/audit-labels.sh
@@ -7,12 +7,12 @@
 #      (po, security, qa, tech, seo, marketing, storytelling, pr-comms).
 #      Two bus labels on the same item = ambiguous ownership → fail.
 #
-#   2. Carry either `needs-human-review` or `human-reviewed` — never both,
-#      never neither. Together they form a binary state that proves the
-#      item has moved through human triage.
-#
 # What is NOT enforced here (yet):
 #
+#   - The `needs-human-review` / `human-reviewed` binary was dropped
+#     in E10 (#286): the repo-level autopilot opt-in is now the gate,
+#     and `human-reviewed` becomes a post-merge stamp posted by
+#     `auto-merge-or-flag.sh` rather than a triage marker.
 #   - PRs are audited the same way as issues; report PRs opened by
 #     `open-report-pr.sh` auto-merge so quickly they rarely linger open
 #     long enough to fail the audit in practice.
@@ -74,16 +74,6 @@ check_item() {
     1) ;;
     *) report_item "$kind" "$number" "carries ${bus_count} bus labels (ambiguous ownership)" ;;
   esac
-
-  local has_needs has_done
-  has_needs=$(jq '[.[] | select(.name == "needs-human-review")] | length' <<<"$labels_json")
-  has_done=$(jq  '[.[] | select(.name == "human-reviewed")]   | length' <<<"$labels_json")
-
-  if [[ "$has_needs" -eq 0 && "$has_done" -eq 0 ]]; then
-    report_item "$kind" "$number" "missing both 'needs-human-review' and 'human-reviewed'"
-  elif [[ "$has_needs" -ge 1 && "$has_done" -ge 1 ]]; then
-    report_item "$kind" "$number" "carries both 'needs-human-review' and 'human-reviewed' — pick one"
-  fi
 }
 
 echo "Auditing open issues..."

--- a/claude-skills/scripts/file-issue.sh
+++ b/claude-skills/scripts/file-issue.sh
@@ -4,16 +4,18 @@
 # Every BSG agent that files a GitHub issue should use this helper instead
 # of calling `gh issue create` directly. The wrapper:
 #
-#   1. Ensures the `needs-human-review` label exists on the target repo
-#      (creates it once if missing), so the convention propagates to any
-#      BSG-consuming repo without manual setup.
-#   2. Adds `needs-human-review` to the `--label` list automatically.
+#   1. In **non-autopilot** mode (no `.bsg-autopilot.yml` or
+#      `enabled: false`): ensures the `needs-human-review` label exists
+#      on the target repo and adds it to the `--label` list automatically.
+#      Humans own the transition out of "needs review" by merging,
+#      closing, or relabeling the issue.
+#   2. In **autopilot** mode (`.bsg-autopilot.yml` with `enabled: true`):
+#      `needs-human-review` is no longer auto-applied — the repo-level
+#      opt-in is the gate, and `filed-by:<agent>` (via --filed-by) is the
+#      traceability marker. See E10 (#286).
 #   3. Forwards every other flag to `gh issue create` unchanged, so the
 #      caller's existing `--title`, `--body`, `--label bug`, `--assignee`,
 #      etc. all keep working.
-#
-# The label is never removed automatically — humans own the transition out
-# of "needs review" by merging, closing, or relabeling the issue.
 #
 # Usage (drop-in replacement for `gh issue create`):
 #   file-issue.sh --title "..." --body "..."
@@ -94,24 +96,43 @@ if [[ -n "$DEDUP_FINGERPRINT" ]]; then
   fi
 fi
 
-# Idempotently ensure the label exists on the target repo. `gh label create`
-# exits non-zero if the label already exists, so swallow that specific case.
-if ! gh label list "${repo_flag[@]}" --json name \
-     --jq '.[] | select(.name == "'"$REVIEW_LABEL"'") | .name' \
-     2>/dev/null | grep -qx "$REVIEW_LABEL"; then
-  gh label create "$REVIEW_LABEL" \
-    "${repo_flag[@]}" \
-    --color "$REVIEW_COLOR" \
-    --description "$REVIEW_DESC" \
-    >/dev/null 2>&1 || true
+# Auto-apply `needs-human-review` only when the target repo is NOT in
+# autopilot mode. In autopilot mode the repo-level opt-in is the gate
+# and `filed-by:<agent>` is the traceability marker — applying
+# needs-human-review on every agent-filed issue would be redundant noise.
+APPLY_REVIEW_LABEL=true
+if [[ -f .bsg-autopilot.yml ]]; then
+  enabled=$(grep -E '^\s*enabled\s*:' .bsg-autopilot.yml 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  if [[ "$enabled" == "true" ]]; then
+    APPLY_REVIEW_LABEL=false
+  fi
 fi
 
-# Labels we always ensure are on the issue: needs-human-review + (optional)
-# the bus label that pins ownership to a specific agent + (optional)
-# filed-by:<agent> for traceability.
-extra_labels="$REVIEW_LABEL"
+# Idempotently ensure the review label exists on the target repo when
+# we're going to apply it. `gh label create` exits non-zero if the label
+# already exists, so swallow that specific case.
+if [[ "$APPLY_REVIEW_LABEL" == "true" ]]; then
+  if ! gh label list "${repo_flag[@]}" --json name \
+       --jq '.[] | select(.name == "'"$REVIEW_LABEL"'") | .name' \
+       2>/dev/null | grep -qx "$REVIEW_LABEL"; then
+    gh label create "$REVIEW_LABEL" \
+      "${repo_flag[@]}" \
+      --color "$REVIEW_COLOR" \
+      --description "$REVIEW_DESC" \
+      >/dev/null 2>&1 || true
+  fi
+fi
+
+# Labels we ensure on the issue:
+#   - needs-human-review (only outside autopilot mode)
+#   - (optional) the bus label that pins ownership to a specific agent
+#   - (optional) filed-by:<agent> for traceability
+extra_labels=""
+if [[ "$APPLY_REVIEW_LABEL" == "true" ]]; then
+  extra_labels="$REVIEW_LABEL"
+fi
 if [[ -n "$BUS_LABEL" ]]; then
-  extra_labels="${extra_labels},${BUS_LABEL}"
+  extra_labels="${extra_labels:+$extra_labels,}$BUS_LABEL"
 fi
 if [[ -n "$FILED_BY" ]]; then
   filed_label="filed-by:${FILED_BY}"
@@ -125,7 +146,7 @@ if [[ -n "$FILED_BY" ]]; then
       --description "Issue filed automatically by the $FILED_BY agent (#222)" \
       >/dev/null 2>&1 || true
   fi
-  extra_labels="${extra_labels},${filed_label}"
+  extra_labels="${extra_labels:+$extra_labels,}$filed_label"
 fi
 
 # `gh issue create --label` accepts either a comma-separated list or
@@ -140,7 +161,11 @@ while [[ $i -lt ${#args[@]} ]]; do
   arg="${args[$i]}"
   if [[ "$arg" == "--label" ]]; then
     existing="${args[$((i+1))]}"
-    final_args+=(--label "${existing},${extra_labels}")
+    if [[ -n "$extra_labels" ]]; then
+      final_args+=(--label "${existing},${extra_labels}")
+    else
+      final_args+=(--label "$existing")
+    fi
     label_merged=1
     i=$((i+2))
   elif [[ "$arg" == "--body" && -n "$DEDUP_FINGERPRINT" ]]; then
@@ -155,7 +180,7 @@ while [[ $i -lt ${#args[@]} ]]; do
     i=$((i+1))
   fi
 done
-if [[ $label_merged -eq 0 ]]; then
+if [[ $label_merged -eq 0 && -n "$extra_labels" ]]; then
   final_args+=(--label "$extra_labels")
 fi
 

--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -4,14 +4,15 @@
 # Returns open issues that satisfy ALL of:
 #   - label matches the caller's bus label (default: tech)
 #   - label:bug OR label:enhancement
-#   - label:human-reviewed       (skipped when .bsg-autopilot.yml authorizes the agent)
-#   - label:safe-to-automate     (skipped when .bsg-autopilot.yml authorizes the agent)
 #   - at least one epic:* label
 #   - has no open PR already referencing it (agent didn't start work yet)
 #
-# When .bsg-autopilot.yml exists, is enabled, and lists the calling agent,
-# both human-reviewed and safe-to-automate label filters are dropped —
-# the repo-level marker replaces per-issue gates. See #221.
+# Auto-implementation is opt-in at the **repo level** via
+# .bsg-autopilot.yml. Without the file, with `enabled: false`, or when
+# the calling agent is not listed under `agents:`, no candidates are
+# emitted (the agent's tick becomes audit-only). The previous per-issue
+# gates `safe-to-automate` and `needs-human-review` were dropped in
+# E10 (#286) — the repo-level marker is the single source of truth.
 #
 # After emitting the candidate list, the first (top) candidate is locked
 # via bus_lock so concurrent ticks don't race on the same issue. The lock
@@ -44,25 +45,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Determine whether autopilot mode is active for this agent.
-AUTOPILOT=false
-if [[ -f .bsg-autopilot.yml ]]; then
-  enabled=$(grep -E '^\s*enabled\s*:' .bsg-autopilot.yml 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
-  if [[ "$enabled" == "true" ]]; then
-    if grep -qE "^\s*-\s+$AGENT\s*$" .bsg-autopilot.yml 2>/dev/null; then
-      AUTOPILOT=true
-    fi
-  fi
+# Auto-implementation requires a repo-level opt-in via .bsg-autopilot.yml.
+# Without the file, with `enabled: false`, or when this agent is not
+# listed under `agents:`, we emit no candidates — the agent's tick
+# becomes audit-only. See #286.
+if [[ ! -f .bsg-autopilot.yml ]]; then
+  exit 0
+fi
+enabled=$(grep -E '^\s*enabled\s*:' .bsg-autopilot.yml 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+if [[ "$enabled" != "true" ]]; then
+  exit 0
+fi
+if ! grep -qE "^\s*-\s+$AGENT\s*$" .bsg-autopilot.yml 2>/dev/null; then
+  exit 0
 fi
 
 LABEL_FLAGS=(--label "$AGENT")
-if [[ "$AUTOPILOT" == "false" ]]; then
-  LABEL_FLAGS+=(--label "human-reviewed" --label "safe-to-automate")
-else
-  # Autopilot: human-reviewed and safe-to-automate are optional.
-  # The repo-level opt-in replaces per-issue gates.
-  :
-fi
 
 # Pull open issues carrying all required labels. GitHub's search API
 # AND-s labels when multiple --label flags are passed, so the bug /


### PR DESCRIPTION
## Summary

Le repo-level opt-in (`.bsg-autopilot.yml enabled: true` + agent listé) devient la **seule source** de vérité pour l'auto-implémentation. Les gates par-issue (`safe-to-automate`, `human-reviewed`) étaient redondantes et créaient du friction inutile.

## Closes

Closes #286.

## Changes

| Fichier | Modif |
|---|---|
| `claude-skills/scripts/list-pilot-candidates.sh` | early-exit quand pas d'autopilot file / `enabled: false` / agent non listé. Filtre simplifié dans la branche autopilot. |
| `claude-skills/agents/{qa,seo,tech-lead}.md` | frontmatter `auto-implements` référence l'autopilot file au lieu de `safe-to-automate` |
| `claude-skills/scripts/file-issue.sh` | n'auto-applique plus `needs-human-review` en mode autopilot — `filed-by:<agent>` est le marqueur de traçabilité |
| `claude-skills/scripts/audit-labels.sh` | drop la règle "doit avoir needs-human-review OU human-reviewed" |
| `CLAUDE.md` | réécriture "Enabling auto-implementation" + "Autopilot mode". Caps remontés à 200 LOC / 8 fichiers (cf. PR #291). `human-reviewed` documenté comme stamp post-merge. |

## Test plan

- [x] `python3 -m unittest claude-skills/tests/test_skills.py` → 15/15 OK
- [x] `bash -n` + `shellcheck --severity=warning` sur les 3 scripts modifiés → 0 warning introduit (1 SC2034 pré-existant dans `file-issue.sh`)
- [x] Smoke `list-pilot-candidates.sh --agent tech` dans 3 modes :
  - sans `.bsg-autopilot.yml` → empty, exit 0 ✓
  - avec `enabled: false` → empty, exit 0 ✓
  - avec `enabled: true` + agent listé → recherche normale, exit 0 ✓
- [ ] À valider après merge : un tick `tech-lead` sur le harness pré-seedé doit picker une issue `bug + tech + epic:*` sans avoir besoin de `safe-to-automate`

## Migration notes

**Repos sans `.bsg-autopilot.yml`** : aucun changement de comportement — les agents tickaient déjà en audit-only sans la file. La différence: avant, ils tickaient en audit-only à cause des gates ; maintenant, à cause de l'opt-in.

**Repos avec `.bsg-autopilot.yml enabled: true`** : les issues `safe-to-automate`/`human-reviewed` existantes restent éligibles (la nouvelle requête est plus permissive, pas plus restrictive).

**Labels morts** : `safe-to-automate` n'est plus utilisé par aucun script, mais reste créé pour ne pas casser les repos qui le portent. Suppression effective dans #290 (cleanup final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)