### PR TITLE
fix(pilot): feat(po): migrate epic:* labels to GitHub milestones — script + bascule éligibilité (#287)

### DIFF
--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -26,8 +26,8 @@ tick: >
   produced mechanically-fixable findings (coverage drop on a specific file,
   high-risk file with zero coverage), file up to max_issues_per_tick (default 3)
   GitHub issues via `file-issue.sh --agent qa --filed-by qa --dedup <fingerprint>`.
-  Each issue carries label:bug + label:qa + label:epic:<plan-item> where the
-  epic is inferred from po/PLAN.md bindings. Skip if autopilot is not enabled
+  Each issue carries label:bug + label:qa + milestone:<plan-item> where the
+  milestone is inferred from po/PLAN.md bindings. Skip if autopilot is not enabled
   or if the finding doesn't match auto-implements.
   (B) Implementation pilot (#219, autopilot #221): determine the pilot
   receipt — one of seven canonical outcomes (see "Phase-B pilot receipt"
@@ -52,8 +52,8 @@ tick: >
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
-  - "label:bug + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa"
-  - "label:enhancement + label:qa + label:epic:* + .bsg-autopilot.yml authorizes qa + fits .bsg-autopilot.yml budget"
+  - "label:bug + label:qa + milestone:* + .bsg-autopilot.yml authorizes qa"
+  - "label:enhancement + label:qa + milestone:* + .bsg-autopilot.yml authorizes qa + fits .bsg-autopilot.yml budget"
   - "fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)"
   - "finding is a missing test for a regression (reproduces failure, then asserts fix)"
 never-auto-implements:
@@ -189,7 +189,7 @@ When the tick's phase (B) runs, the procedure is:
    `bash claude-skills/scripts/list-pilot-candidates.sh --agent qa`.
    The script enforces the label filter
    (`label:bug` or `label:enhancement` + `label:qa` + at least one
-   `label:epic:*`, only when `.bsg-autopilot.yml` authorizes qa).
+   `milestone:*`, only when `.bsg-autopilot.yml` authorizes qa).
    Empty output → stop.
 
 2. **Pick exactly one candidate** — oldest-first, tie-break by lowest

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -29,7 +29,7 @@ tick: >
   description, missing alt text, missing structured data), file up to
   max_issues_per_tick (default 3) GitHub issues via
   `file-issue.sh --agent seo --filed-by seo --dedup <fingerprint>`.
-  Each issue carries label:bug + label:seo + label:epic:<plan-item>.
+  Each issue carries label:bug + label:seo + milestone:<plan-item>.
   Skip if autopilot is not enabled or if the finding doesn't match
   auto-implements.
   (B) Implementation pilot (#216, autopilot #221): determine the pilot
@@ -55,8 +55,8 @@ tick: >
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
-  - "label:bug + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo"
-  - "label:enhancement + label:seo + label:epic:* + .bsg-autopilot.yml authorizes seo + fits .bsg-autopilot.yml budget"
+  - "label:bug + label:seo + milestone:* + .bsg-autopilot.yml authorizes seo"
+  - "label:enhancement + label:seo + milestone:* + .bsg-autopilot.yml authorizes seo + fits .bsg-autopilot.yml budget"
   - "fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)"
   - "finding is a missing HTML element (canonical tag, meta description, alt text, structured data)"
 never-auto-implements:
@@ -183,7 +183,7 @@ When the tick's phase (B) runs, the procedure is:
    `bash claude-skills/scripts/list-pilot-candidates.sh --agent seo`.
    The script enforces the label filter
    (`label:bug` or `label:enhancement` + `label:seo` + at least one
-   `label:epic:*`, only when `.bsg-autopilot.yml` authorizes seo).
+   `milestone:*`, only when `.bsg-autopilot.yml` authorizes seo).
    Empty output → stop.
 
 2. **Pick exactly one candidate** — oldest-first, tie-break by lowest

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -26,7 +26,7 @@ tick: >
   file with obvious split point, missing ADR for a new dependency), file up to
   max_issues_per_tick (default 3) GitHub issues via
   `file-issue.sh --agent tech-lead --filed-by tech --dedup <fingerprint>`.
-  Each issue carries label:bug + label:tech + label:epic:<plan-item>.
+  Each issue carries label:bug + label:tech + milestone:<plan-item>.
   Skip if autopilot is not enabled or if the finding doesn't match
   auto-implements.
   (B) Implementation pilot (#181, autopilot #221): determine the pilot
@@ -52,8 +52,8 @@ tick: >
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.
 auto-implements:
-  - "label:bug + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech"
-  - "label:enhancement + label:tech + label:epic:* + .bsg-autopilot.yml authorizes tech + fits .bsg-autopilot.yml budget"
+  - "label:bug + label:tech + milestone:* + .bsg-autopilot.yml authorizes tech"
+  - "label:enhancement + label:tech + milestone:* + .bsg-autopilot.yml authorizes tech + fits .bsg-autopilot.yml budget"
   - "fits .bsg-autopilot.yml budget (max_loc_per_issue, max_files_per_issue)"
   - "bug description contains reproducible failure case or explicit expected/actual behaviour"
 never-auto-implements:
@@ -180,7 +180,7 @@ When the tick's phase (B) runs, the procedure is:
 1. **Enumerate candidates** with
    `bash claude-skills/scripts/list-pilot-candidates.sh --agent tech`.
    The script returns issues with `label:bug` or `label:enhancement`
-   plus `label:tech` plus at least one `label:epic:*`, only when the
+   plus `label:tech` plus a GitHub milestone, only when the
    repo opts into autopilot via `.bsg-autopilot.yml`. Empty output → stop.
 
 2. **Pick exactly one candidate** — oldest-first, tie-break by lowest

--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -4,7 +4,7 @@
 # Returns open issues that satisfy ALL of:
 #   - label matches the caller's bus label (default: tech)
 #   - label:bug OR label:enhancement
-#   - at least one epic:* label
+#   - assigned to a GitHub milestone (replaces epic:* label — #287)
 #   - has no open PR already referencing it (agent didn't start work yet)
 #
 # Priority — needs:<agent> as PO inbox (#199, E7-bus-activation):
@@ -73,27 +73,28 @@ LABEL_FLAGS=(--label "$AGENT")
 # Pull open issues carrying all required labels. GitHub's search API
 # AND-s labels when multiple --label flags are passed, so the bug /
 # enhancement OR-filter is applied below in jq instead of via --label.
+# milestone is fetched so we can use it as the epic binding signal (#287).
 candidates_json=$(gh issue list "${REPO_FLAG[@]}" \
   --state open \
   "${LABEL_FLAGS[@]}" \
-  --json number,title,labels,url \
+  --json number,title,labels,url,milestone \
   2>/dev/null || echo "[]")
 
 # Post-filter for:
 #   - label:bug OR label:enhancement (#282)
-#   - at least one epic:* label
+#   - assigned to a GitHub milestone (#287 — replaces epic:* label check)
 #   - no open PR already touching this issue (avoid re-attempting)
 # Emit one JSON object per line. Each candidate carries an "inbox"
 # boolean: true when label:needs:<agent> is present (PO claim).
 filtered=$(jq -c --arg needs "needs:$AGENT" '
   .[]
   | select(.labels | any(.name == "bug" or .name == "enhancement"))
-  | select(.labels | any(.name | startswith("epic:")))
+  | select(.milestone != null)
   | {
       number,
       title,
       url,
-      epics: [.labels[].name | select(startswith("epic:"))],
+      milestone: .milestone.title,
       inbox: (.labels | any(.name == $needs))
     }
 ' <<<"$candidates_json")

--- a/claude-skills/scripts/migrate-epics-to-milestones.sh
+++ b/claude-skills/scripts/migrate-epics-to-milestones.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# migrate-epics-to-milestones.sh — one-shot idempotent migration: epic:E* labels → GitHub milestones.
+#
+# Phase 2a of E10 label-simplification (#287).
+#
+# For each label of the form `epic:E*` in the target repo:
+#   1. Create a GitHub milestone with the same name (stripping the "epic:" prefix).
+#   2. For every open issue or PR carrying that label, assign the milestone.
+#
+# The script is idempotent: skip milestone creation if it already exists,
+# skip assignment if the item already carries the correct milestone.
+#
+# Usage:
+#   bash claude-skills/scripts/migrate-epics-to-milestones.sh --dry-run    # preview only
+#   bash claude-skills/scripts/migrate-epics-to-milestones.sh --apply      # execute
+#
+# Optional flags:
+#   --repo OWNER/NAME   target repo (default: current repo from git remote)
+#   --dry-run           print actions without executing (default if neither flag given)
+#   --apply             execute the migration
+#
+# Dependencies: gh (GitHub CLI), jq
+#
+# Exit codes:
+#   0 — success (or dry-run completed)
+#   1 — fatal error (missing dependency, bad args)
+
+set -euo pipefail
+
+DRY_RUN=true
+REPO_FLAG=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)  DRY_RUN=true; shift ;;
+    --apply)    DRY_RUN=false; shift ;;
+    --repo)     REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help)
+      sed -n '2,/^[^#]/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "migrate-epics-to-milestones.sh: unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Verify dependencies.
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh (GitHub CLI) is required" >&2; exit 1
+fi
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required" >&2; exit 1
+fi
+
+if "$DRY_RUN"; then
+  echo "[dry-run] No changes will be made. Pass --apply to execute."
+fi
+
+# ---- Step 1: Enumerate epic:E* labels in the target repo ----
+epic_labels=$(gh label list "${REPO_FLAG[@]}" \
+  --search "epic:" \
+  --json name \
+  --jq '.[].name | select(startswith("epic:E"))' 2>/dev/null || true)
+
+if [[ -z "$epic_labels" ]]; then
+  echo "No epic:E* labels found — nothing to migrate."
+  exit 0
+fi
+
+echo "Found epic labels to migrate:"
+echo "$epic_labels" | sed 's/^/  /'
+
+# ---- Step 2: For each label, ensure its milestone exists ----
+
+# Fetch current milestones once.
+existing_milestones=$(gh api "${REPO_FLAG[@]:+${REPO_FLAG[*]}}" \
+  repos/:owner/:repo/milestones \
+  --paginate \
+  --jq '[.[].title]' 2>/dev/null || echo "[]")
+
+maybe_run() {
+  # maybe_run <description> <command...>
+  local desc="$1"; shift
+  if "$DRY_RUN"; then
+    echo "[dry-run] $desc"
+  else
+    echo "[apply] $desc"
+    "$@"
+  fi
+}
+
+while IFS= read -r label; do
+  # Strip "epic:" prefix to get the milestone name.
+  milestone_name="${label#epic:}"
+
+  # Check if milestone already exists.
+  already_exists=$(echo "$existing_milestones" | jq -r --arg m "$milestone_name" 'any(.[]; . == $m)')
+
+  if [[ "$already_exists" == "true" ]]; then
+    echo "  milestone '$milestone_name' already exists — skipping creation"
+  else
+    maybe_run "create milestone '$milestone_name'" \
+      gh api "${REPO_FLAG[@]:+${REPO_FLAG[*]}}" \
+        repos/:owner/:repo/milestones \
+        --method POST \
+        --field title="$milestone_name" \
+        --silent
+  fi
+
+  # ---- Step 3: Assign milestone to all open issues/PRs with this label ----
+  items=$(gh issue list "${REPO_FLAG[@]}" \
+    --state open \
+    --label "$label" \
+    --json number,milestone \
+    --jq '.[]' 2>/dev/null || true)
+
+  if [[ -z "$items" ]]; then
+    echo "  no open issues with label '$label'"
+    continue
+  fi
+
+  while IFS= read -r item; do
+    num=$(echo "$item" | jq -r '.number')
+    current_ms=$(echo "$item" | jq -r '.milestone.title // ""')
+
+    if [[ "$current_ms" == "$milestone_name" ]]; then
+      echo "  #$num already has milestone '$milestone_name' — skipping"
+      continue
+    fi
+
+    maybe_run "assign milestone '$milestone_name' to #$num (currently: '${current_ms:-none}')" \
+      gh issue edit "$num" "${REPO_FLAG[@]}" \
+        --milestone "$milestone_name"
+  done < <(echo "$items")
+
+done < <(echo "$epic_labels")
+
+echo ""
+if "$DRY_RUN"; then
+  echo "Dry-run complete. Re-run with --apply to execute."
+else
+  echo "Migration complete."
+fi

--- a/claude-skills/tests/test_pilot_candidates.sh
+++ b/claude-skills/tests/test_pilot_candidates.sh
@@ -55,9 +55,9 @@ cat > "$MOCK_GH" <<'MOCK'
 # Only capture args for `gh issue list` calls.
 if [[ "${2:-}" == "list" ]]; then
   echo "$@" > "$GH_ARGS_FILE"
-  # Return one issue with an epic label so jq post-filter passes it through.
+  # Return one issue with a milestone so jq post-filter passes it through.
   cat <<'JSON'
-[{"number":67,"title":"test issue","url":"https://example.com/67","labels":[{"name":"bug"},{"name":"tech"},{"name":"epic:E2"}]}]
+[{"number":67,"title":"test issue","url":"https://example.com/67","labels":[{"name":"bug"},{"name":"tech"}],"milestone":{"title":"E2-some-epic"}}]
 JSON
 fi
 # bus_lock calls `gh issue edit` — succeed silently.
@@ -138,16 +138,16 @@ agents:
 YAML
 }
 
-# ---------- Test 5: jq post-filter requires epic:* label ----------
-echo "--- Test 5: epic filter ---"
+# ---------- Test 5: jq post-filter requires milestone (not epic label) ----------
+echo "--- Test 5: milestone filter — issue without milestone is rejected ---"
 write_autopilot_enabled
-# Mock gh returns an issue WITHOUT an epic label.
+# Mock gh returns an issue WITHOUT a milestone.
 cat > "$MOCK_GH" <<'MOCK2'
 #!/usr/bin/env bash
 if [[ "${2:-}" == "list" ]]; then
   echo "$@" > "$GH_ARGS_FILE"
   cat <<'JSON'
-[{"number":99,"title":"no epic","url":"https://example.com/99","labels":[{"name":"bug"},{"name":"tech"}]}]
+[{"number":99,"title":"no milestone","url":"https://example.com/99","labels":[{"name":"bug"},{"name":"tech"}],"milestone":null}]
 JSON
 fi
 MOCK2
@@ -158,7 +158,7 @@ if [[ -z "$OUTPUT" ]]; then
   PASS=$((PASS + 1))
 else
   FAIL=$((FAIL + 1))
-  echo "FAIL: T5: issue without epic should be filtered out, got: $OUTPUT"
+  echo "FAIL: T5: issue without milestone should be filtered out, got: $OUTPUT"
 fi
 
 # ---------- Test 6: needs-human-review must NEVER appear in label flags ----------
@@ -189,7 +189,7 @@ cat > "$MOCK_GH" <<'MOCK4'
 if [[ "${2:-}" == "list" ]]; then
   echo "$@" > "$GH_ARGS_FILE"
   cat <<'JSON'
-[{"number":42,"title":"lock me","url":"https://example.com/42","labels":[{"name":"bug"},{"name":"tech"},{"name":"epic:E1"}]}]
+[{"number":42,"title":"lock me","url":"https://example.com/42","labels":[{"name":"bug"},{"name":"tech"}],"milestone":{"title":"E1-tick-hygiene"}}]
 JSON
 elif [[ "${2:-}" == "edit" ]]; then
   echo "$@" > "$GH_LOCK_FILE"
@@ -211,7 +211,7 @@ cat > "$MOCK_GH" <<'MOCK8'
 if [[ "${2:-}" == "list" ]]; then
   echo "$@" > "$GH_ARGS_FILE"
   cat <<'JSON'
-[{"number":62,"title":"enh","url":"https://example.com/62","labels":[{"name":"enhancement"},{"name":"tech"},{"name":"epic:E1"}]}]
+[{"number":62,"title":"enh","url":"https://example.com/62","labels":[{"name":"enhancement"},{"name":"tech"}],"milestone":{"title":"E1-tick-hygiene"}}]
 JSON
 fi
 MOCK8
@@ -228,7 +228,7 @@ cat > "$MOCK_GH" <<'MOCK9'
 if [[ "${2:-}" == "list" ]]; then
   echo "$@" > "$GH_ARGS_FILE"
   cat <<'JSON'
-[{"number":77,"title":"docs","url":"https://example.com/77","labels":[{"name":"documentation"},{"name":"tech"},{"name":"epic:E1"}]}]
+[{"number":77,"title":"docs","url":"https://example.com/77","labels":[{"name":"documentation"},{"name":"tech"}],"milestone":{"title":"E1-tick-hygiene"}}]
 JSON
 fi
 MOCK9
@@ -240,6 +240,64 @@ if [[ -z "$OUTPUT" ]]; then
 else
   FAIL=$((FAIL + 1))
   echo "FAIL: T9: docs-only issue should be filtered out, got: $OUTPUT"
+fi
+
+# ---------- Test 10: milestone-based candidate emits milestone field (#287) ----------
+echo "--- Test 10: candidate with milestone emits milestone field, not epics ---"
+write_autopilot_enabled
+cat > "$MOCK_GH" <<'MOCK10'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
+[{"number":100,"title":"milestone issue","url":"https://example.com/100","labels":[{"name":"bug"},{"name":"tech"}],"milestone":{"title":"E5-learn-skill-dedup"}}]
+JSON
+fi
+MOCK10
+chmod +x "$MOCK_GH"
+
+OUTPUT="$(bash "$SUT" --agent tech 2>/dev/null)"
+assert_contains "T10: candidate surfaces" "$OUTPUT" '"number":100'
+assert_contains "T10: has milestone field" "$OUTPUT" '"milestone"'
+assert_contains "T10: milestone title correct" "$OUTPUT" 'E5-learn-skill-dedup'
+assert_not_contains "T10: no epics field" "$OUTPUT" '"epics"'
+
+# ---------- Test 11: gh issue list JSON must include milestone field (#287) ----------
+echo "--- Test 11: gh issue list is called with milestone in --json fields ---"
+write_autopilot_enabled
+cat > "$MOCK_GH" <<'MOCK11'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  echo '[]'
+fi
+MOCK11
+chmod +x "$MOCK_GH"
+
+bash "$SUT" --agent tech >/dev/null 2>&1
+ARGS="$(cat "$GH_ARGS_FILE")"
+assert_contains "T11: milestone in --json fields" "$ARGS" "milestone"
+
+# ---------- Test 12: issue with milestone=null is rejected even with epic label (#287) ----------
+echo "--- Test 12: epic label alone (no milestone) is no longer sufficient ---"
+write_autopilot_enabled
+cat > "$MOCK_GH" <<'MOCK12'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "list" ]]; then
+  echo "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
+[{"number":200,"title":"epic but no milestone","url":"https://example.com/200","labels":[{"name":"bug"},{"name":"tech"},{"name":"epic:E1-tick-hygiene"}],"milestone":null}]
+JSON
+fi
+MOCK12
+chmod +x "$MOCK_GH"
+
+OUTPUT="$(bash "$SUT" --agent tech 2>/dev/null)"
+if [[ -z "$OUTPUT" ]]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: T12: issue with epic label but no milestone should be rejected, got: $OUTPUT"
 fi
 
 # ---------- Summary ----------

--- a/tech/reports/2026-04-30-health.md
+++ b/tech/reports/2026-04-30-health.md
@@ -1,8 +1,8 @@
 <!-- fingerprint: none -->
 # Tech Health — 2026-04-30
 
-**Repository:** `agent-a839d6f4072cbea77`
-**Generated:** 2026-04-30T14:36:37Z
+**Repository:** `agent-aef939edb0fbf556c`
+**Generated:** 2026-04-30T14:55:38Z
 **Ecosystems:** 
 
 ---
@@ -46,3 +46,7 @@ _No ADR directory found. Consider creating `adr/0001-start.md` to document the f
 
 
 
+
+---
+
+pilot: attempted #287 — PR pending


### PR DESCRIPTION
## Summary

- **2a — Migration script** (`claude-skills/scripts/migrate-epics-to-milestones.sh`): idempotent one-shot script that creates a GitHub milestone per `epic:E*` label and assigns it to all open issues/PRs carrying that label. Supports `--dry-run` / `--apply` flags.
- **2b — Candidate eligibility** (`claude-skills/scripts/list-pilot-candidates.sh`): replaces `select(.labels | any(.name | startswith("epic:")))` with `select(.milestone != null)` and emits `milestone: .milestone.title` instead of `epics: [...]`. Adds `milestone` to `--json` fields.
- **Agent frontmatter** (`tech-lead.md`, `qa.md`, `seo.md`): `auto-implements` clauses updated from `label:epic:*` to `milestone:*`; body text references updated to match.

Fixes #287

## Test plan

- [x] T10: issue with milestone surfaces as candidate with `milestone` field (not `epics`)
- [x] T11: `gh issue list` call includes `milestone` in `--json` fields
- [x] T12: issue with `epic:*` label but no milestone is rejected
- [x] All 22 existing pilot-candidate tests pass
- [x] All 15 Python `test_skills.py` subtests pass
- [x] All bash test suites (circuit-breaker, github-bus, tick-fingerprint, read-intent) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)