### PR TITLE
fix(pilot): add validate-plan.sh plan validator (#392)

### DIFF
--- a/claude-skills/scripts/validate-plan.sh
+++ b/claude-skills/scripts/validate-plan.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# validate-plan.sh — validate po/PLAN.md and exit non-zero with a diagnostic
+# when the plan is missing or contains no binding tags (E6-plan-schema-hygiene).
+#
+# Usage:
+#   bash claude-skills/scripts/validate-plan.sh [--plan <path>]
+#
+# Exits:
+#   0   — PLAN.md exists and contains at least one binding tag
+#   1   — PLAN.md is missing
+#   2   — PLAN.md exists but contains no binding tags (format drift)
+#   3   — parse-plan.sh not found (installer misconfiguration)
+#
+# By default reads $PWD/po/PLAN.md. Override with --plan <path>.
+#
+# Uses parse-plan.sh --typed internally so the same grammar is enforced
+# in both the agent tick and this standalone validator.
+set -euo pipefail
+
+PLAN_PATH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan) PLAN_PATH="$2"; shift 2 ;;
+    *) echo "validate-plan.sh: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PLAN_PATH" ]]; then
+  PLAN_PATH="$PWD/po/PLAN.md"
+fi
+
+# Locate parse-plan.sh: prefer the canonical repo path, fall back to cached copy.
+PARSE_PLAN=""
+for candidate in \
+  "$(dirname "$0")/../skills/po/scripts/parse-plan.sh" \
+  "$HOME/.claude/skills/po/scripts/parse-plan.sh"; do
+  if [[ -f "$candidate" ]]; then
+    PARSE_PLAN="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$PARSE_PLAN" ]]; then
+  echo "validate-plan.sh: parse-plan.sh not found — is the BSG skill catalog installed?" >&2
+  echo "  Expected at: $(dirname "$0")/../skills/po/scripts/parse-plan.sh" >&2
+  echo "  or:          \$HOME/.claude/skills/po/scripts/parse-plan.sh" >&2
+  exit 3
+fi
+
+# Run the typed parser to get a structured result.
+result=$(bash "$PARSE_PLAN" --plan "$PLAN_PATH" --typed 2>&1)
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+  echo "validate-plan.sh: parse-plan.sh exited $exit_code — check $PLAN_PATH" >&2
+  echo "$result" >&2
+  exit 1
+fi
+
+status=$(printf '%s' "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status','unknown'))" 2>/dev/null || echo "parse-error")
+
+case "$status" in
+  ok)
+    item_count=$(printf '%s' "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('items',[])))" 2>/dev/null || echo "0")
+    echo "validate-plan.sh: OK — $PLAN_PATH has $item_count bound plan item(s)"
+    exit 0
+    ;;
+  missing)
+    reason=$(printf '%s' "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('reason','plan file missing'))" 2>/dev/null || echo "plan file missing")
+    echo "validate-plan.sh: MISSING — $reason" >&2
+    echo "  To fix: create $PLAN_PATH following the schema in" >&2
+    echo "  claude-skills/skills/po/references/plan-schema.md" >&2
+    exit 1
+    ;;
+  unparseable)
+    reason=$(printf '%s' "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('reason','no binding tags found'))" 2>/dev/null || echo "no binding tags found")
+    echo "validate-plan.sh: INVALID — $reason" >&2
+    echo "  To fix: ensure bullets carry at least one binding tag, e.g.:" >&2
+    echo "    - Ship feature X   [milestone:M1]" >&2
+    echo "  See claude-skills/skills/po/references/plan-schema.md for the grammar." >&2
+    exit 2
+    ;;
+  *)
+    echo "validate-plan.sh: UNKNOWN parse status '$status' — raw output:" >&2
+    echo "$result" >&2
+    exit 2
+    ;;
+esac

--- a/claude-skills/tests/test_validate_plan.py
+++ b/claude-skills/tests/test_validate_plan.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Tests for issue #392 — validate-plan.sh: plan validator script.
+
+E6-plan-schema-hygiene requires a `validate-plan.sh` script that:
+  1. Exists and is executable
+  2. Exits 0 when PLAN.md is valid (has bound items)
+  3. Exits non-zero and prints a diagnostic when PLAN.md is missing
+  4. Exits non-zero and prints a diagnostic when PLAN.md has no bound items
+
+Stdlib only — no third-party dependencies, no network.
+
+Run locally:
+    python3 claude-skills/tests/test_validate_plan.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATE_SCRIPT = REPO_ROOT / "claude-skills" / "scripts" / "validate-plan.sh"
+PARSE_PLAN = REPO_ROOT / "claude-skills" / "skills" / "po" / "scripts" / "parse-plan.sh"
+
+VALID_PLAN = textwrap.dedent("""\
+    # Big plan — test-repo
+
+    ## Objectives
+    - Ship feature X   [milestone:M1]
+    - Fix critical bug  [milestone:M2]
+
+    ## Epics
+    - **M1** — feature X   [milestone:M1] [label:enhancement]
+    - **M2** — critical fix [milestone:M2] [label:bug]
+""")
+
+EMPTY_PLAN = textwrap.dedent("""\
+    # Big plan — test-repo
+
+    ## Objectives
+    - Ship feature X (no binding tags here)
+""")
+
+
+class TestValidatePlanScriptExists(unittest.TestCase):
+
+    def test_validate_plan_script_exists(self):
+        """validate-plan.sh must exist at claude-skills/scripts/validate-plan.sh."""
+        self.assertTrue(
+            VALIDATE_SCRIPT.exists(),
+            f"validate-plan.sh not found at {VALIDATE_SCRIPT} — E6-plan-schema-hygiene requires this script",
+        )
+
+    def test_validate_plan_script_is_executable(self):
+        """validate-plan.sh must be executable."""
+        if not VALIDATE_SCRIPT.exists():
+            self.skipTest("validate-plan.sh does not exist yet")
+        self.assertTrue(
+            os.access(VALIDATE_SCRIPT, os.X_OK),
+            "validate-plan.sh exists but is not executable",
+        )
+
+
+class TestValidatePlanBehavior(unittest.TestCase):
+
+    def _run(self, *args: str, plan_path: str | None = None) -> subprocess.CompletedProcess:
+        cmd = ["bash", str(VALIDATE_SCRIPT)]
+        if plan_path is not None:
+            cmd += ["--plan", plan_path]
+        cmd += list(args)
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+    def setUp(self):
+        if not VALIDATE_SCRIPT.exists():
+            self.skipTest("validate-plan.sh does not exist yet")
+
+    def test_valid_plan_exits_zero(self):
+        """validate-plan.sh exits 0 when PLAN.md contains bound items."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(VALID_PLAN)
+            plan_path = f.name
+        try:
+            result = self._run(plan_path=plan_path)
+            self.assertEqual(
+                result.returncode, 0,
+                f"Expected exit 0 for valid plan.\nstdout: {result.stdout}\nstderr: {result.stderr}",
+            )
+        finally:
+            os.unlink(plan_path)
+
+    def test_missing_plan_exits_nonzero(self):
+        """validate-plan.sh exits non-zero when PLAN.md does not exist."""
+        result = self._run(plan_path="/tmp/does-not-exist-plan-392.md")
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit when PLAN.md is missing",
+        )
+
+    def test_missing_plan_prints_diagnostic(self):
+        """validate-plan.sh prints a useful error message when PLAN.md is missing."""
+        result = self._run(plan_path="/tmp/does-not-exist-plan-392.md")
+        combined = result.stdout + result.stderr
+        self.assertTrue(
+            len(combined.strip()) > 0,
+            "Expected at least one diagnostic line for missing PLAN.md, got silence",
+        )
+
+    def test_empty_plan_exits_nonzero(self):
+        """validate-plan.sh exits non-zero when PLAN.md has no binding tags."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(EMPTY_PLAN)
+            plan_path = f.name
+        try:
+            result = self._run(plan_path=plan_path)
+            self.assertNotEqual(
+                result.returncode, 0,
+                f"Expected non-zero exit for unbound plan.\nstdout: {result.stdout}\nstderr: {result.stderr}",
+            )
+        finally:
+            os.unlink(plan_path)
+
+    def test_empty_plan_prints_diagnostic(self):
+        """validate-plan.sh prints a diagnostic when PLAN.md has no binding tags."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(EMPTY_PLAN)
+            plan_path = f.name
+        try:
+            result = self._run(plan_path=plan_path)
+            combined = result.stdout + result.stderr
+            self.assertTrue(
+                len(combined.strip()) > 0,
+                "Expected a diagnostic for unbound plan, got silence",
+            )
+        finally:
+            os.unlink(plan_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `claude-skills/scripts/validate-plan.sh` — the missing deliverable from E6-plan-schema-hygiene
- Script wraps `parse-plan.sh --typed` and exits non-zero with an actionable diagnostic when PLAN.md is missing or contains no binding tags, fixing the silent failure described in #392
- Adds `claude-skills/tests/test_validate_plan.py` with 7 tests covering existence, executability, and all three exit paths (valid, missing, unbound)

## Test plan

- [x] `test_validate_plan_script_exists` — script present at `claude-skills/scripts/validate-plan.sh`
- [x] `test_validate_plan_script_is_executable` — chmod +x applied
- [x] `test_valid_plan_exits_zero` — valid PLAN.md with binding tags exits 0
- [x] `test_missing_plan_exits_nonzero` — missing file exits 1
- [x] `test_missing_plan_prints_diagnostic` — missing file prints actionable message
- [x] `test_empty_plan_exits_nonzero` — unbound PLAN.md exits 2
- [x] `test_empty_plan_prints_diagnostic` — unbound PLAN.md prints actionable message

All 7 tests pass: `python3 claude-skills/tests/test_validate_plan.py`

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)