### PR TITLE
feat(autopilot): implement 6 efficiency fixes from #363

### DIFF
--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -42,6 +42,11 @@ tick: >
   Issues carry label:bug + target agent's bus label + label:needs-human-review
   + label:epic:<slug>. Max max_issues_per_tick (default 3) from
   .bsg-autopilot.yml. See the "Task delegation pipeline" section below.
+  Also run `bash claude-skills/scripts/po-decompose-oversized.sh` to surface
+  open issues whose estimated_loc exceeds max_loc_per_issue. The script
+  emits a JSONL list — DO NOT auto-split existing issues. Surface the list
+  in the status report under "Decomposition needed" so a human can decide
+  whether to split each one. See "Decomposing oversized issues" below.
   (C) Peer review (#222 phase 3b): if .bsg-autopilot.yml has a peer_review
   section listing po, run `peer-review-candidates.sh --reviewer po`.
   For each candidate PR (max 2 per tick): check plan alignment, scope-creep
@@ -359,6 +364,42 @@ When issues are delegated, append to the tick receipt:
 ```
 Tick: <status>, report at <PR url> — delegated N issues (tech:2, qa:1)
 ```
+
+### Decomposing oversized issues (#363 fix #4)
+
+The phase-B implementation pilots enforce a per-issue LOC cap
+(`max_loc_per_issue` in `.bsg-autopilot.yml`, default 200). Issues
+above the cap never get picked up — they sit in the backlog until a
+human splits them. The PO surfaces them every tick:
+
+```bash
+bash claude-skills/scripts/po-decompose-oversized.sh
+```
+
+The script emits one JSON line per oversized issue:
+
+```json
+{"number": 292, "title": "umbrella", "estimated_loc": 1500,
+ "agent": "tech", "milestone": "v2", "reason": "explicit-hint"}
+```
+
+It looks for explicit `estimated_loc:` / `~N LOC` hints in the issue
+body. When no hint is present, it falls back to a body-length
+heuristic (> 60 lines = "likely oversized") and flags the issue for
+manual sizing.
+
+**The PO does NOT auto-split.** Decomposition is a planning decision
+that requires human judgement. The script's job is to make the queue
+visible — the PO surfaces it in the status report under
+`## Decomposition needed`, and the human (or, optionally, the PO in
+a later confirmed action) calls `file-issue.sh --type enhancement`
+once for each sub-task. If the PO does file sub-issues, it must:
+
+- Route each one to the same target agent's bus label
+- Bind each one to the same milestone as the parent
+- Reference the parent in each child body
+  (`Child of #NN — see decomposition note`)
+- Cap at `max_issues_per_tick` per parent
 
 ---
 

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -17,6 +17,8 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh qa qa)"`.
   If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh qa qa qa)"`.
+  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phases A/A.5/B/C would re-derive identical output. The idle decision is logged to qa/idle-ticks.log.
   (A) Run the full QA audit (coverage + risk + flaky), archive the snapshot to
   qa/history/, write the report to qa/reports/YYYY-MM-DD-audit.md. Do NOT
   open the report PR yet — defer to (B.post) so the pilot receipt is embedded

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -18,6 +18,8 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh seo seo)"`.
   If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh seo seo seo)"`.
+  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phases A/A.5/B/C would re-derive identical output. The idle decision is logged to seo/idle-ticks.log.
   (A) Run the full SEO audit (meta + links + content + sitemap), write the
   report to seo/reports/YYYY-MM-DD-audit.md. Do NOT open the report PR yet
   — defer to (B.post) so the pilot receipt is embedded in the report. Stay

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -17,6 +17,8 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh tech-lead tech)"`.
   If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR" and skip to (B) — phases (A) and (A.5) are gated by audit freshness, but (B) and (C) have independent triggers and must always run.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh tech-lead tech tech)"`.
+  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phases A/A.5/B/C would re-derive identical output. The idle decision is logged to tech/idle-ticks.log.
   (A) Run the full architecture health check (deps + quality + debt + ADR gap
   detection). Write the detailed report to tech/reports/YYYY-MM-DD-health.md.
   Do NOT open the report PR yet — defer to (B.post) so the pilot receipt

--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -62,7 +62,26 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
   # Swap labels BEFORE merging — `gh pr edit` after `--delete-branch` can hit
   # a transient eventual-consistency window where the edit silently no-ops.
   gh pr edit "$PR_NUMBER" --add-label human-reviewed --remove-label needs-human-review >/dev/null 2>&1 || true
+  # Capture the head ref before merging — `gh pr merge --delete-branch`
+  # nukes the remote branch, but a local worktree may still reference it
+  # and we want to clean that up too (#363).
+  HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
   gh pr merge "$PR_NUMBER" --squash --delete-branch >/dev/null
+  # Post-merge cleanup: if a local worktree was checked out on this
+  # branch, remove it and delete the local branch ref. Best-effort —
+  # never fail the merge over cleanup. See #363.
+  if [[ -n "$HEAD_REF" ]]; then
+    wt_path=$(git worktree list --porcelain \
+      | awk -v b="refs/heads/$HEAD_REF" '
+          $1 == "worktree" {p=$2}
+          $1 == "branch" && $2 == b {print p; exit}
+        ')
+    if [[ -n "$wt_path" ]]; then
+      git worktree unlock "$wt_path" 2>/dev/null || true
+      git worktree remove --force "$wt_path" 2>/dev/null || true
+    fi
+    git branch -D "$HEAD_REF" 2>/dev/null || true
+  fi
   [[ -n "$LINKED_ISSUE" ]] && bus_unlock "$LINKED_ISSUE" "$AGENT" || true
   # Advance the PO inbox: drop needs:<agent> from the linked issue so the
   # next tick picks the next priority claim. #199 (E7-bus-activation).

--- a/claude-skills/scripts/file-issue.sh
+++ b/claude-skills/scripts/file-issue.sh
@@ -38,6 +38,13 @@
 # no output (idempotent). The fingerprint is appended to the body as
 # a hidden HTML comment: `<!-- bsg-dedup:FINGERPRINT -->`.
 #
+# With `--type bug|enhancement` (default: enhancement), the script
+# always appends the type label so the issue is picked up by
+# `list-pilot-candidates.sh`, which filters on
+# `select(.labels | any(.name == "bug" or .name == "enhancement"))`.
+# Without this, agent-filed issues from phase A.5 would never become
+# phase B candidates — see #363.
+#
 # Exits with the issue URL on stdout. Exits non-zero on any real failure.
 
 set -euo pipefail
@@ -48,6 +55,7 @@ REVIEW_DESC="Awaiting a human decision (triage, merge, or scope)"
 BUS_LABEL=""
 FILED_BY=""
 DEDUP_FINGERPRINT=""
+ISSUE_TYPE="enhancement"
 
 # Target repo is whatever `gh` resolves (explicit --repo wins, else the cwd).
 repo_flag=()
@@ -73,6 +81,13 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dedup)
       DEDUP_FINGERPRINT="$2"
+      shift 2
+      ;;
+    --type)
+      case "$2" in
+        bug|enhancement) ISSUE_TYPE="$2" ;;
+        *) echo "file-issue.sh: --type must be bug or enhancement, got: $2" >&2; exit 2 ;;
+      esac
       shift 2
       ;;
     *)
@@ -127,6 +142,8 @@ fi
 #   - needs-human-review (only outside autopilot mode)
 #   - (optional) the bus label that pins ownership to a specific agent
 #   - (optional) filed-by:<agent> for traceability
+#   - bug or enhancement (always — required for list-pilot-candidates.sh
+#     to recognise the issue, see #363)
 extra_labels=""
 if [[ "$APPLY_REVIEW_LABEL" == "true" ]]; then
   extra_labels="$REVIEW_LABEL"
@@ -134,6 +151,11 @@ fi
 if [[ -n "$BUS_LABEL" ]]; then
   extra_labels="${extra_labels:+$extra_labels,}$BUS_LABEL"
 fi
+
+# Always include the type label so phase-A.5 issues become phase-B
+# candidates. The caller may also pass --label "bug" explicitly; that's
+# fine — gh deduplicates labels server-side.
+extra_labels="${extra_labels:+$extra_labels,}$ISSUE_TYPE"
 if [[ -n "$FILED_BY" ]]; then
   filed_label="filed-by:${FILED_BY}"
   # Ensure the filed-by label exists.

--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -156,15 +156,23 @@ fi
 
 # Prefer auto-merge; fall back to direct squash merge if the repo has
 # no required checks / reviews configured (common for young repos).
-if ! gh pr merge --auto --squash "$pr_url" >/dev/null 2>&1; then
+# The `--delete-branch` flag cleans up the remote head ref so it
+# doesn't accumulate in `gh pr list --state all` output (#363).
+if ! gh pr merge --auto --squash --delete-branch "$pr_url" >/dev/null 2>&1; then
   echo "open-report-pr.sh: auto-merge not available, merging directly" >&2
-  gh pr merge --squash "$pr_url" >/dev/null
+  gh pr merge --squash --delete-branch "$pr_url" >/dev/null
 fi
 
 # Return to the original branch. Fast-forward pull to bring in the
 # merged commit (best-effort; ignored if the PR is still queued).
 git checkout "$original" >/dev/null 2>&1 || true
 git pull --ff-only >/dev/null 2>&1 || true
+
+# Post-merge cleanup: delete the local report branch we just pushed
+# (best-effort). The runtime / git-worktree may still hold a
+# reference; failure here doesn't matter — `prune-agent-worktrees.sh`
+# will catch the leftovers on the next tick. See #363.
+git branch -D "$branch" >/dev/null 2>&1 || true
 
 # If we're running inside an agent worktree under .claude/worktrees/agent-*,
 # release the lock so the dispatcher-level prune (or the Agent runtime)

--- a/claude-skills/scripts/po-decompose-oversized.sh
+++ b/claude-skills/scripts/po-decompose-oversized.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# po-decompose-oversized.sh — flag open issues whose estimated LOC exceeds
+# the autopilot budget so the PO can decompose them into sub-issues.
+#
+# Closes #363 fix #4. The output:commit pilot enforces a per-issue LOC
+# cap (`max_loc_per_issue` from .bsg-autopilot.yml). Issues above the
+# cap never get picked up — they sit in the backlog forever. This
+# script identifies them so the PO can split each one into sub-tickets
+# that fit the budget.
+#
+# What it does:
+#
+#   1. Read `max_loc_per_issue` from .bsg-autopilot.yml (default 200)
+#   2. Enumerate open issues that have a bus label (tech/qa/seo) AND
+#      are bound to a milestone — i.e. they would normally be phase-B
+#      candidates if they fit the budget.
+#   3. Estimate LOC for each issue from explicit hints in the body:
+#        - "estimated_loc: N"
+#        - "estimated LOC: N"
+#        - "~N LOC", "~N lines"
+#      When no hint is found, fall back to a body-length heuristic:
+#      issues with > 60 lines of body are treated as "likely oversized"
+#      and flagged for the PO to size manually.
+#   4. Emit a JSONL stream of oversized issues — one per line:
+#        {"number": N, "title": "...", "estimated_loc": N|null,
+#         "agent": "tech", "milestone": "..."}
+#   5. The PO reads this list and (optionally) files sub-issue stubs
+#      with `file-issue.sh --type enhancement`. This script does NOT
+#      create issues itself — the PO is the judge of whether to split,
+#      defer, or rescope.
+#
+# Usage:
+#   bash claude-skills/scripts/po-decompose-oversized.sh [--repo OWNER/NAME]
+#
+# Exit 0 always (no oversized issues is not an error).
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "po-decompose-oversized.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Read max_loc_per_issue from .bsg-autopilot.yml — fall back to 200.
+MAX_LOC=200
+if [[ -f .bsg-autopilot.yml ]]; then
+  configured=$(grep -E '^\s*max_loc_per_issue\s*:' .bsg-autopilot.yml 2>/dev/null \
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  if [[ -n "$configured" ]]; then
+    MAX_LOC="$configured"
+  fi
+fi
+
+# Bus labels we route to (`output: commit` agents).
+BUS_LABELS=("tech" "qa" "seo")
+
+emit_jsonl() {
+  local agent="$1"
+  gh issue list "${REPO_FLAG[@]}" \
+    --state open \
+    --label "$agent" \
+    --json number,title,body,milestone,labels \
+    --limit 200 2>/dev/null \
+    | jq -c --arg agent "$agent" --argjson cap "$MAX_LOC" '
+        .[]
+        | select(.milestone != null)
+        | . as $iss
+        | (
+            # Try to extract an explicit LOC hint from the body.
+            ($iss.body // "")
+            | (
+                capture("estimated[_ ]loc[: ]+(?<n>[0-9]+)"; "i").n //
+                capture("~\\s*(?<n>[0-9]+)\\s+(?:LOC|lines)"; "i").n //
+                empty
+              )
+            | tonumber
+          ) as $explicit
+        | (($iss.body // "") | split("\n") | length) as $body_lines
+        | if $explicit then
+            (if $explicit > $cap then
+              {number: $iss.number, title: $iss.title, estimated_loc: $explicit,
+               agent: $agent, milestone: $iss.milestone.title, reason: "explicit-hint"}
+             else empty end)
+          elif $body_lines > 60 then
+            {number: $iss.number, title: $iss.title, estimated_loc: null,
+             agent: $agent, milestone: $iss.milestone.title,
+             reason: "body-length>60 (no explicit estimate)"}
+          else empty end
+      '
+}
+
+for label in "${BUS_LABELS[@]}"; do
+  emit_jsonl "$label"
+done

--- a/claude-skills/scripts/prune-agent-worktrees.sh
+++ b/claude-skills/scripts/prune-agent-worktrees.sh
@@ -19,6 +19,13 @@
 # names, main, sibling worktrees outside .claude/worktrees/ — is left
 # alone. The script is safe to run anytime and emits a one-line summary.
 #
+# After the worktree pass, the script also deletes orphaned local
+# branches matching `worktree-agent-*` whose backing worktree is gone
+# (the runtime never deletes them, so they accumulate — see #363).
+# `git branch -D` is used because these scratch branches don't get
+# pushed and the standard `git branch -d` would refuse "not fully
+# merged" branches.
+#
 # Usage:
 #   bash claude-skills/scripts/prune-agent-worktrees.sh
 #
@@ -101,4 +108,21 @@ done < <(git worktree list --porcelain; echo)
 
 git worktree prune
 
-echo "prune-agent-worktrees: pruned=${pruned} kept=${kept}"
+# After pruning the worktrees, sweep orphaned worktree-agent-* branches
+# whose backing worktree is gone (#363). Build a set of branches still
+# referenced by an active worktree, then delete every other
+# worktree-agent-* local branch.
+active_branches=$(git worktree list --porcelain \
+  | awk '$1 == "branch" {sub("^refs/heads/", "", $2); print $2}')
+branch_pruned=0
+while IFS= read -r br; do
+  [[ -z "$br" ]] && continue
+  if grep -Fxq "$br" <<<"$active_branches"; then
+    continue
+  fi
+  if git branch -D "$br" >/dev/null 2>&1; then
+    branch_pruned=$((branch_pruned + 1))
+  fi
+done < <(git for-each-ref --format='%(refname:short)' 'refs/heads/worktree-agent-*')
+
+echo "prune-agent-worktrees: pruned=${pruned} kept=${kept} branches-pruned=${branch_pruned}"

--- a/claude-skills/scripts/tick-idle-check.sh
+++ b/claude-skills/scripts/tick-idle-check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# tick-idle-check.sh — pre-flight idle check for output:commit agents.
+#
+# Closes #363 fix #5. Cuts the recurring `/loop` cost when an agent has
+# nothing to do: when there are no phase-B candidates AND the audit
+# fingerprint hasn't changed since yesterday, the tick exits idle
+# without running phases A / A.5 / B / C.
+#
+# Decision matrix:
+#
+#   1. Run `list-pilot-candidates.sh --agent <name>`. If it emits ≥ 1
+#      candidate, we are NOT idle — the agent has phase-B work to do.
+#   2. Run `tick-fingerprint.sh <agent> <report-dir>`. If
+#      TICK_SHORT_CIRCUIT=1, today's report already matches the current
+#      input state — phase-A is unchanged. Combined with (1) being
+#      empty, there is nothing for this tick to produce.
+#   3. Otherwise the agent must run phases A/A.5/B/C as usual.
+#
+# When idle, the script appends a one-line entry to
+# `<report-dir>/idle-ticks.log` (e.g. `tech/idle-ticks.log`) for
+# trend analysis. The log is git-ignored by convention but committed
+# in repos that want to track agent cadence.
+#
+# Usage (sourced via eval, like tick-fingerprint.sh):
+#   eval "$(bash claude-skills/scripts/tick-idle-check.sh <agent-cli-name> <bus-label> <report-dir>)"
+#
+# Arguments:
+#   <agent-cli-name>  the name passed to tick-fingerprint.sh
+#                     (e.g. tech-lead, qa, seo)
+#   <bus-label>       the bus label passed to list-pilot-candidates.sh
+#                     (e.g. tech, qa, seo) — this differs from the CLI
+#                     name for tech-lead vs tech.
+#   <report-dir>      e.g. tech, qa, seo (used for idle-ticks.log path)
+#
+# Exports:
+#   TICK_IDLE             1 if the agent should short-circuit, 0 otherwise
+#   TICK_IDLE_RECEIPT     One-line receipt to surface in chat when idle
+#                         (e.g. "Tick: idle — no candidates")
+#
+# When TICK_IDLE=1, the calling agent should emit TICK_IDLE_RECEIPT and
+# exit without running phases A/A.5/B/C. See the agent's tick frontmatter
+# for the integration point.
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: tick-idle-check.sh <agent-cli-name> <bus-label> <report-dir>" >&2
+  exit 2
+fi
+
+AGENT_CLI="$1"
+BUS_LABEL="$2"
+REPORT_DIR="$3"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Step 1: are there any phase-B candidates?
+candidates=$(bash "$SCRIPT_DIR/list-pilot-candidates.sh" --agent "$BUS_LABEL" 2>/dev/null || echo "")
+candidate_count=$(printf '%s\n' "$candidates" | grep -c '^{' || true)
+
+# Step 2: is today's audit fingerprint already on file?
+# Run tick-fingerprint.sh in a subshell to capture its exports without
+# polluting the caller — we only need to know if SHORT_CIRCUIT was set.
+fp_exports=$(bash "$SCRIPT_DIR/tick-fingerprint.sh" "$AGENT_CLI" "$REPORT_DIR" 2>/dev/null || true)
+short_circuit=$(printf '%s\n' "$fp_exports" | sed -n 's/^export TICK_SHORT_CIRCUIT=//p' | head -1)
+
+TICK_IDLE=0
+TICK_IDLE_RECEIPT=""
+if [[ "$candidate_count" -eq 0 ]] && [[ "$short_circuit" == "1" ]]; then
+  TICK_IDLE=1
+  TICK_IDLE_RECEIPT="Tick: idle — no candidates"
+  # Append to idle-ticks.log for cadence analysis. Best-effort — never
+  # fail the tick over a missing report dir or unwritable filesystem.
+  log_dir="$REPO_ROOT/$REPORT_DIR"
+  if [[ -d "$log_dir" ]]; then
+    printf '%s %s idle (no candidates, audit fingerprint matched)\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AGENT_CLI" \
+      >> "$log_dir/idle-ticks.log" 2>/dev/null || true
+  fi
+fi
+
+cat <<EXPORTS
+export TICK_IDLE=$TICK_IDLE
+export TICK_IDLE_RECEIPT='$TICK_IDLE_RECEIPT'
+EXPORTS

--- a/claude-skills/skills/po/scripts/reconcile-milestones.sh
+++ b/claude-skills/skills/po/scripts/reconcile-milestones.sh
@@ -107,15 +107,33 @@ mapfile -t epic_lines < <(
 
 all_bound=()
 declare -A slug_to_nums
-for line in "${epic_lines[@]}"; do
+# Guard the loop body: when the plan parses but yields no epics,
+# `epic_lines` is an empty array and indexing `epic_lines[@]` under
+# `set -u` errors with "unbound variable" on older bash. The
+# `${epic_lines[@]:-}` expansion treats an unset/empty array as empty
+# without aborting the script. See #363 fix #6.
+for line in "${epic_lines[@]:-}"; do
+  [[ -z "$line" ]] && continue
   slug="${line%%$'\t'*}"
   nums="${line##*$'\t'}"
   slug_to_nums["$slug"]="$nums"
   IFS=',' read -r -a arr <<<"$nums"
-  all_bound+=("${arr[@]}")
+  # The `read -a` call may leave `arr` empty when `nums` itself is
+  # empty (no bindings on this epic). Guard the append with the same
+  # `${arr[@]:-}` defensive expansion so set -u stays happy.
+  all_bound+=("${arr[@]:-}")
 done
 
 echo "reconcile-milestones: ${#slug_to_nums[@]} epics parsed from plan"
+
+# Short-circuit: if no epic slugs were parsed, there's nothing to
+# reconcile. Skip the assign / scope-creep loops cleanly rather than
+# letting `${!slug_to_nums[@]}` iterate over an empty associative
+# array under set -u.
+if [[ "${#slug_to_nums[@]}" -eq 0 ]]; then
+  echo "reconcile-milestones: no epics with bindings — nothing to reconcile"
+  exit 0
+fi
 
 # Step 2: ensure milestones exist and assign to bound issues/PRs.
 declare -A slug_to_milestone_num


### PR DESCRIPTION
## Summary

Implements 5 of the 6 efficiency improvements from #363. Fix #3 is an issue-tracker action and stays out of the diff per the issue text — it is flagged below for human follow-up.

| # | Fix | Status | Files |
|---|---|---|---|
| 1 | `file-issue.sh`: auto-append `bug`/`enhancement` label | done | `claude-skills/scripts/file-issue.sh` |
| 2 | Worktree + branch cleanup after merge | done | `auto-merge-or-flag.sh`, `open-report-pr.sh`, `prune-agent-worktrees.sh` |
| 3 | Split umbrella issue #292 into sub-tickets | deferred-to-human | (no diff — see note below) |
| 4 | PO phase A.5: decompose oversized issues | done | `po-decompose-oversized.sh`, `po-manager.md` |
| 5 | Adaptive back-off — skip sweeps on empty backlog | done | `tick-idle-check.sh`, `tech-lead.md`, `qa.md`, `seo.md` |
| 6 | Fix `slug_to_nums` unbound variable | done | `claude-skills/skills/po/scripts/reconcile-milestones.sh` |

## Per-fix notes

**#1** — Adds `--type bug|enhancement` (default `enhancement`). The label is always merged into the final `--label` list alongside the bus / review / filed-by labels, so phase-A.5 issues become valid phase-B candidates.

**#2** — `prune-agent-worktrees.sh` already pruned worktrees; this PR adds:
- post-merge cleanup in both merge helpers (capture head ref, remove worktree + local branch)
- a second pass in `prune-agent-worktrees.sh` that deletes orphaned `worktree-agent-*` local branches whose worktree is gone
- the summary line now reports `branches-pruned=N`.

**#3 — DEFERRED TO HUMAN.** Issue #292 still needs to be split into ≤5 sub-tickets, each within `max_loc_per_issue` (currently 1000). This PR does not modify #292 — the new `po-decompose-oversized.sh` from fix #4 will surface it on the next PO tick under "Decomposition needed".

**#4** — New `po-decompose-oversized.sh` lists open issues with bus label + milestone whose `estimated_loc` exceeds the budget (or whose body length suggests they're untracked). The PO does NOT auto-split — the script makes the queue visible; humans (or the PO in a confirmed action) call `file-issue.sh --type enhancement` to file children.

**#5** — `tick-idle-check.sh` is a shared pre-flight gate. When `list-pilot-candidates.sh --agent <name>` is empty AND `tick-fingerprint.sh` returns `TICK_SHORT_CIRCUIT=1`, the agent emits `Tick: idle — no candidates` and exits before running phases A/A.5/B/C. Wired into tech-lead, qa, and seo as phase (0.6). Idle decisions append to `<agent>/idle-ticks.log`.

**#6** — `reconcile-milestones.sh` aborted under `set -u` when the plan parser returned zero epic bindings (empty associative array iteration). Defensive `${arr[@]:-}` expansions and an early exit when `slug_to_nums` is empty fix the silent breakage.

## Test plan

- [x] `python3 -m pytest claude-skills/tests/test_skills.py -q` — 15 passed, 147 subtests
- [x] `bash -n` syntax check on every touched/new shell script
- [x] Smoke-tested `tick-idle-check.sh` and `po-decompose-oversized.sh` against the live repo
- [ ] Reviewer: confirm `file-issue.sh --type bug` and `--type enhancement` paths both reach `gh issue create`
- [ ] Reviewer: spot-check that `auto-merge-or-flag.sh` cleanup section is best-effort and never aborts the merge
- [ ] Reviewer: confirm phase (0.6) wiring in tech-lead / qa / seo is consistent

## Scope

11 files touched, ~310 LOC across 5 commits. Within the autopilot pilot budget for a single human-initiated PR.

Closes #363 (fixes #1, #2, #4, #5, #6)
Refs #363 (fix #3 deferred to human — see #292)
Refs #292 (oversized umbrella — needs human decomposition; fix #4 surfaces it on the next PO tick)