### PR TITLE
fix(pilot): activate GitHub coordination bus per-agent claim handler (#394)

### DIFF
--- a/claude-skills/scripts/bus-handler.sh
+++ b/claude-skills/scripts/bus-handler.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# bus-handler.sh — per-agent claim handler for the GitHub coordination bus.
+#
+# Called at tick step (0) by each output:commit agent to process issues
+# that carry the label "needs:<agent>". When the inbox is non-empty,
+# the handler acknowledges each item with a structured marker comment
+# so other agents and humans can trace the flow through GitHub labels.
+#
+# The handler is intentionally minimal: it acknowledges the claim and
+# returns the issue numbers so the calling agent's tick can decide
+# whether to attempt auto-implementation (via list-pilot-candidates.sh)
+# or just log the handoff. Heavy per-role handler logic is deferred to
+# #199 — this script is the activation layer for E7-bus-activation.
+#
+# Usage:
+#   bash claude-skills/scripts/bus-handler.sh \
+#     [--agent NAME] \
+#     [--action acknowledge|log] \
+#     [--repo OWNER/NAME]
+#
+# Outputs one issue number per line for each processed inbox item.
+# Exits 0 always (empty inbox is not an error).
+#
+# Actions:
+#   acknowledge  (default) — post a <!-- agent:<name> v1 kind:claim -->
+#                            marker comment on each inbox issue and print
+#                            the issue number to stdout.
+#   log          — print the issue numbers to stdout without posting a
+#                  comment (dry-run / audit mode).
+#
+# Requirements: gh (GitHub CLI), jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source bus primitives (best-effort).
+# shellcheck source=claude-skills/scripts/github-bus.sh
+source "$SCRIPT_DIR/github-bus.sh" 2>/dev/null || true
+
+AGENT="tech"
+ACTION="acknowledge"
+REPO_FLAG=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)  AGENT="$2";  shift 2 ;;
+    --action) ACTION="$2"; shift 2 ;;
+    --repo)   REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "bus-handler.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Fetch open issues with the needs:<agent> label.
+# Exclude issues already locked by any agent (concurrent tick guard).
+inbox_json=$(gh issue list "${REPO_FLAG[@]}" \
+  --label "needs:${AGENT}" \
+  --state open \
+  --json number,labels,title \
+  --limit 50 \
+  2>/dev/null || echo "[]")
+
+# Filter out locked issues client-side.
+unlocked=$(jq -c '[
+  .[]
+  | select(
+      .labels
+      | map(.name)
+      | map(startswith("agent:lock:"))
+      | any
+      | not
+    )
+]' <<<"$inbox_json")
+
+count=$(jq 'length' <<<"$unlocked")
+if [[ "$count" -eq 0 ]]; then
+  exit 0
+fi
+
+# Process each unlocked inbox issue.
+while IFS= read -r issue; do
+  num=$(jq -r '.number' <<<"$issue")
+  title=$(jq -r '.title' <<<"$issue")
+
+  case "$ACTION" in
+    acknowledge)
+      # Post a machine-readable marker so the handoff is traceable.
+      marker_body=$(printf 'agent: %s\naction: claim\ntitle: "%s"\nstatus: acknowledged' \
+        "$AGENT" "$title")
+      gh issue comment "${REPO_FLAG[@]}" "$num" \
+        --body "$(printf '<!-- agent:%s v1 kind:claim -->\n%s\n<!-- /agent:%s -->' \
+          "$AGENT" "$marker_body" "$AGENT")" \
+        >/dev/null 2>&1 || true
+      echo "$num"
+      ;;
+    log)
+      echo "$num"
+      ;;
+    *)
+      echo "bus-handler.sh: unknown action: $ACTION" >&2
+      exit 2
+      ;;
+  esac
+done < <(jq -c '.[]' <<<"$unlocked")

--- a/claude-skills/tests/test_bus_handler.sh
+++ b/claude-skills/tests/test_bus_handler.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# test_bus_handler.sh — unit tests for bus-handler.sh per-agent claim processing.
+#
+# Verifies that bus-handler.sh:
+#   1. Identifies issues in the needs:<agent> inbox
+#   2. Posts a structured marker comment acknowledging the claim
+#   3. Returns the list of inbox issue numbers it processed
+#   4. Returns empty output for an empty inbox (no-op)
+#
+# Run locally:
+#   bash claude-skills/tests/test_bus_handler.sh
+#
+# Exit 0 = all pass, exit 1 = failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SUT="$REPO_ROOT/claude-skills/scripts/bus-handler.sh"
+
+# Fail fast if the script doesn't exist yet (this is the failing test commit).
+if [[ ! -f "$SUT" ]]; then
+  echo "FAIL: bus-handler.sh not found at $SUT"
+  echo "=== 1 tests: 0 passed, 1 failed ==="
+  exit 1
+fi
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  got : $got"
+    echo "  want: $want"
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected to contain: $needle"
+    echo "  got: $haystack"
+  fi
+}
+
+# ── Mock gh ───────────────────────────────────────────────────────────────────
+MOCK_GH="$TMPDIR_TEST/gh"
+GH_CALLS_FILE="$TMPDIR_TEST/gh_calls"
+GH_RESPONSE_FILE="$TMPDIR_TEST/gh_response"
+cat > "$MOCK_GH" <<'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_CALLS_FILE"
+cat "$GH_RESPONSE_FILE" 2>/dev/null || echo "[]"
+MOCK
+chmod +x "$MOCK_GH"
+export GH_CALLS_FILE GH_RESPONSE_FILE
+export PATH="$TMPDIR_TEST:$PATH"
+
+# ── Test 1: acknowledge-only — bus-handler.sh posts a marker comment ─────────
+echo "--- Test 1: handler posts acknowledge marker for inbox item ---"
+> "$GH_CALLS_FILE"
+cat > "$GH_RESPONSE_FILE" <<'JSON'
+[{"number":42,"labels":[{"name":"needs:tech"},{"name":"enhancement"},{"name":"tech"}],"title":"Test inbox item","body":""}]
+JSON
+
+bash "$SUT" --agent tech --action acknowledge 2>/dev/null || true
+CALLS="$(cat "$GH_CALLS_FILE")"
+assert_contains "T1: issue comment called" "$CALLS" "issue comment 42"
+
+# ── Test 2: handler prints processed issue numbers ───────────────────────────
+echo "--- Test 2: handler returns processed issue numbers ---"
+> "$GH_CALLS_FILE"
+cat > "$GH_RESPONSE_FILE" <<'JSON'
+[{"number":99,"labels":[{"name":"needs:tech"}],"title":"Another item","body":""}]
+JSON
+
+RESULT=$(bash "$SUT" --agent tech --action acknowledge 2>/dev/null)
+assert_eq "T2: processed number emitted" "$RESULT" "99"
+
+# ── Test 3: empty inbox — no-op ───────────────────────────────────────────────
+echo "--- Test 3: empty inbox returns empty output ---"
+> "$GH_CALLS_FILE"
+echo "[]" > "$GH_RESPONSE_FILE"
+
+RESULT=$(bash "$SUT" --agent tech --action acknowledge 2>/dev/null)
+assert_eq "T3: empty inbox is silent" "$RESULT" ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=== $((PASS + FAIL)) tests: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Adds `claude-skills/scripts/bus-handler.sh` — the activation layer for E7-bus-activation (#394)
- Agents call this at tick step (0) to acknowledge `needs:<agent>` inbox items with a structured marker comment, enabling traceability through the GitHub label bus
- Dry-run mode (`--action log`) available for audit-only ticks; heavy per-role handler logic from #199 plugs in on top on the next sweep

## Test plan

- [x] `bash claude-skills/tests/test_bus_handler.sh` — 3/3 pass
- [x] Test 1: inbox item triggers `gh issue comment` call
- [x] Test 2: processed issue numbers emitted to stdout
- [x] Test 3: empty inbox is a no-op (silent exit 0)

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)