### PR TITLE
fix(pilot): pipeline regression harness I5-I8 + CI workflow (#292)

### DIFF
--- a/.github/workflows/pipeline-regression.yml
+++ b/.github/workflows/pipeline-regression.yml
@@ -1,0 +1,45 @@
+name: pipeline regression (unit)
+
+# Runs assert-invariants.sh unit tests and the test_assert_invariants.sh
+# harness on every PR that touches the pipeline scripts or agent definitions.
+#
+# NB: this workflow executes the *test harness* only — it does NOT run the
+# full 30-minute compressed run against a live test repo. That heavier run
+# is triggered manually via:
+#   bash claude-skills/scripts/test/run-pipeline-test.sh \
+#     --repo beyond-scale-group/bsg-stack-test-harness --duration 30m
+#
+# This distinction is intentional: CI runs fast invariant unit tests;
+# the live harness is a human-initiated regression run per CLAUDE.md
+# ("Do not add CI automation for these agents").
+
+on:
+  pull_request:
+    paths:
+      - 'claude-skills/scripts/**'
+      - 'claude-skills/agents/**'
+      - 'claude-skills/commands/tick-all.md'
+      - '.bsg-autopilot.yml'
+      - '.github/workflows/pipeline-regression.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'claude-skills/scripts/**'
+      - 'claude-skills/agents/**'
+      - 'claude-skills/commands/tick-all.md'
+      - '.bsg-autopilot.yml'
+
+jobs:
+  invariant-unit-tests:
+    name: assert-invariants unit tests (I1-I8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify required tooling
+        run: |
+          jq --version
+          python3 --version
+
+      - name: Run assert-invariants I5-I8 unit tests
+        run: bash claude-skills/tests/test_assert_invariants.sh

--- a/claude-skills/scripts/test/assert-invariants.sh
+++ b/claude-skills/scripts/test/assert-invariants.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
-# assert-invariants.sh — verify pipeline regression invariants I1-I4
+# assert-invariants.sh — verify pipeline regression invariants I1-I8
 # from the artifacts collected by run-pipeline-test.sh (#292).
 #
 # I1 distribution      ≥ 2 different bus_labels opened ≥ 1 PR
 # I2 idempotency       no duplicate report PRs (same agent, same day)
 # I3 lock cleanup      zero agent:lock:* labels left (live query)
-# I4 budget compliance no merged PR exceeds 200 LOC / 8 files
+# I4 budget compliance no merged PR exceeds MAX_LOC LOC / MAX_FILES files
+# I5 issue dedup       no two open agent-filed issues share a fingerprint
+# I6 phase-B reactivity eligible issues get a PR within REACTIVITY_SECS (default 300s)
+# I7 token budget      total tokens ≤ baseline × TOKEN_DRIFT_FACTOR (default 1.2)
+# I8 auto-merge labels every auto-merged PR carries human-reviewed
 #
 # Inputs: --logs DIR (must contain prs.json and issues.json)
-# Optional: --repo OWNER/NAME (required for I3)
-# Optional env: MAX_LOC (default 200), MAX_FILES (default 8)
+# Optional: --repo OWNER/NAME     (required for I3)
+#           --baseline-dir DIR    (dir with latest.json; skips I7 if absent)
+#           --tokens N            (current run token count; skips I7 if absent)
+# Optional env: MAX_LOC (default 200), MAX_FILES (default 8),
+#               REACTIVITY_SECS (default 300), TOKEN_DRIFT_FACTOR (default 1.2)
 #
 # Exits 0 if all pass, 1 if any failed.
 
@@ -17,10 +24,14 @@ set -euo pipefail
 
 LOG_DIR=""
 REPO=""
+BASELINE_DIR=""
+TOKENS=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --logs) LOG_DIR="$2"; shift 2 ;;
-    --repo) REPO="$2"; shift 2 ;;
+    --logs)          LOG_DIR="$2";      shift 2 ;;
+    --repo)          REPO="$2";         shift 2 ;;
+    --baseline-dir)  BASELINE_DIR="$2"; shift 2 ;;
+    --tokens)        TOKENS="$2";       shift 2 ;;
     -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "assert-invariants: unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -34,6 +45,8 @@ ISSUES="$LOG_DIR/issues.json"
 
 MAX_LOC=${MAX_LOC:-200}
 MAX_FILES=${MAX_FILES:-8}
+REACTIVITY_SECS=${REACTIVITY_SECS:-300}
+TOKEN_DRIFT_FACTOR=${TOKEN_DRIFT_FACTOR:-1.2}
 
 PASS=0
 FAIL=0
@@ -61,10 +74,11 @@ else
 fi
 
 # ---------- I2 — idempotency ----------
+# Guard against null titles with (.title // "")
 dups=$(jq -r '
   [ .[]
-    | select(.title | test("^report\\("))
-    | { agent: ((.title | capture("^report\\((?<a>[^)]+)\\)") // {}).a // "_"),
+    | select((.title // "") | test("^report\\("))
+    | { agent: (((.title // "") | capture("^report\\((?<a>[^)]+)\\)") // {}).a // "_"),
         day:    (.createdAt[:10]) }
   ]
   | group_by(.agent + "|" + .day)
@@ -105,6 +119,122 @@ if [[ "$violations" -eq 0 ]]; then
   report "I4 budget compliance" PASS "$merged merged PR(s) within $MAX_LOC LOC / $MAX_FILES files"
 else
   report "I4 budget compliance" FAIL "$violations merged PR(s) exceed budget"
+fi
+
+# ---------- I5 — issue dedup (filed-by fingerprints) ----------
+# No two open agent-filed issues should share the same "fingerprint:" value.
+dup_fingerprints=$(jq -r '
+  [ .[]
+    | select(.state == "OPEN")
+    | select((.labels // []) | map(.name) | any(startswith("filed-by:")))
+    | (.body // "") | scan("fingerprint: ([^\n]+)") | .[0]
+  ]
+  | group_by(.)
+  | map(select(length > 1) | .[0])
+  | length
+' "$ISSUES")
+if [[ "$dup_fingerprints" -eq 0 ]]; then
+  agent_filed=$(jq '[.[] | select((.labels // []) | map(.name) | any(startswith("filed-by:")))] | length' "$ISSUES")
+  report "I5 issue dedup" PASS "$agent_filed agent-filed issue(s), no duplicate fingerprints"
+else
+  report "I5 issue dedup" FAIL "$dup_fingerprints fingerprint(s) appear on >1 open issue"
+fi
+
+# ---------- I6 — phase-B reactivity ----------
+# For each issue that was eligible for auto-implementation (has bus label +
+# bug/enhancement label), check that a PR referencing it was opened within
+# REACTIVITY_SECS seconds of the issue's creation.
+# We match PRs whose body contains "#N" matching the issue number.
+slow=$(python3 - <<PYEOF
+import json, sys
+from datetime import datetime, timezone
+
+with open("$PRS")    as f: prs    = json.load(f)
+with open("$ISSUES") as f: issues = json.load(f)
+
+BUS_LABELS = {"tech","qa","seo","po","security"}
+IMPL_LABELS = {"bug","enhancement"}
+SECS = int("$REACTIVITY_SECS")
+
+def parse_dt(s):
+    if not s: return None
+    s = s.rstrip("Z")
+    try: return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+    except Exception: return None
+
+slow = 0
+for issue in issues:
+    labels = {l["name"] for l in (issue.get("labels") or [])}
+    if not (labels & BUS_LABELS and labels & IMPL_LABELS):
+        continue
+    issue_num = issue["number"]
+    issue_ts  = parse_dt(issue.get("createdAt"))
+    if not issue_ts:
+        continue
+    # find earliest PR referencing this issue
+    refs = []
+    for pr in prs:
+        body = pr.get("body") or ""
+        if f"#{issue_num}" in body:
+            pr_ts = parse_dt(pr.get("createdAt"))
+            if pr_ts:
+                refs.append(pr_ts)
+    if not refs:
+        # no PR found — skip (harness may still be running)
+        continue
+    first_pr_ts = min(refs)
+    delta = (first_pr_ts - issue_ts).total_seconds()
+    if delta > SECS:
+        slow += 1
+
+print(slow)
+PYEOF
+)
+if [[ "$slow" -eq 0 ]]; then
+  report "I6 phase-B reactivity" PASS "all eligible issues got a PR within ${REACTIVITY_SECS}s"
+else
+  report "I6 phase-B reactivity" FAIL "$slow issue(s) waited >${REACTIVITY_SECS}s for a PR"
+fi
+
+# ---------- I7 — token budget ----------
+if [[ -n "$BASELINE_DIR" && -n "$TOKENS" && -f "$BASELINE_DIR/latest.json" ]]; then
+  baseline_tokens=$(jq '.total_tokens // 0' "$BASELINE_DIR/latest.json")
+  if [[ "$baseline_tokens" -le 0 ]]; then
+    report "I7 token budget" SKIP "baseline total_tokens is 0 or missing"
+  else
+    # Use python3 for float comparison
+    within=$(python3 -c "
+import sys
+current=$TOKENS
+baseline=$baseline_tokens
+factor=$TOKEN_DRIFT_FACTOR
+print('yes' if current <= baseline * factor else 'no')
+")
+    if [[ "$within" == "yes" ]]; then
+      pct=$(python3 -c "print(f'+{($TOKENS/$baseline_tokens - 1)*100:.1f}%')" 2>/dev/null || echo "")
+      report "I7 token budget" PASS "tokens ${TOKENS} within ${TOKEN_DRIFT_FACTOR}x baseline ${baseline_tokens} ${pct}"
+    else
+      pct=$(python3 -c "print(f'+{($TOKENS/$baseline_tokens - 1)*100:.1f}%')" 2>/dev/null || echo "")
+      report "I7 token budget" FAIL "tokens ${TOKENS} exceeds ${TOKEN_DRIFT_FACTOR}x baseline ${baseline_tokens} ${pct}"
+    fi
+  fi
+else
+  report "I7 token budget" SKIP "needs --baseline-dir and --tokens"
+fi
+
+# ---------- I8 — auto-merge labels ----------
+# Every merged PR should carry human-reviewed (auto-merge path stamps it).
+merged_without_label=$(jq '
+  [ .[]
+    | select(.state == "MERGED")
+    | select( ((.labels // []) | map(.name) | any(. == "human-reviewed")) | not )
+  ] | length
+' "$PRS")
+if [[ "$merged_without_label" -eq 0 ]]; then
+  merged_total=$(jq '[.[] | select(.state == "MERGED")] | length' "$PRS")
+  report "I8 auto-merge labels" PASS "$merged_total merged PR(s) all carry human-reviewed"
+else
+  report "I8 auto-merge labels" FAIL "$merged_without_label merged PR(s) missing human-reviewed"
 fi
 
 echo

--- a/claude-skills/tests/test_assert_invariants.sh
+++ b/claude-skills/tests/test_assert_invariants.sh
@@ -12,8 +12,6 @@
 
 set -euo pipefail
 
-SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts/test/assert-invariants.sh"; pwd)/$(basename claude-skills/scripts/test/assert-invariants.sh)"
-# Resolve relative to repo root
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 SCRIPT="$REPO_ROOT/claude-skills/scripts/test/assert-invariants.sh"
 
@@ -22,11 +20,6 @@ FAIL=0
 
 ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
 fail() { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
-
-run_assert() {   # $1=label  args…
-  local label="$1"; shift
-  bash "$SCRIPT" "$@" 2>&1
-}
 
 # ---- helpers ----------------------------------------------------------------
 
@@ -49,11 +42,22 @@ write_baselines() {  # dir json
   echo "$2" > "$1/latest.json"
 }
 
+# Minimal valid PR JSON that won't trigger I1/I2 errors — two buses, no report PRs
+BASE_PRS='[
+  {"number":1,"title":"fix: something","state":"OPEN","createdAt":"2026-05-04T10:00:00Z",
+   "labels":[{"name":"tech"}],"body":"","additions":10,"deletions":5,"changedFiles":2},
+  {"number":2,"title":"fix: other","state":"OPEN","createdAt":"2026-05-04T10:01:00Z",
+   "labels":[{"name":"qa"}],"body":"","additions":5,"deletions":2,"changedFiles":1}
+]'
+
+# Minimal valid issues JSON (empty)
+BASE_ISSUES='[]'
+
 # ---- I5 — issue dedup -------------------------------------------------------
 
 test_i5_pass() {
   local d; d=$(make_logs)
-  write_prs "$d" "[]"
+  write_prs "$d" "$BASE_PRS"
   # Two issues with different fingerprints
   write_issues "$d" '[
     {"number":1,"body":"fingerprint: tech:stale-todo:foo.py:10","labels":[{"name":"filed-by:tech"}],"state":"OPEN"},
@@ -70,7 +74,7 @@ test_i5_pass() {
 
 test_i5_fail() {
   local d; d=$(make_logs)
-  write_prs "$d" "[]"
+  write_prs "$d" "$BASE_PRS"
   # Two issues sharing the same fingerprint = dedup violation
   write_issues "$d" '[
     {"number":1,"body":"fingerprint: tech:stale-todo:foo.py:10","labels":[{"name":"filed-by:tech"}],"state":"OPEN"},
@@ -91,12 +95,16 @@ test_i6_pass() {
   local d; d=$(make_logs)
   # Issue created at T, PR opened at T+3min (within 5min SLA)
   write_issues "$d" '[
-    {"number":10,"labels":[{"name":"tech"},{"name":"bug"},{"name":"safe-to-automate"}],
+    {"number":10,"labels":[{"name":"tech"},{"name":"bug"}],
      "state":"OPEN","createdAt":"2026-05-04T10:00:00Z"}
   ]'
   write_prs "$d" '[
-    {"number":100,"body":"Closes #10","state":"OPEN","createdAt":"2026-05-04T10:03:00Z",
-     "labels":[{"name":"tech"}]}
+    {"number":1,"title":"fix: baseline-a","state":"OPEN","createdAt":"2026-05-04T09:00:00Z",
+     "labels":[{"name":"tech"}],"body":"","additions":10,"deletions":5,"changedFiles":2},
+    {"number":2,"title":"fix: baseline-b","state":"OPEN","createdAt":"2026-05-04T09:01:00Z",
+     "labels":[{"name":"qa"}],"body":"","additions":5,"deletions":2,"changedFiles":1},
+    {"number":100,"title":"fix: issue 10","state":"OPEN","createdAt":"2026-05-04T10:03:00Z",
+     "labels":[{"name":"tech"}],"body":"Closes #10","additions":20,"deletions":5,"changedFiles":2}
   ]'
   local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
   if echo "$out" | grep -q "I6.*✓"; then
@@ -111,12 +119,16 @@ test_i6_fail() {
   local d; d=$(make_logs)
   # Issue created at T, PR opened at T+10min (exceeds 5min SLA)
   write_issues "$d" '[
-    {"number":10,"labels":[{"name":"tech"},{"name":"bug"},{"name":"safe-to-automate"}],
+    {"number":10,"labels":[{"name":"tech"},{"name":"bug"}],
      "state":"OPEN","createdAt":"2026-05-04T10:00:00Z"}
   ]'
   write_prs "$d" '[
-    {"number":100,"body":"Closes #10","state":"OPEN","createdAt":"2026-05-04T10:10:00Z",
-     "labels":[{"name":"tech"}]}
+    {"number":1,"title":"fix: baseline-a","state":"OPEN","createdAt":"2026-05-04T09:00:00Z",
+     "labels":[{"name":"tech"}],"body":"","additions":10,"deletions":5,"changedFiles":2},
+    {"number":2,"title":"fix: baseline-b","state":"OPEN","createdAt":"2026-05-04T09:01:00Z",
+     "labels":[{"name":"qa"}],"body":"","additions":5,"deletions":2,"changedFiles":1},
+    {"number":100,"title":"fix: slow pr","state":"OPEN","createdAt":"2026-05-04T10:10:00Z",
+     "labels":[{"name":"tech"}],"body":"Closes #10","additions":20,"deletions":5,"changedFiles":2}
   ]'
   local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
   if echo "$out" | grep -q "I6.*✗"; then
@@ -132,8 +144,8 @@ test_i6_fail() {
 test_i7_pass() {
   local d; d=$(make_logs)
   local bdir; bdir=$(mktemp -d)
-  write_prs "$d" "[]"
-  write_issues "$d" "[]"
+  write_prs "$d" "$BASE_PRS"
+  write_issues "$d" "$BASE_ISSUES"
   write_baselines "$bdir" '{"total_tokens":1000000}'
   # current tokens = 1.1× baseline (within 20% drift)
   local out; out=$(bash "$SCRIPT" --logs "$d" --baseline-dir "$bdir" --tokens 1100000 2>&1) || true
@@ -148,8 +160,8 @@ test_i7_pass() {
 test_i7_fail() {
   local d; d=$(make_logs)
   local bdir; bdir=$(mktemp -d)
-  write_prs "$d" "[]"
-  write_issues "$d" "[]"
+  write_prs "$d" "$BASE_PRS"
+  write_issues "$d" "$BASE_ISSUES"
   write_baselines "$bdir" '{"total_tokens":1000000}'
   # current tokens = 1.3× baseline (exceeds 20% drift)
   local out; out=$(bash "$SCRIPT" --logs "$d" --baseline-dir "$bdir" --tokens 1300000 2>&1) || true
@@ -165,11 +177,16 @@ test_i7_fail() {
 
 test_i8_pass() {
   local d; d=$(make_logs)
-  write_issues "$d" "[]"
-  # Merged PR carries human-reviewed
+  write_issues "$d" "$BASE_ISSUES"
+  # All merged PRs carry human-reviewed (plus 2 open ones for I1)
   write_prs "$d" '[
-    {"number":200,"state":"MERGED","mergedAt":"2026-05-04T11:00:00Z",
-     "labels":[{"name":"human-reviewed"},{"name":"tech"}]}
+    {"number":1,"title":"fix: open-a","state":"OPEN","createdAt":"2026-05-04T09:00:00Z",
+     "labels":[{"name":"tech"}],"body":"","additions":5,"deletions":2,"changedFiles":1},
+    {"number":2,"title":"fix: open-b","state":"OPEN","createdAt":"2026-05-04T09:01:00Z",
+     "labels":[{"name":"qa"}],"body":"","additions":5,"deletions":2,"changedFiles":1},
+    {"number":200,"title":"fix: merged","state":"MERGED","mergedAt":"2026-05-04T11:00:00Z",
+     "createdAt":"2026-05-04T10:00:00Z","labels":[{"name":"human-reviewed"},{"name":"tech"}],
+     "body":"","additions":10,"deletions":5,"changedFiles":2}
   ]'
   local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
   if echo "$out" | grep -q "I8.*✓"; then
@@ -182,11 +199,16 @@ test_i8_pass() {
 
 test_i8_fail() {
   local d; d=$(make_logs)
-  write_issues "$d" "[]"
+  write_issues "$d" "$BASE_ISSUES"
   # Merged PR missing human-reviewed
   write_prs "$d" '[
-    {"number":201,"state":"MERGED","mergedAt":"2026-05-04T11:00:00Z",
-     "labels":[{"name":"tech"}]}
+    {"number":1,"title":"fix: open-a","state":"OPEN","createdAt":"2026-05-04T09:00:00Z",
+     "labels":[{"name":"tech"}],"body":"","additions":5,"deletions":2,"changedFiles":1},
+    {"number":2,"title":"fix: open-b","state":"OPEN","createdAt":"2026-05-04T09:01:00Z",
+     "labels":[{"name":"qa"}],"body":"","additions":5,"deletions":2,"changedFiles":1},
+    {"number":201,"title":"fix: merged no label","state":"MERGED","mergedAt":"2026-05-04T11:00:00Z",
+     "createdAt":"2026-05-04T10:00:00Z","labels":[{"name":"tech"}],
+     "body":"","additions":10,"deletions":5,"changedFiles":2}
   ]'
   local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
   if echo "$out" | grep -q "I8.*✗"; then

--- a/claude-skills/tests/test_assert_invariants.sh
+++ b/claude-skills/tests/test_assert_invariants.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# test_assert_invariants.sh — unit tests for assert-invariants.sh I5-I8 (#292)
+#
+# Exercises the four invariants added in the #292 completion pass:
+#   I5 issue dedup (no two open issues share a filed-by fingerprint)
+#   I6 phase-B reactivity (eligible issues get a PR within 5 min of creation)
+#   I7 token budget (total tokens ≤ baseline × 1.2)
+#   I8 auto-merge labels (every auto-merged PR carries human-reviewed)
+#
+# Usage: bash claude-skills/tests/test_assert_invariants.sh
+# Exit 0 = all assertions passed; exit 1 = at least one failed.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts/test/assert-invariants.sh"; pwd)/$(basename claude-skills/scripts/test/assert-invariants.sh)"
+# Resolve relative to repo root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
+SCRIPT="$REPO_ROOT/claude-skills/scripts/test/assert-invariants.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+
+run_assert() {   # $1=label  args…
+  local label="$1"; shift
+  bash "$SCRIPT" "$@" 2>&1
+}
+
+# ---- helpers ----------------------------------------------------------------
+
+make_logs() {
+  local dir
+  dir=$(mktemp -d)
+  echo "$dir"
+}
+
+write_prs() {   # dir json
+  echo "$2" > "$1/prs.json"
+}
+
+write_issues() {  # dir json
+  echo "$2" > "$1/issues.json"
+}
+
+write_baselines() {  # dir json
+  mkdir -p "$1"
+  echo "$2" > "$1/latest.json"
+}
+
+# ---- I5 — issue dedup -------------------------------------------------------
+
+test_i5_pass() {
+  local d; d=$(make_logs)
+  write_prs "$d" "[]"
+  # Two issues with different fingerprints
+  write_issues "$d" '[
+    {"number":1,"body":"fingerprint: tech:stale-todo:foo.py:10","labels":[{"name":"filed-by:tech"}],"state":"OPEN"},
+    {"number":2,"body":"fingerprint: tech:stale-todo:bar.py:20","labels":[{"name":"filed-by:tech"}],"state":"OPEN"}
+  ]'
+  local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
+  if echo "$out" | grep -q "I5.*✓"; then
+    ok "I5 pass: distinct fingerprints"
+  else
+    fail "I5 pass: distinct fingerprints — got: $out"
+  fi
+  rm -rf "$d"
+}
+
+test_i5_fail() {
+  local d; d=$(make_logs)
+  write_prs "$d" "[]"
+  # Two issues sharing the same fingerprint = dedup violation
+  write_issues "$d" '[
+    {"number":1,"body":"fingerprint: tech:stale-todo:foo.py:10","labels":[{"name":"filed-by:tech"}],"state":"OPEN"},
+    {"number":2,"body":"fingerprint: tech:stale-todo:foo.py:10","labels":[{"name":"filed-by:tech"}],"state":"OPEN"}
+  ]'
+  local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
+  if echo "$out" | grep -q "I5.*✗"; then
+    ok "I5 fail: duplicate fingerprint detected"
+  else
+    fail "I5 fail: expected detection of duplicate fingerprint — got: $out"
+  fi
+  rm -rf "$d"
+}
+
+# ---- I6 — phase-B reactivity ------------------------------------------------
+
+test_i6_pass() {
+  local d; d=$(make_logs)
+  # Issue created at T, PR opened at T+3min (within 5min SLA)
+  write_issues "$d" '[
+    {"number":10,"labels":[{"name":"tech"},{"name":"bug"},{"name":"safe-to-automate"}],
+     "state":"OPEN","createdAt":"2026-05-04T10:00:00Z"}
+  ]'
+  write_prs "$d" '[
+    {"number":100,"body":"Closes #10","state":"OPEN","createdAt":"2026-05-04T10:03:00Z",
+     "labels":[{"name":"tech"}]}
+  ]'
+  local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
+  if echo "$out" | grep -q "I6.*✓"; then
+    ok "I6 pass: PR within 5min SLA"
+  else
+    fail "I6 pass: expected I6 pass — got: $out"
+  fi
+  rm -rf "$d"
+}
+
+test_i6_fail() {
+  local d; d=$(make_logs)
+  # Issue created at T, PR opened at T+10min (exceeds 5min SLA)
+  write_issues "$d" '[
+    {"number":10,"labels":[{"name":"tech"},{"name":"bug"},{"name":"safe-to-automate"}],
+     "state":"OPEN","createdAt":"2026-05-04T10:00:00Z"}
+  ]'
+  write_prs "$d" '[
+    {"number":100,"body":"Closes #10","state":"OPEN","createdAt":"2026-05-04T10:10:00Z",
+     "labels":[{"name":"tech"}]}
+  ]'
+  local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
+  if echo "$out" | grep -q "I6.*✗"; then
+    ok "I6 fail: slow PR detected"
+  else
+    fail "I6 fail: expected I6 failure for slow PR — got: $out"
+  fi
+  rm -rf "$d"
+}
+
+# ---- I7 — token budget ------------------------------------------------------
+
+test_i7_pass() {
+  local d; d=$(make_logs)
+  local bdir; bdir=$(mktemp -d)
+  write_prs "$d" "[]"
+  write_issues "$d" "[]"
+  write_baselines "$bdir" '{"total_tokens":1000000}'
+  # current tokens = 1.1× baseline (within 20% drift)
+  local out; out=$(bash "$SCRIPT" --logs "$d" --baseline-dir "$bdir" --tokens 1100000 2>&1) || true
+  if echo "$out" | grep -q "I7.*✓"; then
+    ok "I7 pass: tokens within 20% drift"
+  else
+    fail "I7 pass: expected I7 pass — got: $out"
+  fi
+  rm -rf "$d" "$bdir"
+}
+
+test_i7_fail() {
+  local d; d=$(make_logs)
+  local bdir; bdir=$(mktemp -d)
+  write_prs "$d" "[]"
+  write_issues "$d" "[]"
+  write_baselines "$bdir" '{"total_tokens":1000000}'
+  # current tokens = 1.3× baseline (exceeds 20% drift)
+  local out; out=$(bash "$SCRIPT" --logs "$d" --baseline-dir "$bdir" --tokens 1300000 2>&1) || true
+  if echo "$out" | grep -q "I7.*✗"; then
+    ok "I7 fail: token drift detected"
+  else
+    fail "I7 fail: expected I7 failure for token drift — got: $out"
+  fi
+  rm -rf "$d" "$bdir"
+}
+
+# ---- I8 — auto-merge labels -------------------------------------------------
+
+test_i8_pass() {
+  local d; d=$(make_logs)
+  write_issues "$d" "[]"
+  # Merged PR carries human-reviewed
+  write_prs "$d" '[
+    {"number":200,"state":"MERGED","mergedAt":"2026-05-04T11:00:00Z",
+     "labels":[{"name":"human-reviewed"},{"name":"tech"}]}
+  ]'
+  local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
+  if echo "$out" | grep -q "I8.*✓"; then
+    ok "I8 pass: merged PR carries human-reviewed"
+  else
+    fail "I8 pass: expected I8 pass — got: $out"
+  fi
+  rm -rf "$d"
+}
+
+test_i8_fail() {
+  local d; d=$(make_logs)
+  write_issues "$d" "[]"
+  # Merged PR missing human-reviewed
+  write_prs "$d" '[
+    {"number":201,"state":"MERGED","mergedAt":"2026-05-04T11:00:00Z",
+     "labels":[{"name":"tech"}]}
+  ]'
+  local out; out=$(bash "$SCRIPT" --logs "$d" 2>&1) || true
+  if echo "$out" | grep -q "I8.*✗"; then
+    ok "I8 fail: missing human-reviewed on merged PR detected"
+  else
+    fail "I8 fail: expected I8 failure — got: $out"
+  fi
+  rm -rf "$d"
+}
+
+# ---- run --------------------------------------------------------------------
+
+echo "assert-invariants I5-I8 unit tests"
+echo
+
+test_i5_pass
+test_i5_fail
+test_i6_pass
+test_i6_fail
+test_i7_pass
+test_i7_fail
+test_i8_pass
+test_i8_fail
+
+echo
+echo "summary: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- Adds invariants I5–I8 to `claude-skills/scripts/test/assert-invariants.sh` (issue dedup, phase-B reactivity, token budget drift, auto-merge labels)
- Fixes null-title jq crash in I2 (`(.title // "")` guard)
- Adds `.github/workflows/pipeline-regression.yml` gated on pipeline path changes
- Adds `claude-skills/tests/test_assert_invariants.sh` with 8 unit tests (4 pass, 4 fail scenarios)

## Test plan

- [x] `bash claude-skills/tests/test_assert_invariants.sh` — 8/8 pass
- [x] `python3 claude-skills/tests/test_skills.py` — 15/15 pass
- [ ] CI `pipeline regression (unit)` job runs on this PR

Closes #292