### PR TITLE
feat(autopilot): agent budget references .bsg-autopilot.yml dynamically

### DIFF
--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -53,8 +53,8 @@ tick: >
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa"
-  - "label:enhancement + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa + estimated fix size <= 30 LOC and touches <= 3 files"
-  - "estimated fix size <= 30 LOC and touches <= 3 files"
+  - "label:enhancement + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa + fits .bsg-autopilot.yml budget"
+  - "fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)"
   - "finding is a missing test for a regression (reproduces failure, then asserts fix)"
 never-auto-implements:
   - "changes to claude-skills/agents/*.md (cannot rewrite peers)"

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -56,8 +56,8 @@ tick: >
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo"
-  - "label:enhancement + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo + estimated fix size <= 30 LOC and touches <= 3 files"
-  - "estimated fix size <= 30 LOC and touches <= 3 files"
+  - "label:enhancement + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo + fits .bsg-autopilot.yml budget"
+  - "fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)"
   - "finding is a missing HTML element (canonical tag, meta description, alt text, structured data)"
 never-auto-implements:
   - "changes to claude-skills/agents/*.md (cannot rewrite peers)"

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -53,8 +53,8 @@ tick: >
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
   - "label:bug + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech"
-  - "label:enhancement + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech + estimated fix size <= 30 LOC and touches <= 3 files"
-  - "estimated fix size <= 30 LOC and touches <= 3 files"
+  - "label:enhancement + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech + fits .bsg-autopilot.yml budget"
+  - "fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)"
   - "bug description contains reproducible failure case or explicit expected/actual behaviour"
 never-auto-implements:
   - "changes to claude-skills/agents/*.md (cannot rewrite peers)"


### PR DESCRIPTION
## Summary

Frontmatter dans tech-lead/qa/seo hardcodait \`estimated fix size <= 30 LOC and touches <= 3 files\` — le budget pilote original. PR #291 a remonté le runtime budget à 200/8 mais la frontmatter n'a pas suivi, donc les agents skippaient silencieusement les enhancements de plus de 30 LOC.

Remplacement par \`fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)\` — référence dynamique qui suit la config sans patch frontmatter à chaque fois.

## Why

Combiné avec #300 (override never-auto-implements pour bsg-stack), cette PR débloque l'agent sur #287/#288.

## Files

3 fichiers, 6 LOC. Fits 30/3 budget, donc cette PR pourrait elle-même être agent-implémentée. Faite manuellement pour bootstrapper le changement.

## Test plan

- [x] \`python3 -m unittest claude-skills/tests/test_skills.py\` → 15/15 OK
- [ ] Après merge + cache refresh : \`@tech-lead tick\` doit ramasser #287 ou #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)