### PR TITLE
feat(autopilot): activate the bus — needs:<agent> as PO inbox priority

### DIFF
--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -278,6 +278,36 @@ are **mechanically actionable** by another agent:
    on the **next** tick-all sweep
 6. Max `max_issues_per_tick` (from `.bsg-autopilot.yml`, default 3)
 
+### Inbox priority — `needs:<agent>` claim (#199, E7-bus-activation)
+
+After delegating, **the PO sets the work order** by applying
+`needs:<agent>` to the issues that should be picked up on the next
+tick. The agent's `list-pilot-candidates.sh` returns inbox issues
+(those carrying `needs:<agent>`) in priority over the rest of the
+backlog — the PO controls what the agent actually attempts, not just
+what the agent CAN attempt.
+
+```bash
+# Promote one issue to the front of the tech queue:
+gh issue edit <num> --add-label "needs:tech"
+
+# Demote / cancel the claim:
+gh issue edit <num> --remove-label "needs:tech"
+```
+
+Conventions:
+
+- When the inbox is empty for a given agent, the script falls back to
+  oldest-first across all owned (`<agent>`) issues, so repos without
+  an active PO behave as before.
+- `auto-merge-or-flag.sh` removes `needs:<agent>` after the
+  implementation PR is merged or flagged, so the inbox advances to
+  the next priority automatically.
+- Apply `needs:<agent>` only to issues that are **ready to ship** —
+  fully specified, unblocked, within budget. The PO's discipline here
+  is the difference between an agent doing the right work and an
+  agent doing the next available work.
+
 ### Receipt format
 
 When issues are delegated, append to the tick receipt:

--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -64,8 +64,14 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
   gh pr edit "$PR_NUMBER" --add-label human-reviewed --remove-label needs-human-review >/dev/null 2>&1 || true
   gh pr merge "$PR_NUMBER" --squash --delete-branch >/dev/null
   [[ -n "$LINKED_ISSUE" ]] && bus_unlock "$LINKED_ISSUE" "$AGENT" || true
+  # Advance the PO inbox: drop needs:<agent> from the linked issue so the
+  # next tick picks the next priority claim. #199 (E7-bus-activation).
+  [[ -n "$LINKED_ISSUE" ]] && gh issue edit "$LINKED_ISSUE" --remove-label "needs:$AGENT" >/dev/null 2>&1 || true
 else
   echo "auto-merge-or-flag: PR #${PR_NUMBER} ← needs-human-review (default)"
   gh pr edit "$PR_NUMBER" --add-label needs-human-review >/dev/null
   [[ -n "$LINKED_ISSUE" ]] && bus_unlock "$LINKED_ISSUE" "$AGENT" || true
+  # Drop needs:<agent> as well — once the PR is in human review, the
+  # PO inbox claim has been consumed regardless of merge state.
+  [[ -n "$LINKED_ISSUE" ]] && gh issue edit "$LINKED_ISSUE" --remove-label "needs:$AGENT" >/dev/null 2>&1 || true
 fi

--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -7,6 +7,14 @@
 #   - at least one epic:* label
 #   - has no open PR already referencing it (agent didn't start work yet)
 #
+# Priority — needs:<agent> as PO inbox (#199, E7-bus-activation):
+# When at least one open issue carries label:needs:<agent>, only those
+# are returned (the PO has explicitly claimed which work to do next).
+# When the inbox is empty, the script falls back to the full bus
+# backlog — oldest-first by issue number — for backward compatibility
+# with repos that don't run an active PO. This activates the bus
+# routing primitive from docs/label-taxonomy.md.
+#
 # Auto-implementation is opt-in at the **repo level** via
 # .bsg-autopilot.yml. Without the file, with `enabled: false`, or when
 # the calling agent is not listed under `agents:`, no candidates are
@@ -75,8 +83,9 @@ candidates_json=$(gh issue list "${REPO_FLAG[@]}" \
 #   - label:bug OR label:enhancement (#282)
 #   - at least one epic:* label
 #   - no open PR already touching this issue (avoid re-attempting)
-# Emit one JSON object per line.
-filtered=$(jq -c '
+# Emit one JSON object per line. Each candidate carries an "inbox"
+# boolean: true when label:needs:<agent> is present (PO claim).
+filtered=$(jq -c --arg needs "needs:$AGENT" '
   .[]
   | select(.labels | any(.name == "bug" or .name == "enhancement"))
   | select(.labels | any(.name | startswith("epic:")))
@@ -84,9 +93,19 @@ filtered=$(jq -c '
       number,
       title,
       url,
-      epics: [.labels[].name | select(startswith("epic:"))]
+      epics: [.labels[].name | select(startswith("epic:"))],
+      inbox: (.labels | any(.name == $needs))
     }
 ' <<<"$candidates_json")
+
+# Inbox priority (#199): if any issue carries needs:<agent>, only emit
+# those — that's the PO claim. Otherwise fall back to the full backlog
+# (oldest-first preserved by gh issue list ordering) so repos without
+# an active PO keep the previous behavior.
+inbox_items=$(jq -c 'select(.inbox == true)' <<<"$filtered")
+if [[ -n "$inbox_items" ]]; then
+  filtered="$inbox_items"
+fi
 
 echo "$filtered"
 


### PR DESCRIPTION
## Summary

Active la dette **#199 (E7-bus-activation)** — le bus était documenté mais inerte. Le PO pouvait poser \`needs:<agent>\` sans effet runtime.

## Closes

Closes #199 partially (script-level activation). Le tick-all skill et github-bus.sh primitives ne sont pas encore branchés à 100% mais c'est le path critique.

## Changes

| Fichier | Modif | LOC |
|---|---|---|
| \`list-pilot-candidates.sh\` | Si ≥ 1 issue avec \`needs:<agent>\` → ne retourner que celles-là (PO inbox). Sinon fallback sur la backlog complète (oldest-first, comportement actuel) | +20 |
| \`auto-merge-or-flag.sh\` | Après merge/flag, retirer \`needs:<agent>\` de l'issue parente → l'inbox avance | +6 |
| \`agents/po-manager.md\` | Phase A.5 : nouvelle section "Inbox priority" qui documente le mécanisme | +30 |

Total : **+58/-3 LOC, 3 fichiers**. Sous le cap 200/8.

## Test plan

- [x] \`python3 -m unittest claude-skills/tests/test_skills.py\` → 15/15 OK
- [x] \`bash claude-skills/tests/test_pilot_candidates.sh\` → 16/16 OK
- [x] **Live smoke test** :
  \`\`\`bash
  $ bash claude-skills/scripts/list-pilot-candidates.sh --agent tech
  {\"number\":287, ..., \"inbox\":true}
  \`\`\`
  Avec #287 en inbox, le script retourne **uniquement #287**. Avant cette PR, il aurait retourné #62, #63, #104, #199, #287, #288.

## Backward compatibility

Repos sans PO actif : aucun \`needs:<agent>\` posé → fallback sur la backlog complète comme avant. **Pas de régression**.

## Suite

Une fois mergée :
1. \`needs:tech\` sur #287 (déjà posé par le report PO d'aujourd'hui)
2. Cache refresh (\`update-bsg-skills.py\` + \`rm\` forcé)
3. Prochain \`/tick-all\` → tech-lead implémente #287 directement, plus de queue à traverser

🤖 Generated with [Claude Code](https://claude.com/claude-code)