### PR TITLE
fix(open-report-pr): attribute commits to the calling agent

### DIFF
--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -145,7 +145,9 @@ if git diff --cached --quiet; then
   git checkout "$original" >/dev/null 2>&1 || true
   exit 0
 fi
-git commit -m "$title" >/dev/null
+git -c "user.name=${AGENT}" \
+    -c "user.email=${AGENT}@bsg-agents.bot" \
+    commit -m "$title" >/dev/null
 git push -u origin "$branch" >/dev/null 2>&1
 
 # Reuse an existing PR targeting this branch, otherwise open a new one.


### PR DESCRIPTION
## Summary
- Force the git author/committer at commit time in `open-report-pr.sh` to `<agent> <<agent>@bsg-agents.bot>` derived from `--agent`.
- Stops report commits from being attributed to whatever `user.name` the worktree happens to inherit (today: `actions-user` on CI, the developer locally).
- Push attribution stays under the human's `gh` credentials — only the commit metadata changes.

## Test plan
- [ ] Next `@po-manager tick` (or any agent tick) opens a PR whose commit lists the agent as author in the GitHub UI
- [ ] CI green on this PR (existing test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)