### PR TITLE
fix(pilot): retire needs-rework — replace with comment-only peer review (#312)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,7 +434,7 @@ The tick gains a phase **(C)** after implementation:
 3. For each eligible PR (max 2 per tick): read the diff, evaluate
    against the agent's criteria, post a review comment
 4. Apply `peer-reviewed:<reviewer>` label after review
-5. If issues found, also apply `needs-rework`
+5. If issues found, post a review comment with the rework rationale (comment-only — no label)
 
 **Hard rules for peer review:**
 - Agents NEVER merge PRs — only comment and label
@@ -449,7 +449,6 @@ The tick gains a phase **(C)** after implementation:
 | Label | Applied by | Meaning |
 |---|---|---|
 | `peer-reviewed:<agent>` | Reviewing agent | This agent has reviewed the PR |
-| `needs-rework` | Reviewing agent | Issues found — author should address before human review |
 
 ### Coordination bus (GitHub labels as queues)
 

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -46,8 +46,8 @@ tick: >
   section listing po, run `peer-review-candidates.sh --reviewer po`.
   For each candidate PR (max 2 per tick): check plan alignment, scope-creep
   risk, and epic binding. Add a review comment and apply `peer-reviewed:po`
-  label. If the PR implements work outside the current plan, also apply
-  `needs-rework`. Never merge, never apply `human-reviewed`.
+  label. If the PR implements work outside the current plan, post a review
+  comment with the rework rationale. Never merge, never apply `human-reviewed`.
 delegates-to: [tech, qa, seo]
 auto-implements: []
 never-auto-implements:

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -46,8 +46,8 @@ tick: >
   section listing qa, run `peer-review-candidates.sh --reviewer qa`.
   For each candidate PR (max 2 per tick): read the diff, check for test
   coverage and regression risk. Add a review comment and apply
-  `peer-reviewed:qa` label. If issues found, also apply `needs-rework`.
-  Never merge, never apply `human-reviewed`.
+  `peer-reviewed:qa` label. If issues found, post a review comment with
+  the rework rationale. Never merge, never apply `human-reviewed`.
   In chat, reply with one line: `Tick: <state> — <PR URL> · pilot: <outcome>`.
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -25,8 +25,8 @@ tick: >
   section listing security, run `peer-review-candidates.sh --reviewer security`.
   For each candidate PR (max 2 per tick): scan the diff for secret patterns,
   injection risk, and dependency safety. Add a review comment and apply
-  `peer-reviewed:security` label. If issues found, also apply `needs-rework`.
-  Never merge, never apply `human-reviewed`, never auto-approve.
+  `peer-reviewed:security` label. If issues found, post a review comment
+  with the rework rationale. Never merge, never apply `human-reviewed`, never auto-approve.
 auto-implements: []
 never-auto-implements:
   - "security fixes must be written and reviewed by humans — never by an agent"

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -50,7 +50,7 @@ tick: >
   For each candidate PR (max 2 per tick): read the diff, check for SEO
   regressions (removed meta tags, broken canonical, dropped structured data).
   Add a review comment and apply `peer-reviewed:seo` label. If issues found,
-  also apply `needs-rework`. Never merge, never apply `human-reviewed`.
+  post a review comment with the rework rationale. Never merge, never apply `human-reviewed`.
   In chat, reply with one line: `Tick: <state> — <PR URL> · pilot: <outcome>`.
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -46,8 +46,8 @@ tick: >
   section listing tech, run `peer-review-candidates.sh --reviewer tech`.
   For each candidate PR (max 2 per tick): read the diff, check for code
   quality issues, architecture fit, and naming conventions. Add a review
-  comment and apply `peer-reviewed:tech` label. If issues found, also apply
-  `needs-rework`. Never merge, never apply `human-reviewed`.
+  comment and apply `peer-reviewed:tech` label. If issues found, post a
+  review comment with the rework rationale. Never merge, never apply `human-reviewed`.
   In chat, reply with one line: `Tick: <state> — <PR URL> · pilot: <outcome>`.
   The `pilot:` segment must always be present — see the seven canonical
   outcomes in the "Phase-B pilot receipt" table below.

--- a/claude-skills/tests/test_no_needs_rework_in_peer_review.sh
+++ b/claude-skills/tests/test_no_needs_rework_in_peer_review.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# test_no_needs_rework_in_peer_review.sh
+#
+# Asserts that no agent or CLAUDE.md peer review section instructs
+# reviewers to apply the `needs-rework` label. Per issue #312, peer
+# review is comment-only — the reviewer posts a comment with the rework
+# rationale instead of applying a label.
+#
+# Exit 0 = pass, 1 = fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+AGENT_FILES=(
+  "$REPO_ROOT/claude-skills/agents/tech-lead.md"
+  "$REPO_ROOT/claude-skills/agents/qa.md"
+  "$REPO_ROOT/claude-skills/agents/seo.md"
+  "$REPO_ROOT/claude-skills/agents/po-manager.md"
+  "$REPO_ROOT/claude-skills/agents/security.md"
+)
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+
+failures=0
+
+for f in "${AGENT_FILES[@]}" "$CLAUDE_MD"; do
+  if grep -qn "needs-rework" "$f"; then
+    echo "FAIL: needs-rework still referenced in $f"
+    grep -n "needs-rework" "$f"
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ $failures -eq 0 ]]; then
+  echo "PASS: no needs-rework references found in peer review docs"
+  exit 0
+else
+  echo "FAIL: $failures file(s) still reference needs-rework"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Replace `needs-rework` label application with comment-only peer review in all 5 agent files (`tech-lead`, `qa`, `seo`, `po-manager`, `security`) and `CLAUDE.md`
- The reviewing agent now posts a review comment with the rework rationale instead of applying a label — behavior is equivalent but removes label-management burden
- Adds a regression test (`test_no_needs_rework_in_peer_review.sh`) that fails before the fix and passes after

## Test plan

- [x] `bash claude-skills/tests/test_no_needs_rework_in_peer_review.sh` exits 0 (verified locally)
- [ ] Confirm no script reads `needs-rework` (grep confirms empty — verified in issue #312)
- [ ] Spot-check one agent file to confirm the instruction reads "post a review comment with the rework rationale"

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)