### PR TITLE
fix(pilot): per-bus daily PR caps in pilot-circuit-breaker.sh (#289)

### DIFF
--- a/claude-skills/scripts/pilot-circuit-breaker.sh
+++ b/claude-skills/scripts/pilot-circuit-breaker.sh
@@ -2,21 +2,40 @@
 # pilot-circuit-breaker.sh — daily cap on implementation PRs.
 #
 # Counts PRs opened today by the pilot agents (title matches
-# `fix(*-pilot):`) and compares against the max_prs_per_day budget
+# `fix(pilot):`) and compares against the max_prs_per_day budget
 # from .bsg-autopilot.yml (default: 3). Exits 0 if under budget,
 # exits 1 if at or over budget.
 #
+# max_prs_per_day can be a scalar (global cap) or a map with per-bus
+# caps and a _default fallback:
+#
+#   budget:
+#     max_prs_per_day: 200          # scalar — backward-compat
+#
+#   budget:
+#     max_prs_per_day:              # map — per-bus caps
+#       _default: 200
+#       tech: 50
+#       qa: 30
+#
 # Usage:
-#   bash claude-skills/scripts/pilot-circuit-breaker.sh [--repo OWNER/NAME]
+#   bash claude-skills/scripts/pilot-circuit-breaker.sh [--bus <name>] [--repo OWNER/NAME]
+#
+# --bus <name>  When max_prs_per_day is a map, look up the cap for <name>
+#               (falling back to _default). Also filters the PR count by
+#               the bus label so each bus counts only its own PRs.
 #
 # The caller's tick should check the exit code before entering phase (B).
 
 set -euo pipefail
 
 REPO_FLAG=()
+BUS=""
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)  REPO_FLAG=(--repo "$2"); shift 2 ;;
+    --bus)   BUS="$2"; shift 2 ;;
     -h|--help)
       sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
@@ -25,25 +44,67 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-MAX_PRS=3
+DEFAULT_CAP=3
+MAX_PRS=$DEFAULT_CAP
 
 if [[ -f .bsg-autopilot.yml ]]; then
-  parsed=$(grep -E '^\s*max_prs_per_day\s*:' .bsg-autopilot.yml 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
-  if [[ -n "$parsed" && "$parsed" =~ ^[0-9]+$ ]]; then
-    MAX_PRS="$parsed"
+  # Detect whether max_prs_per_day is a scalar or a map.
+  # A scalar appears as:   max_prs_per_day: 200
+  # A map appears as:      max_prs_per_day:\n    _default: 200\n    tech: 50
+  # Note: grep -E and awk on macOS do not support \s — use [ \t]* instead.
+  scalar=$(grep -E '^[ \t]*max_prs_per_day[ \t]*:[ \t]*[0-9]+[ \t]*$' .bsg-autopilot.yml 2>/dev/null \
+             | head -1 | sed 's/.*:[ \t]*//' | tr -d '[:space:]' || true)
+
+  if [[ -n "$scalar" && "$scalar" =~ ^[0-9]+$ ]]; then
+    # Scalar format — backward-compat global cap
+    MAX_PRS="$scalar"
+  elif [[ -n "$BUS" ]]; then
+    # Map format — extract lines indented under max_prs_per_day:
+    # (macOS awk does not support \s; use character classes)
+    map_block=$(awk '
+      /^[ \t]*max_prs_per_day[ \t]*:[ \t]*$/ { in_block=1; next }
+      in_block && /^[^ \t]/ { in_block=0 }
+      in_block { print }
+    ' .bsg-autopilot.yml)
+
+    bus_cap=$(echo "$map_block" \
+      | grep -E "^[ \t]+${BUS}[ \t]*:[ \t]*[0-9]+" \
+      | head -1 | sed 's/.*:[ \t]*//' | tr -d '[:space:]' || true)
+
+    default_cap=$(echo "$map_block" \
+      | grep -E "^[ \t]+_default[ \t]*:[ \t]*[0-9]+" \
+      | head -1 | sed 's/.*:[ \t]*//' | tr -d '[:space:]' || true)
+
+    if [[ -n "$bus_cap" && "$bus_cap" =~ ^[0-9]+$ ]]; then
+      MAX_PRS="$bus_cap"
+    elif [[ -n "$default_cap" && "$default_cap" =~ ^[0-9]+$ ]]; then
+      MAX_PRS="$default_cap"
+    fi
+    # else: no map entry and no _default → keep DEFAULT_CAP
   fi
+  # If map format but no --bus provided, fall back to DEFAULT_CAP (safe default)
 fi
 
 today=$(date +%Y-%m-%d)
 
-count=$(gh pr list "${REPO_FLAG[@]}" \
-  --state all \
-  --search "fix( in:title -pilot): in:title created:${today}" \
-  --json number \
-  --limit 200 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+# Build the search query. When a bus is specified, additionally filter by label
+# so each bus counts only its own pilot PRs.
+if [[ -n "$BUS" ]]; then
+  count=$(gh pr list "${REPO_FLAG[@]}" \
+    --state all \
+    --search "fix(pilot): in:title created:${today} label:${BUS}" \
+    --json number,labels \
+    --limit 200 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+else
+  count=$(gh pr list "${REPO_FLAG[@]}" \
+    --state all \
+    --search "fix(pilot): in:title created:${today}" \
+    --json number \
+    --limit 200 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+fi
 
 if [[ "$count" -ge "$MAX_PRS" ]]; then
-  echo "circuit-breaker: $count/$MAX_PRS pilot PRs today — at limit, skipping phase (B)"
+  echo "circuit-breaker: $count/$MAX_PRS pilot PRs today${BUS:+ for bus=$BUS} — at limit, skipping phase (B)"
   exit 1
 fi
 

--- a/claude-skills/tests/test_circuit_breaker.sh
+++ b/claude-skills/tests/test_circuit_breaker.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# test_circuit_breaker.sh — unit tests for pilot-circuit-breaker.sh
+#
+# Tests:
+#   - Scalar max_prs_per_day (backward-compat): global cap
+#   - Map max_prs_per_day: per-bus cap with _default fallback
+#   - --bus flag respected when map format used
+#   - Under cap → exit 0; at/over cap → exit 1
+#
+# Run locally:
+#   bash claude-skills/tests/test_circuit_breaker.sh
+#
+# Exit 0 = all pass, exit 1 = failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SUT="$REPO_ROOT/claude-skills/scripts/pilot-circuit-breaker.sh"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local label="$1" expected="$2"
+  shift 2
+  local actual
+  actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [[ "$actual" -eq "$expected" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label — expected exit $expected, got $actual"
+  fi
+}
+
+# --- Mock gh: returns N fake pilot PRs ---
+make_mock_gh() {
+  local count="$1"
+  local bus_label="${2:-}"
+  local mock="$TMPDIR_TEST/gh"
+  local items=""
+  for i in $(seq 1 "$count"); do
+    local labels_json='[{"name":"tech"}]'
+    if [[ -n "$bus_label" ]]; then
+      labels_json="[{\"name\":\"$bus_label\"}]"
+    fi
+    items+='{"number":'"$i"',"labels":'"$labels_json"'},'
+  done
+  items="${items%,}"
+  cat > "$mock" <<MOCK
+#!/usr/bin/env bash
+echo '[$items]'
+MOCK
+  # Use printf to safely embed the items string
+  printf '#!/usr/bin/env bash\necho '"'"'[%s]'"'"'\n' "$items" > "$mock"
+  chmod +x "$mock"
+  export PATH="$TMPDIR_TEST:$PATH"
+}
+
+# ---- Test 1: scalar cap — under limit (2 PRs, cap 3) → exit 0 ----
+echo "--- Test 1: scalar cap, under limit ---"
+cd "$TMPDIR_TEST"
+cat > .bsg-autopilot.yml <<'YAML'
+enabled: true
+budget:
+  max_prs_per_day: 3
+YAML
+make_mock_gh 2
+assert_exit "T1: 2 PRs < cap=3 → exit 0" 0 bash "$SUT"
+
+# ---- Test 2: scalar cap — at limit (3 PRs, cap 3) → exit 1 ----
+echo "--- Test 2: scalar cap, at limit ---"
+make_mock_gh 3
+assert_exit "T2: 3 PRs >= cap=3 → exit 1" 1 bash "$SUT"
+
+# ---- Test 3: map cap — bus under its own cap (tech: 2 PRs, cap 5) → exit 0 ----
+echo "--- Test 3: map cap, bus under limit ---"
+cat > .bsg-autopilot.yml <<'YAML'
+enabled: true
+budget:
+  max_prs_per_day:
+    _default: 200
+    tech: 5
+    qa: 3
+YAML
+make_mock_gh 2 "tech"
+assert_exit "T3: tech 2 PRs < cap=5 → exit 0" 0 bash "$SUT" --bus tech
+
+# ---- Test 4: map cap — bus at its own cap (tech: 5 PRs, cap 5) → exit 1 ----
+echo "--- Test 4: map cap, bus at limit ---"
+make_mock_gh 5 "tech"
+assert_exit "T4: tech 5 PRs >= cap=5 → exit 1" 1 bash "$SUT" --bus tech
+
+# ---- Test 5: map cap — _default fallback used for unlisted bus ----
+echo "--- Test 5: map cap, _default fallback ---"
+cat > .bsg-autopilot.yml <<'YAML'
+enabled: true
+budget:
+  max_prs_per_day:
+    _default: 2
+    tech: 50
+YAML
+make_mock_gh 2 "seo"
+assert_exit "T5: seo 2 PRs >= _default=2 → exit 1" 1 bash "$SUT" --bus seo
+
+# ---- Test 6: map cap — bus well under _default ----
+echo "--- Test 6: map cap, bus under _default ---"
+make_mock_gh 1 "seo"
+assert_exit "T6: seo 1 PR < _default=2 → exit 0" 0 bash "$SUT" --bus seo
+
+# ---- Test 7: no autopilot file — uses hardcoded default=3 ----
+echo "--- Test 7: no autopilot file, default cap ---"
+rm -f .bsg-autopilot.yml
+make_mock_gh 2
+assert_exit "T7: 2 PRs < default cap=3 → exit 0" 0 bash "$SUT"
+
+make_mock_gh 3
+assert_exit "T7b: 3 PRs >= default cap=3 → exit 1" 1 bash "$SUT"
+
+# ---- Test 8: backward compat — scalar used even without --bus ----
+echo "--- Test 8: scalar cap, no --bus flag ---"
+cat > .bsg-autopilot.yml <<'YAML'
+enabled: true
+budget:
+  max_prs_per_day: 10
+YAML
+make_mock_gh 5
+assert_exit "T8: scalar cap 10, 5 PRs → exit 0" 0 bash "$SUT"
+
+# ---------- Summary ----------
+echo ""
+echo "=== $((PASS + FAIL)) tests: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Add `--bus <name>` flag to `pilot-circuit-breaker.sh` so each agent bus can be checked against its own daily PR cap
- Support map format for `max_prs_per_day` in `.bsg-autopilot.yml` with per-bus caps and `_default` fallback (backward-compat with existing scalar format)
- Filter the `gh pr list` query by bus label when `--bus` is provided, so each bus counts only its own pilot PRs
- Fix macOS awk/grep `\s` incompatibility — use `[ \t]*` character classes throughout

## Test plan

- [x] New test file `claude-skills/tests/test_circuit_breaker.sh` — 9 tests, all pass
- [x] Scalar `max_prs_per_day` (backward-compat): global cap unchanged
- [x] Map format: per-bus cap (`tech: 5`) respected
- [x] Map format: `_default` fallback used for unlisted buses
- [x] Under-cap → exit 0; at/over cap → exit 1
- [x] No `.bsg-autopilot.yml` → hardcoded default of 3

Closes #289