### PR TITLE
fix(pilot): add adaptive back-off to 6 agents missing tick-idle-check (#393)

### DIFF
--- a/claude-skills/agents/cleaner.md
+++ b/claude-skills/agents/cleaner.md
@@ -21,6 +21,7 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh cleaner cleaner)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so the report embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh cleaner cleaner cleaner)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to cleaner/idle-ticks.log.
   (1) Run the hygiene pass: remove orphaned `agent:lock:*` labels (held > 2h),
   remove `needs:*` labels from closed issues, remove `agent:done` from
   re-opened issues, post duplicate-detection comments (Levenshtein ≤ 10% on

--- a/claude-skills/agents/marketing.md
+++ b/claude-skills/agents/marketing.md
@@ -18,6 +18,7 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh marketing marketing)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh marketing marketing marketing)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to marketing/idle-ticks.log.
   Audit the content calendar for overdue items, check feature-marketing
   alignment against recent releases and milestones, land the report as
   marketing/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -21,6 +21,7 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh po-manager po)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh po-manager po po)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to po/idle-ticks.log.
   (1) Run `reconcile-milestones.sh` to assign GitHub milestones from po/PLAN.md
   bindings — each bound issue/PR gets the milestone matching its epic slug,
   scope-creep label for unbound ones (idempotent; skip silently if the plan

--- a/claude-skills/agents/pr-comms.md
+++ b/claude-skills/agents/pr-comms.md
@@ -18,6 +18,7 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh pr-comms comms)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh pr-comms pr-comms comms)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to comms/idle-ticks.log.
   Scan for PR-worthy events since last tick, draft press angles for
   unannounced events, land the report as
   comms/reports/YYYY-MM-DD-events.md via open-report-pr.sh, and stay

--- a/claude-skills/agents/security.md
+++ b/claude-skills/agents/security.md
@@ -17,6 +17,7 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh security security)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh security security security)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to security/idle-ticks.log.
   (A) Run the full security audit (deps + secrets + config), land it as
   security/reports/YYYY-MM-DD-audit.md via open-report-pr.sh, and stay
   silent in chat unless a silence-breaker fires (critical/high CVE, secret

--- a/claude-skills/agents/storytelling.md
+++ b/claude-skills/agents/storytelling.md
@@ -18,6 +18,7 @@ tick: >
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh storytelling brand)"`.
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh storytelling storytelling brand)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to brand/idle-ticks.log.
   Audit public-facing repo assets against brand/NARRATIVE.md (voice
   consistency, key-message coverage, talking points for unnarrated
   releases), land the report as brand/reports/YYYY-MM-DD-audit.md via

--- a/claude-skills/tests/test_skills.py
+++ b/claude-skills/tests/test_skills.py
@@ -526,6 +526,33 @@ class TestSharedSkills(unittest.TestCase):
                     f"should only skip phases (A) and (A.5). See #261.",
                 )
 
+    # --------------------------------- adaptive back-off (#363)
+
+    def test_all_agents_tick_has_adaptive_backoff(self) -> None:
+        """Every agent tick must include the adaptive back-off step (0.6).
+
+        tick-idle-check.sh short-circuits the tick when there are no
+        phase-B candidates AND the audit fingerprint matches yesterday's.
+        Without it, a no-change tick-all sweep reruns the full audit
+        pipeline for every agent on every loop — the primary token-burn
+        source identified in E1-tick-hygiene. See #363 and #393.
+        """
+        for path in list_agents():
+            with self.subTest(agent=path.stem):
+                text = path.read_text()
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match)
+                frontmatter = fm_match.group(1)
+                tick_body = self._extract_tick_body(frontmatter)
+                self.assertIn(
+                    "tick-idle-check.sh",
+                    tick_body,
+                    f"{path.relative_to(REPO_ROOT)}: tick field is missing the "
+                    f"adaptive back-off step (0.6). Add: eval \"$(bash "
+                    f"claude-skills/scripts/tick-idle-check.sh <agent> <bus> "
+                    f"<report-dir>)\". See #363 and #393.",
+                )
+
     # ----------------------------------------- output:pr agents have exclusions
 
     def test_pr_agents_have_never_auto_implements_clauses(self) -> None:


### PR DESCRIPTION
## Summary

- 6 agents (security, marketing, po-manager, pr-comms, storytelling, cleaner) were missing the `tick-idle-check.sh` step (0.6) that short-circuits a tick when there are no phase-B candidates AND the audit fingerprint matches yesterday's
- Without it, every no-change `/tick-all` sweep reruns the full audit pipeline for these agents — the primary token-burn identified in E1-tick-hygiene
- Adds a new `test_all_agents_tick_has_adaptive_backoff` test that enforces the invariant for all agents going forward

Closes #393

## Test plan

- [x] New test `test_all_agents_tick_has_adaptive_backoff` committed first as a failing test
- [x] Fix applied to 6 agent files
- [x] All 16 tests pass (`16 passed, 156 subtests passed`)
- [ ] Verify no-change tick sweep token cost reduction on next `/tick-all` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)