### PR TITLE
feat(autopilot): override_never_auto_implements — meta-repo self-editing

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -36,6 +36,19 @@ budget:
 # "Autopilot mode → auto_merge".
 auto_merge: true
 
+# bsg-stack-specific override: this is the meta-repo where agents and
+# skills are authored. The default "cannot rewrite peers" clause is a
+# safeguard for downstream consumer repos — here it actively blocks
+# the work. We override it explicitly. See #287/#288 — agent frontmatter
+# updates that an agent must perform on another agent.
+override_never_auto_implements:
+  tech:
+    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+  qa:
+    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+  seo:
+    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+
 peer_review:
   tech:
     reviews: [qa, seo]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,42 @@ diff, not implicit in the agent's narrative. When an agent is
 `output: pr`, `auto-implements` stays empty and `never-auto-implements`
 carries at least one clause explaining the exclusion.
 
+#### Repo-level overrides — `override_never_auto_implements`
+
+Some `never-auto-implements` clauses exist as safety rails for
+**downstream consumer repos** but become active blockers in
+meta-repos. The canonical example is `"changes to
+claude-skills/agents/*.md (cannot rewrite peers)"` — sane in a
+consumer repo where agent files are cached read-only, actively
+preventing work in `bsg-stack` itself where editing agent definitions
+*is* the work.
+
+A repo may declare an override map in `.bsg-autopilot.yml`:
+
+```yaml
+override_never_auto_implements:
+  tech:
+    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+  qa:
+    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+  seo:
+    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
+```
+
+During phase B step 3 (scope contract check), each `output: commit`
+agent reads its own frontmatter `never-auto-implements`, then
+**subtracts** the clauses listed under its bus label in
+`override_never_auto_implements`. The match is **exact-string**.
+Clauses not overridden still apply normally. The override only
+loosens the agent's deny list — it does not weaken any other
+guardrail (budget, circuit-breaker, scope contract allow-list).
+
+Override entries should be exceptional and self-explanatory in the
+diff: name the clause being lifted and explain why the repo is the
+exception. `bsg-stack` is the demonstrator — it overrides the
+"cannot rewrite peers" clause for tech, qa, and seo because every
+E10-style task requires editing peer agent definitions.
+
 ### Enabling auto-implementation on a target repository
 
 Auto-implementation is opt-in at the **repo level** via

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -201,6 +201,14 @@ When the tick's phase (B) runs, the procedure is:
    doesn't match at least one `auto-implements` clause, skip it too —
    the contract is allow-list.
 
+   **Repo-level override.** Before applying a `never-auto-implements`
+   clause, check whether the repo's `.bsg-autopilot.yml` carries an
+   `override_never_auto_implements:` map. If the calling agent (`qa`)
+   is a key in that map and the clause string appears in its list,
+   the clause is **disabled** for this repo. Treat the issue as if the
+   clause weren't there. This is how meta-repos like `bsg-stack` opt
+   into agents editing each other's definitions.
+
 4. **Budget the attempt.** Abort at 80 000 tokens for this single issue.
    If the abort hits, close the draft PR with a reasoning comment; do
    NOT retry until the issue's label set changes.

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -195,6 +195,14 @@ When the tick's phase (B) runs, the procedure is:
    doesn't match at least one `auto-implements` clause, skip it too —
    the contract is allow-list.
 
+   **Repo-level override.** Before applying a `never-auto-implements`
+   clause, check whether the repo's `.bsg-autopilot.yml` carries an
+   `override_never_auto_implements:` map. If the calling agent (`seo`)
+   is a key in that map and the clause string appears in its list,
+   the clause is **disabled** for this repo. Treat the issue as if the
+   clause weren't there. This is how meta-repos like `bsg-stack` opt
+   into agents editing each other's definitions.
+
 4. **Budget the attempt.** Abort at 80 000 tokens for this single issue.
    If the abort hits, close the draft PR with a reasoning comment; do
    NOT retry until the issue's label set changes.

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -192,6 +192,14 @@ When the tick's phase (B) runs, the procedure is:
    doesn't match at least one `auto-implements` clause, skip it too —
    the contract is allow-list.
 
+   **Repo-level override.** Before applying a `never-auto-implements`
+   clause, check whether the repo's `.bsg-autopilot.yml` carries an
+   `override_never_auto_implements:` map. If the calling agent (`tech`)
+   is a key in that map and the clause string appears in its list,
+   the clause is **disabled** for this repo. Treat the issue as if the
+   clause weren't there. This is how meta-repos like `bsg-stack` opt
+   into agents editing each other's definitions.
+
 4. **Budget the attempt.** Abort at 80 000 tokens for this single issue.
    If the abort hits, close the draft PR with a reasoning comment; do
    NOT retry until the issue's label set changes.


### PR DESCRIPTION
## Summary

Le tick agentique d'aujourd'hui a identifié 6 candidats incluant #287 / #288 mais **skippé tous** parce qu'ils touchent `claude-skills/agents/*.md` — la clause `never-auto-implements: "cannot rewrite peers"`. L'autopilot a fonctionné exactement comme spécifié — la spec était fausse pour bsg-stack qui EST le meta-repo où les agents évoluent.

## Solution

Mécanisme `override_never_auto_implements` dans `.bsg-autopilot.yml` qui désactive des clauses spécifiques **par agent** et **par exact-string match**.

```yaml
override_never_auto_implements:
  tech:
    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
  qa:
    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
  seo:
    - "changes to claude-skills/agents/*.md (cannot rewrite peers)"
```

Pendant phase B step 3, l'agent lit son `never-auto-implements`, soustrait les clauses présentes dans l'override map sous son bus_label, puis matche le résultat. Les autres garde-fous (budget, circuit-breaker, allow-list) ne sont pas touchés.

## Bootstrap

Cette PR touche `claude-skills/agents/{qa,seo,tech-lead}.md` → bloquée par la clause qu'elle supprime → faite manuellement. **Une fois mergée**, l'override est actif et les agents peuvent implémenter #287/#288.

## Files

| Fichier | Modif | LOC |
|---|---|---|
| `.bsg-autopilot.yml` | ajout du bloc `override_never_auto_implements` + commentaire d'intention | +13 |
| `claude-skills/agents/{qa,seo,tech-lead}.md` | phase B step 3 consulte l'override avant d'appliquer never-auto-implements | +8 chacun |
| `CLAUDE.md` | section "Repo-level overrides" qui explique exact-string match, scope, et l'exception bsg-stack | +36 |

Total : **73 LOC, 5 fichiers** (sous le nouveau cap 200/8).

## Test plan

- [x] `python3 -m unittest claude-skills/tests/test_skills.py` → 15/15 OK
- [x] `bash claude-skills/tests/test_pilot_candidates.sh` → 16/16 OK
- [ ] Après merge : prochain `/tick-all` doit picker #287 ou #288 (au lieu de skip-all)

## Why this is the right level of abstraction

- **Pas de hardcode "bsg-stack"** dans les agent files — l'override est dans la config du repo
- **Granularité fine** : par agent (tech/qa/seo séparément) + par clause (exact string)
- **Safe by default** : les consumer repos sans override gardent les deny lists complètes
- **Audit trail** : la liste d'overrides apparaît dans le diff de `.bsg-autopilot.yml`, donc explicite
- **Reverse-compatible** : un agent ancien qui ne consulte pas l'override fonctionne toujours, juste plus restrictif

🤖 Generated with [Claude Code](https://claude.com/claude-code)