### PR TITLE
feat(autopilot): aggressive auto-routing, decomposition, and stuck-issue escalation (#416)

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -14,6 +14,12 @@
 
 enabled: true
 
+# Default human assignee when an agent escalates an issue via
+# --reason spec-clarification or --reason tech-decision (file-issue.sh)
+# or when detect-stuck-issues.sh fires a tier-2 escalation. The named
+# user gets the issue assigned + an @-mention in the body. See #416.
+default_human_reviewer: guillaumebadin
+
 agents:
   - tech
   - seo

--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -108,6 +108,10 @@ that most repos already have.
 | `enhancement` | `a2eeef` (cyan) | Agents and humans | Standard GitHub label for feature requests and improvements. |
 | `po`, `security`, `qa`, `tech`, `seo`, `marketing`, `storytelling`, `pr-comms`, `cleaner` | `5319e7` (purple) | `file-issue.sh` with `--agent <name>`; agents apply their own on hand-off via `github-bus.sh` | The **bus label** for each agent — one label per agent, sourced from `claude-skills/agents/registry.json`. Every open issue carries exactly one. Enables filtering by ownership (`label:security` = "all security's inbox") and is what `bus_claim` keys off of. |
 | `safe-to-automate` | `c2e0c6` (light green) | **Humans only** | Gate for the `output: commit` pilot (#181). A human has reviewed the issue and declared: "I'm OK with an agent attempting this fix automatically on its next tick." Without this label, agents in `output: commit` mode must not touch the issue. Absence = default-safe. |
+| `needs:spec-clarification` | `d93f0b` (red) | Agents (`file-issue.sh --reason spec-clarification` + `detect-stuck-issues.sh` tier 2) | Awaiting human spec clarification — the agent could not proceed without it. Always paired with `needs-human-review` and an issue assignee from `default_human_reviewer`. Removed by the human as part of un-stucking the issue. See #416. |
+| `needs:tech-decision` | `d93f0b` (red) | Agents (`file-issue.sh --reason tech-decision`) | Awaiting human technical decision — the agent cannot pick the right approach without one. Always paired with `needs-human-review` and an issue assignee. See #416. |
+| `stuck:nudged` | `fbca04` (yellow) | `detect-stuck-issues.sh` (tier 1) | Marker that tier-1 stuck nudge has fired on this issue. Idempotent — keeps tier 1 from re-firing. Removed automatically when the issue moves (PR opened, label change, etc.) — agents do not need to clean it. |
+| `parent:<N>` | `ededed` (light gray) | `decompose-issue.sh` | Marks an issue as a child of issue #N. Created on demand when a parent is decomposed. Allows filtering all children of a given parent (`label:parent:292`). |
 
 Invariant every open item must satisfy — enforced by
 `claude-skills/scripts/audit-labels.sh`:
@@ -142,6 +146,20 @@ done
 gh label create safe-to-automate \
   --color c2e0c6 \
   --description "Human-applied: this item is safe for an agent's output:commit tick to attempt"
+
+# Human-in-the-loop reason labels (#416). Agents apply these when they
+# need a human decision to proceed.
+gh label create needs:spec-clarification \
+  --color d93f0b \
+  --description "Awaiting human spec clarification — agent could not proceed without it"
+
+gh label create needs:tech-decision \
+  --color d93f0b \
+  --description "Awaiting human technical decision — agent cannot pick the right approach"
+
+gh label create stuck:nudged \
+  --color fbca04 \
+  --description "detect-stuck-issues: tier-1 nudge applied (idempotent marker)"
 ```
 
 To verify compliance on any repo:

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -26,12 +26,25 @@ tick: >
   bindings — each bound issue/PR gets the milestone matching its epic slug,
   scope-creep label for unbound ones (idempotent; skip silently if the plan
   is missing or unparseable).
+  (1.4) Run `bash claude-skills/scripts/normalize-issue-labels.sh` — auto-add
+  missing type labels (Cas A) and infer + apply missing bus labels (Cas B/C)
+  on open issues. Cap at max_issues_per_tick from .bsg-autopilot.yml. Log the
+  emitted JSON list in the status report under "Label normalization". The
+  inference is keyword-based with `tech` as the strong default and posts a
+  transparency comment so humans/agents can swap on mis-route. See "Label
+  normalization (#416)" below.
   (1.5) Orphan triage: fetch open issues with no milestone, match each against
   po/PLAN.md milestones by topic/label affinity, assign the inferred milestone,
   and add `needs:<agent>` when a known bus label (tech, qa, seo) is present so
   the issue surfaces on the next sweep. Cap at max_issues_per_tick from
   .bsg-autopilot.yml (default 3). Log assignments in the status report under
   "Orphan triage". See the "Orphan triage" section below.
+  (1.6) Run `bash claude-skills/scripts/detect-stuck-issues.sh` — flag and
+  escalate eligible-but-unimplemented issues. Tier 1 (>2 days) posts an
+  @-mention nudge to the owning agent. Tier 2 (>5 days) assigns the
+  default_human_reviewer + applies needs:spec-clarification. Log fired
+  escalations in the status report under "Stuck issues". Silence-breaker if
+  any tier-2 escalation fired. See "Stuck detection (#416)" below.
   (2) Run the full status + adherence report and land it as
   po/reports/YYYY-MM-DD-status.md via open-report-pr.sh. Stay silent in chat
   unless a silence-breaker fires (see the "Tick action" section below).
@@ -43,11 +56,14 @@ tick: >
   Issues carry label:bug + target agent's bus label + label:needs-human-review
   + label:epic:<slug>. Max max_issues_per_tick (default 3) from
   .bsg-autopilot.yml. See the "Task delegation pipeline" section below.
-  Also run `bash claude-skills/scripts/po-decompose-oversized.sh` to surface
-  open issues whose estimated_loc exceeds max_loc_per_issue. The script
-  emits a JSONL list — DO NOT auto-split existing issues. Surface the list
-  in the status report under "Decomposition needed" so a human can decide
-  whether to split each one. See "Decomposing oversized issues" below.
+  Also run `bash claude-skills/scripts/po-decompose-oversized.sh` to find
+  open issues whose estimated_loc exceeds max_loc_per_issue. For each
+  oversized issue with a parseable breakdown in its body, the PO calls
+  `bash claude-skills/scripts/decompose-issue.sh --parent <num> --child
+  "<title>"...` to file sub-issues that fit the budget (#416). When the
+  body lacks a clear breakdown, the PO instead refiles with `--reason
+  spec-clarification` so a human can clarify rather than guess. See
+  "Decomposing oversized issues" below.
   (C) Peer review (#222 phase 3b): if .bsg-autopilot.yml has a peer_review
   section listing po, run `peer-review-candidates.sh --reviewer po`.
   For each candidate PR (max 2 per tick): check plan alignment, scope-creep
@@ -153,6 +169,30 @@ that nothing gets posted in chat when the project is healthy.
    not bound. Milestones are created if they don't exist yet. Scope-creep
    is removed from items that now have a milestone.
 
+1.4. **Normalize labels** — auto-route open issues into the autopilot
+   pipeline by adding missing type and bus labels. `list-pilot-candidates.sh`
+   requires three labels per issue (bus + type + milestone); without all
+   three the issue is invisible to the pilot and sits in the backlog
+   forever.
+
+   ```bash
+   bash claude-skills/scripts/normalize-issue-labels.sh
+   ```
+
+   Three cases the script handles automatically (cap: `max_issues_per_tick`):
+
+   - **Cas A** — has bus label, missing type → adds `enhancement`
+   - **Cas B** — has type, missing bus → infers bus from keywords (qa, seo,
+     or tech as default) + adds `needs:<inferred>` + posts a transparency
+     comment so a human or another agent can swap on mis-route
+   - **Cas C** — neither, but has milestone → applies both A + B in one shot
+
+   The inference is keyword-based and intentionally biased toward `tech`
+   (the largest backlog and lowest cost on a wrong route). Mis-routes are
+   self-correcting: the receiving agent's scope contract rejects out-of-
+   scope work and another tick swaps the label. A waiting-for-human label
+   decision is more expensive than a mis-route.
+
 1.5. **Triage orphan issues** (open issues with no milestone). After step 1,
    any issue still without a milestone is invisible to
    `list-pilot-candidates.sh` (which filters with `select(.milestone != null)`
@@ -188,6 +228,26 @@ that nothing gets posted in chat when the project is healthy.
      "Orphan triage" section in the status report.
 
    Skip silently when there are no orphans, no PLAN, or no clear match.
+
+1.6. **Detect stuck issues** — flag and escalate eligible-but-unimplemented
+   issues. Stuck flow is the autopilot's silent failure mode (agent picked
+   nothing up because of budget, scope contract, or circuit-breaker).
+
+   ```bash
+   bash claude-skills/scripts/detect-stuck-issues.sh
+   ```
+
+   Two-tier escalation:
+
+   - **Tier 1 (>2 days)** — comment `@<bus_label>` on the issue prompting
+     re-attempt. Idempotent via `stuck:nudged` label. No human involved.
+   - **Tier 2 (>5 days)** — agent couldn't make progress despite the
+     nudge. Assign to `default_human_reviewer` from `.bsg-autopilot.yml`,
+     apply `needs:spec-clarification` + `needs-human-review`, post an
+     @-mention comment. The issue is human-owned until a human removes
+     `needs:spec-clarification`.
+
+   Silence-breaker: any tier-2 escalation that fired in this tick.
 
 2. **Compose the full status report** (adherence at the top, then
    milestones, stale, PR flow). `generate-report.sh` collects a fresh
@@ -241,6 +301,7 @@ Break silence if **any** of these hold on the snapshot you just produced:
 | Overdue milestone                      | `milestone-progress.sh` → status `overdue` or `at_risk`     | Any                            |
 | New stale issue                        | `stale-issues.sh` (threshold 30 days)                       | Any issue crosses the 30d line |
 | PR stuck without review / merge signal | `pr-flow.sh`                                                | Any PR open > 14 days          |
+| Stuck issue escalated to human         | `detect-stuck-issues.sh` (tier 2)                           | Any tier-2 escalation fired    |
 | Missing `po/PLAN.md`                   | `adherence.sh` → `planFound: false`                         | First tick only — then silent  |
 
 The "missing PLAN" case is a one-shot: surface it once so the user sees
@@ -366,12 +427,13 @@ When issues are delegated, append to the tick receipt:
 Tick: <status>, report at <PR url> — delegated N issues (tech:2, qa:1)
 ```
 
-### Decomposing oversized issues (#363 fix #4)
+### Decomposing oversized issues (#363 #416)
 
 The phase-B implementation pilots enforce a per-issue LOC cap
-(`max_loc_per_issue` in `.bsg-autopilot.yml`, default 200). Issues
-above the cap never get picked up — they sit in the backlog until a
-human splits them. The PO surfaces them every tick:
+(`max_loc_per_issue` in `.bsg-autopilot.yml`, default 200 — bsg-stack
+sets it to 1000). Issues above the cap never get picked up — they sit
+in the backlog until they're split. The PO finds them, then **decomposes
+them automatically** so the pipeline keeps moving.
 
 ```bash
 bash claude-skills/scripts/po-decompose-oversized.sh
@@ -384,23 +446,71 @@ The script emits one JSON line per oversized issue:
  "agent": "tech", "milestone": "v2", "reason": "explicit-hint"}
 ```
 
-It looks for explicit `estimated_loc:` / `~N LOC` hints in the issue
-body. When no hint is present, it falls back to a body-length
-heuristic (> 60 lines = "likely oversized") and flags the issue for
-manual sizing.
+For each oversized issue (cap at `max_issues_per_tick` per parent),
+the PO reads the parent's body and proposes a decomposition into
+sub-tasks that each fit the budget. Then it calls the executor:
 
-**The PO does NOT auto-split.** Decomposition is a planning decision
-that requires human judgement. The script's job is to make the queue
-visible — the PO surfaces it in the status report under
-`## Decomposition needed`, and the human (or, optionally, the PO in
-a later confirmed action) calls `file-issue.sh --type enhancement`
-once for each sub-task. If the PO does file sub-issues, it must:
+```bash
+bash claude-skills/scripts/decompose-issue.sh \
+  --parent <num> \
+  --child "<sub-task title 1>" \
+  --child "<sub-task title 2>" \
+  --child "<sub-task title 3>"
+```
 
-- Route each one to the same target agent's bus label
-- Bind each one to the same milestone as the parent
-- Reference the parent in each child body
-  (`Child of #NN — see decomposition note`)
-- Cap at `max_issues_per_tick` per parent
+The script handles the mechanics — files each sub-issue via
+`file-issue.sh` with the parent's bus label, milestone, and a
+`parent:<N>` label, then posts a single comment on the parent
+listing all children.
+
+**Division of labor:**
+- The script does mechanics (filing, labeling, parent-child link)
+- The PO (LLM) makes judgment calls (which sub-tasks, what titles,
+  what scope each child should cover)
+
+If the parent's body has no clear breakdown — a one-line "do X
+better" with no detail — the PO falls back to filing the parent
+with `--reason spec-clarification` instead of guessing. Decomposition
+without a spec is a different problem than decomposition with one.
+
+### Label normalization (#416)
+
+`normalize-issue-labels.sh` runs at step 1.4 and is the primary
+defense against unrouted backlog items. The keyword inference
+covers the most common cases but is intentionally simple — when it
+mis-routes, the receiving agent's scope contract rejects the work
+and the next tick swaps the label.
+
+To keep mis-routes cheap:
+
+- Tech is the strong default (largest backlog, smallest cost on a
+  bad route)
+- Each non-trivial route (qa, seo) requires multi-word phrase matches,
+  not single keywords like `test` or `meta` which are too noisy
+- Every Cas-B/C inference posts a transparency comment so the route
+  is visible in the issue's history
+
+The script is idempotent — running it twice is a no-op.
+
+### Stuck detection (#416)
+
+`detect-stuck-issues.sh` runs at step 1.6 and catches the failure
+mode where an issue is fully labeled but the pilot can't pick it up
+(scope contract rejection, budget cap, circuit-breaker). Without
+this, those issues silently rot.
+
+Two-tier escalation aligned with "humans are the fallback":
+
+- **Tier 1 (2+ days idle)** — `@<bus_label>` nudge, no human attention
+  required. Idempotent via `stuck:nudged` label.
+- **Tier 2 (5+ days idle)** — assign to `default_human_reviewer`,
+  apply `needs:spec-clarification`, post @-mention. The issue is
+  out of the agent pipeline until a human un-stucks it by removing
+  `needs:spec-clarification`.
+
+The cap-out at tier 2 is a feature: it forces the PO to stop
+auto-trying when an agent has provably failed and needs human input
+to make a different choice.
 
 ---
 

--- a/claude-skills/scripts/decompose-issue.sh
+++ b/claude-skills/scripts/decompose-issue.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# decompose-issue.sh — split an oversized issue into child sub-issues that
+# fit the autopilot pilot budget.
+#
+# `po-decompose-oversized.sh` flags issues whose estimated_loc exceeds
+# `max_loc_per_issue` — they sit in the backlog because the pilot can't
+# pick them up. This script is the mechanical executor for splitting:
+# the PO agent (LLM) decides *how* to split (which sub-tasks, what
+# titles), and this script files each sub-issue with the right
+# inheritance.
+#
+# What it does:
+#
+#   1. Read the parent issue's bus label, milestone, and labels via gh.
+#   2. For each --child "<title>" argument, file a sub-issue via
+#      file-issue.sh with:
+#        - parent's bus label (same agent ownership)
+#        - parent's milestone
+#        - type: enhancement
+#        - label: parent:<parent-num>
+#        - body referencing the parent number
+#   3. Post a single comment on the parent listing all created
+#      sub-issues so the audit trail is visible from one place.
+#   4. (Optional) close the parent when --close-parent is passed —
+#      the parent has been fully decomposed and the work tracker
+#      moves to the children.
+#
+# The script is idempotent on the comment + close steps but NOT on
+# child creation — calling it twice with the same --child arguments
+# files duplicates. The PO agent is responsible for not re-decomposing
+# an already-split issue (the `parent:<N>` label on existing children
+# is the marker).
+#
+# Usage:
+#   decompose-issue.sh --parent <num> \
+#     --child "<sub-task title 1>" \
+#     --child "<sub-task title 2>" \
+#     [--child-body <num> "<body>"] \
+#     [--close-parent] \
+#     [--repo OWNER/NAME]
+#
+# The optional --child-body <index> "<body>" pairs let the caller
+# attach a body to specific children (1-indexed). Children without
+# bodies get a default `Child of #<parent>. See parent for context.`
+#
+# Emits one line per created sub-issue (JSON: number, url). Exit 0
+# on success.
+
+set -euo pipefail
+
+PARENT=""
+CHILDREN=()
+CHILD_BODIES=()
+CLOSE_PARENT=false
+REPO_FLAG=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --parent) PARENT="$2"; shift 2 ;;
+    --child) CHILDREN+=("$2"); shift 2 ;;
+    --child-body)
+      idx="$2"; body="$3"
+      CHILD_BODIES[$idx]="$body"
+      shift 3
+      ;;
+    --close-parent) CLOSE_PARENT=true; shift ;;
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "decompose-issue.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PARENT" ]]; then
+  echo "decompose-issue.sh: --parent <num> is required" >&2
+  exit 2
+fi
+
+if [[ ${#CHILDREN[@]} -eq 0 ]]; then
+  echo "decompose-issue.sh: at least one --child <title> is required" >&2
+  exit 2
+fi
+
+# Read parent metadata.
+parent_json=$(gh issue view "$PARENT" "${REPO_FLAG[@]}" \
+  --json number,labels,milestone,title 2>/dev/null || echo "{}")
+
+parent_title=$(jq -r '.title // empty' <<<"$parent_json")
+parent_milestone=$(jq -r '.milestone.title // empty' <<<"$parent_json")
+parent_bus=$(jq -r '
+  .labels[] | select(.name == "tech" or .name == "qa" or .name == "seo") | .name
+' <<<"$parent_json" | head -1)
+
+if [[ -z "$parent_title" ]]; then
+  echo "decompose-issue.sh: parent #${PARENT} not found or unreadable" >&2
+  exit 1
+fi
+
+if [[ -z "$parent_bus" ]]; then
+  echo "decompose-issue.sh: parent #${PARENT} has no bus label (tech/qa/seo) — refusing to decompose" >&2
+  echo "decompose-issue.sh: run normalize-issue-labels.sh first to apply a bus label" >&2
+  exit 1
+fi
+
+# Map bus_label → agent name for file-issue.sh --agent.
+case "$parent_bus" in
+  tech) parent_agent="tech-lead" ;;
+  qa)   parent_agent="qa" ;;
+  seo)  parent_agent="seo" ;;
+  *)
+    echo "decompose-issue.sh: unsupported bus label '${parent_bus}' on parent #${PARENT}" >&2
+    exit 1
+    ;;
+esac
+
+# Bootstrap the parent:<N> label on this repo (idempotent).
+parent_label="parent:${PARENT}"
+gh label create "$parent_label" "${REPO_FLAG[@]}" \
+  --color "ededed" \
+  --description "Sub-issue of #${PARENT} — created by decompose-issue.sh" \
+  >/dev/null 2>&1 || true
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+created_numbers=()
+created_urls=()
+
+i=0
+for title in "${CHILDREN[@]}"; do
+  i=$((i + 1))
+  body="${CHILD_BODIES[$i]:-}"
+  if [[ -z "$body" ]]; then
+    body="Child of #${PARENT} (\`${parent_title}\`).
+
+This sub-issue was created by \`decompose-issue.sh\` to fit the autopilot pilot budget. See the parent for full context."
+  fi
+
+  file_issue_args=(
+    --agent "$parent_agent"
+    --filed-by "po-decompose"
+    --type "enhancement"
+    --title "$title"
+    --body "$body"
+    --label "$parent_label"
+  )
+  if [[ -n "$parent_milestone" ]]; then
+    file_issue_args+=(--milestone "$parent_milestone")
+  fi
+  if [[ ${#REPO_FLAG[@]} -gt 0 ]]; then
+    file_issue_args+=("${REPO_FLAG[@]}")
+  fi
+
+  url=$(bash "$SCRIPT_DIR/file-issue.sh" "${file_issue_args[@]}" 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    echo "decompose-issue.sh: failed to file child '${title}' — aborting" >&2
+    exit 1
+  fi
+
+  num=$(echo "$url" | grep -oE '[0-9]+$' || echo "")
+  created_numbers+=("$num")
+  created_urls+=("$url")
+  jq -nc --arg n "$num" --arg u "$url" --arg t "$title" \
+    '{number: ($n | tonumber? // null), url: $u, title: $t}'
+done
+
+# Post a single comment on the parent listing all children.
+{
+  echo "**Decomposed into ${#created_numbers[@]} sub-issue(s):**"
+  echo
+  i=0
+  for num in "${created_numbers[@]}"; do
+    echo "- #${num} — ${CHILDREN[$i]}"
+    i=$((i + 1))
+  done
+  echo
+  echo "Created by \`decompose-issue.sh\`. Each sub-issue inherits the parent's bus label (\`${parent_bus}\`) and milestone (\`${parent_milestone:-none}\`)."
+} | gh issue comment "$PARENT" "${REPO_FLAG[@]}" --body-file - >/dev/null 2>&1 || true
+
+if [[ "$CLOSE_PARENT" == "true" ]]; then
+  gh issue close "$PARENT" "${REPO_FLAG[@]}" \
+    --reason completed \
+    --comment "Closed automatically — fully decomposed into sub-issues. Track work on the children." \
+    >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/claude-skills/scripts/detect-stuck-issues.sh
+++ b/claude-skills/scripts/detect-stuck-issues.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# detect-stuck-issues.sh — flag and escalate eligible-but-unimplemented issues.
+#
+# An issue is "stuck" when it is fully eligible for the autopilot pilot
+# (carries bus + type + milestone, no open PR referencing it), yet hasn't
+# moved in N days. Stuck flow is the autopilot's silent failure mode —
+# the agent picked nothing up because of budget, scope contract, or
+# circuit-breaker, and nobody noticed.
+#
+# Two-tier escalation aligned with the principle "humans are the
+# fallback, not the default":
+#
+#   Tier 1 — STUCK_DAYS_NUDGE (default 2 days):
+#     Post a comment on the issue tagging the owning agent
+#     (`@<bus_label>`) and prompting another tick attempt. No human
+#     intervention. Add `stuck:nudged` label so the next tier can fire.
+#
+#   Tier 2 — STUCK_DAYS_ESCALATE (default 5 days):
+#     The agent hasn't been able to make progress despite the nudge —
+#     spec is likely ambiguous or the tech choice isn't tranched.
+#     Assign the issue to `default_human_reviewer` from
+#     .bsg-autopilot.yml, post a comment with `@<human>` mention, and
+#     apply `needs:spec-clarification` + `needs-human-review`.
+#
+# Idempotent: each tier applies its label and won't re-fire on the
+# same tier. Once tier 2 fires, the issue is human-owned until the
+# human removes `needs:spec-clarification` (which un-stuckes it).
+#
+# Usage:
+#   detect-stuck-issues.sh [--repo OWNER/NAME] [--dry-run]
+#                          [--nudge-days N] [--escalate-days N]
+#
+# Emits one line per stuck issue acted upon (JSON: number, tier, action).
+# Exit 0 always — silent run when nothing is stuck.
+
+set -euo pipefail
+
+REPO_FLAG=()
+DRY_RUN=false
+NUDGE_DAYS=2
+ESCALATE_DAYS=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --nudge-days) NUDGE_DAYS="$2"; shift 2 ;;
+    --escalate-days) ESCALATE_DAYS="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "detect-stuck-issues.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Read default_human_reviewer from .bsg-autopilot.yml. If absent, tier 2
+# escalation falls back to the issue creator (next best human).
+HUMAN_REVIEWER=""
+if [[ -f .bsg-autopilot.yml ]]; then
+  HUMAN_REVIEWER=$(grep -E '^\s*default_human_reviewer\s*:' .bsg-autopilot.yml 2>/dev/null \
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'")
+fi
+
+# Bootstrap the labels we may apply (idempotent).
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  if ! gh label list "${REPO_FLAG[@]}" --json name \
+       --jq '.[] | select(.name == "'"$name"'") | .name' \
+       2>/dev/null | grep -qx "$name"; then
+    gh label create "$name" "${REPO_FLAG[@]}" \
+      --color "$color" --description "$desc" >/dev/null 2>&1 || true
+  fi
+}
+
+ensure_label "stuck:nudged" "fbca04" "detect-stuck-issues: tier-1 nudge applied (idempotent marker)"
+ensure_label "needs:spec-clarification" "d93f0b" "Awaiting human spec clarification — agent could not proceed"
+
+# Compute cutoff timestamps (BSD/GNU date compatible — both ship on macOS
+# and Linux runners). Use python3 as a portable fallback.
+to_iso_back() {
+  local days="$1"
+  python3 -c "
+import datetime
+print((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=$days)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+"
+}
+
+NUDGE_CUTOFF=$(to_iso_back "$NUDGE_DAYS")
+ESCALATE_CUTOFF=$(to_iso_back "$ESCALATE_DAYS")
+
+# Pull all open eligible-shaped issues (bus + type + milestone). We
+# filter for actually-stuck ones (no open PR referencing them) below.
+all_eligible=$(gh issue list "${REPO_FLAG[@]}" \
+  --state open \
+  --json number,title,labels,milestone,updatedAt,author \
+  --limit 200 2>/dev/null || echo "[]")
+
+# Filter via jq: must have bus + type + milestone, must not already
+# carry needs:spec-clarification (already escalated).
+candidates=$(jq -c '
+  .[]
+  | select(.labels | any(.name == "tech" or .name == "qa" or .name == "seo"))
+  | select(.labels | any(.name == "bug" or .name == "enhancement"))
+  | select(.milestone != null)
+  | select(.labels | any(.name == "needs:spec-clarification") | not)
+  | {
+      number,
+      title,
+      updatedAt,
+      author: (.author.login // "unknown"),
+      bus: ([.labels[] | select(.name == "tech" or .name == "qa" or .name == "seo") | .name] | first),
+      already_nudged: (.labels | any(.name == "stuck:nudged"))
+    }
+' <<<"$all_eligible")
+
+if [[ -z "$candidates" ]]; then
+  exit 0
+fi
+
+# For each candidate, check there is no open PR referencing it.
+echo "$candidates" | while read -r cand; do
+  num=$(jq -r '.number' <<<"$cand")
+  title=$(jq -r '.title' <<<"$cand")
+  updated_at=$(jq -r '.updatedAt' <<<"$cand")
+  author=$(jq -r '.author' <<<"$cand")
+  bus=$(jq -r '.bus' <<<"$cand")
+  already_nudged=$(jq -r '.already_nudged' <<<"$cand")
+
+  # Skip if there's an open PR referencing the issue (work in flight).
+  pr_count=$(gh pr list "${REPO_FLAG[@]}" \
+    --state open --search "fixes #$num OR closes #$num" \
+    --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+  if [[ "$pr_count" -gt 0 ]]; then
+    continue
+  fi
+
+  # Determine tier by comparing updatedAt to cutoffs (string comparison
+  # works because all timestamps are RFC3339 UTC).
+  tier=""
+  if [[ "$updated_at" < "$ESCALATE_CUTOFF" ]]; then
+    tier="escalate"
+  elif [[ "$updated_at" < "$NUDGE_CUTOFF" && "$already_nudged" == "false" ]]; then
+    tier="nudge"
+  fi
+
+  if [[ -z "$tier" ]]; then
+    continue
+  fi
+
+  jq -nc --arg n "$num" --arg t "$tier" --arg b "$bus" --arg u "$updated_at" \
+    '{number: ($n | tonumber), tier: $t, bus: $b, last_update: $u}'
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    continue
+  fi
+
+  if [[ "$tier" == "nudge" ]]; then
+    gh issue comment "$num" "${REPO_FLAG[@]}" --body "@${bus} this issue has been eligible for the autopilot pilot for ${NUDGE_DAYS}+ days without progress. Likely causes: budget cap (\`max_loc_per_issue\`), circuit-breaker (\`max_prs_per_day\`), or scope contract rejection. Please re-attempt or comment with the blocker." >/dev/null 2>&1 || true
+    gh issue edit "$num" "${REPO_FLAG[@]}" --add-label "stuck:nudged" >/dev/null 2>&1 || true
+  elif [[ "$tier" == "escalate" ]]; then
+    target_human="${HUMAN_REVIEWER:-$author}"
+    gh issue comment "$num" "${REPO_FLAG[@]}" --body "@${target_human} this issue has been stuck for ${ESCALATE_DAYS}+ days despite agent nudges. Likely cause: spec ambiguity or unresolved tech choice. Please clarify the spec or split the work — then remove \`needs:spec-clarification\` to put the issue back in the pipeline." >/dev/null 2>&1 || true
+    gh issue edit "$num" "${REPO_FLAG[@]}" \
+      --add-label "needs:spec-clarification" \
+      --add-label "needs-human-review" \
+      --add-assignee "$target_human" >/dev/null 2>&1 || true
+  fi
+done
+
+exit 0

--- a/claude-skills/scripts/file-issue.sh
+++ b/claude-skills/scripts/file-issue.sh
@@ -45,6 +45,22 @@
 # Without this, agent-filed issues from phase A.5 would never become
 # phase B candidates — see #363.
 #
+# With `--reason spec-clarification|tech-decision`, the issue is filed
+# as explicitly human-gated. The helper:
+#   - Applies `needs:<reason>` so the reason for human attention is
+#     visible in label filters
+#   - Applies `needs-human-review` even in autopilot mode
+#   - Reads `default_human_reviewer` from `.bsg-autopilot.yml` and
+#     assigns the issue to that user (or to the value of `--assign-to`
+#     if explicitly passed)
+#   - Prepends `@<human>` to the body so the assignee gets an
+#     @-mention notification
+# This is the only legitimate path for an agent to surface human
+# attention. See CLAUDE.md → "Restreindre les triggers humains".
+#
+# With `--assign-to <login>`, override the default human reviewer for
+# this single issue. Useful when a specific person owns the domain.
+#
 # Exits with the issue URL on stdout. Exits non-zero on any real failure.
 
 set -euo pipefail
@@ -56,6 +72,8 @@ BUS_LABEL=""
 FILED_BY=""
 DEDUP_FINGERPRINT=""
 ISSUE_TYPE="enhancement"
+HUMAN_REASON=""
+ASSIGN_TO=""
 
 # Target repo is whatever `gh` resolves (explicit --repo wins, else the cwd).
 repo_flag=()
@@ -90,6 +108,17 @@ while [[ $# -gt 0 ]]; do
       esac
       shift 2
       ;;
+    --reason)
+      case "$2" in
+        spec-clarification|tech-decision) HUMAN_REASON="$2" ;;
+        *) echo "file-issue.sh: --reason must be spec-clarification or tech-decision, got: $2" >&2; exit 2 ;;
+      esac
+      shift 2
+      ;;
+    --assign-to)
+      ASSIGN_TO="$2"
+      shift 2
+      ;;
     *)
       args+=("$1")
       shift
@@ -115,12 +144,24 @@ fi
 # autopilot mode. In autopilot mode the repo-level opt-in is the gate
 # and `filed-by:<agent>` is the traceability marker — applying
 # needs-human-review on every agent-filed issue would be redundant noise.
+# EXCEPTION: when --reason is passed, the issue is explicitly
+# human-gated and gets the label regardless of autopilot mode.
 APPLY_REVIEW_LABEL=true
 if [[ -f .bsg-autopilot.yml ]]; then
   enabled=$(grep -E '^\s*enabled\s*:' .bsg-autopilot.yml 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
   if [[ "$enabled" == "true" ]]; then
     APPLY_REVIEW_LABEL=false
   fi
+fi
+if [[ -n "$HUMAN_REASON" ]]; then
+  APPLY_REVIEW_LABEL=true
+fi
+
+# Resolve the human assignee for --reason flows. Explicit --assign-to
+# wins; otherwise read default_human_reviewer from .bsg-autopilot.yml.
+if [[ -n "$HUMAN_REASON" && -z "$ASSIGN_TO" && -f .bsg-autopilot.yml ]]; then
+  ASSIGN_TO=$(grep -E '^\s*default_human_reviewer\s*:' .bsg-autopilot.yml 2>/dev/null \
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'")
 fi
 
 # Idempotently ensure the review label exists on the target repo when
@@ -171,13 +212,53 @@ if [[ -n "$FILED_BY" ]]; then
   extra_labels="${extra_labels:+$extra_labels,}$filed_label"
 fi
 
+# Reason label for the human-in-the-loop trigger.
+if [[ -n "$HUMAN_REASON" ]]; then
+  reason_label="needs:${HUMAN_REASON}"
+  if ! gh label list "${repo_flag[@]}" --json name \
+       --jq '.[] | select(.name == "'"$reason_label"'") | .name' \
+       2>/dev/null | grep -qxF "$reason_label"; then
+    case "$HUMAN_REASON" in
+      spec-clarification)
+        reason_color="d93f0b"
+        reason_desc="Awaiting human spec clarification — agent could not proceed without it"
+        ;;
+      tech-decision)
+        reason_color="d93f0b"
+        reason_desc="Awaiting human technical decision — agent cannot pick the right approach without one"
+        ;;
+    esac
+    gh label create "$reason_label" \
+      "${repo_flag[@]}" \
+      --color "$reason_color" \
+      --description "$reason_desc" \
+      >/dev/null 2>&1 || true
+  fi
+  extra_labels="${extra_labels:+$extra_labels,}$reason_label"
+fi
+
 # `gh issue create --label` accepts either a comma-separated list or
 # multiple flags — we normalise to one `--label` flag with $extra_labels
-# appended to whatever was passed. If --dedup was used, inject the
-# fingerprint as a hidden HTML comment into --body.
+# appended to whatever was passed. We also transform --body to inject
+# the dedup fingerprint and the human @-mention when applicable.
+mention_prefix=""
+if [[ -n "$HUMAN_REASON" && -n "$ASSIGN_TO" ]]; then
+  case "$HUMAN_REASON" in
+    spec-clarification)
+      mention_prefix="@${ASSIGN_TO} please clarify the spec — agent cannot proceed without it.
+
+"
+      ;;
+    tech-decision)
+      mention_prefix="@${ASSIGN_TO} please make the technical decision — agent cannot pick the right approach without one.
+
+"
+      ;;
+  esac
+fi
+
 final_args=()
 label_merged=0
-body_injected=0
 i=0
 while [[ $i -lt ${#args[@]} ]]; do
   arg="${args[$i]}"
@@ -190,12 +271,15 @@ while [[ $i -lt ${#args[@]} ]]; do
     fi
     label_merged=1
     i=$((i+2))
-  elif [[ "$arg" == "--body" && -n "$DEDUP_FINGERPRINT" ]]; then
+  elif [[ "$arg" == "--body" ]]; then
     existing_body="${args[$((i+1))]}"
-    final_args+=(--body "${existing_body}
+    new_body="${mention_prefix}${existing_body}"
+    if [[ -n "$DEDUP_FINGERPRINT" ]]; then
+      new_body="${new_body}
 
-<!-- bsg-dedup:${DEDUP_FINGERPRINT} -->")
-    body_injected=1
+<!-- bsg-dedup:${DEDUP_FINGERPRINT} -->"
+    fi
+    final_args+=(--body "$new_body")
     i=$((i+2))
   else
     final_args+=("$arg")
@@ -204,6 +288,9 @@ while [[ $i -lt ${#args[@]} ]]; do
 done
 if [[ $label_merged -eq 0 && -n "$extra_labels" ]]; then
   final_args+=(--label "$extra_labels")
+fi
+if [[ -n "$ASSIGN_TO" ]]; then
+  final_args+=(--assignee "$ASSIGN_TO")
 fi
 
 exec gh issue create "${final_args[@]}"

--- a/claude-skills/scripts/normalize-issue-labels.sh
+++ b/claude-skills/scripts/normalize-issue-labels.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# normalize-issue-labels.sh — auto-route open issues into the autopilot
+# pipeline by adding missing type and bus labels.
+#
+# `list-pilot-candidates.sh` requires three labels per issue: a bus label
+# (tech/qa/seo), a type label (bug/enhancement), and a milestone. Issues
+# missing any one of those sit in the backlog forever even when they're
+# fully specified — the pipeline just can't see them.
+#
+# This script normalizes labels at every PO tick (step 1.4) so the
+# pipeline becomes the default path. Goal: maximize auto-implementation,
+# minimize human routing decisions. Mis-routes are cheap and self-
+# correcting — the receiving agent rejects out-of-scope work and swaps
+# the label. A ticket waiting for a human to apply a label is expensive.
+#
+# Three normalization cases:
+#
+#   Cas A — has bus label, missing type:
+#     Add `enhancement` automatically.
+#
+#   Cas B — has type label, missing bus:
+#     Infer bus from keywords in title/body and apply it. Also apply
+#     `needs:<inferred>` so the issue becomes a phase-B candidate on the
+#     next sweep. Post a comment naming the inferred route so a human
+#     (or another agent) can swap if the inference is wrong.
+#
+#   Cas C — neither bus nor type, but milestone assigned:
+#     Apply Cas A + Cas B in one shot (the milestone proves the issue is
+#     real work, not a draft).
+#
+# Inference rules — multi-word phrase match against title + body. Single
+# words like "test" or "meta" are too noisy (a meta-repo discussion or a
+# "test the helper" body would mis-route). Tech is the strong default —
+# false positives on qa/seo are more expensive than tech catching extra
+# work since tech is the largest backlog.
+#
+#   qa:    "test coverage", "flaky test", "regression test", "coverage
+#          report", "test suite", "pytest", "vitest", "jest", "ci flake"
+#   seo:   "meta tag", "meta description", "<meta ", "canonical url",
+#          "sitemap.xml", "robots.txt", "og:", "schema.org", "hreflang",
+#          "open graph", "structured data"
+#   tech:  default — anything that isn't qa or seo
+#
+# Cap at `max_issues_per_tick` from .bsg-autopilot.yml (default 10) per
+# run so a single tick can't flood the repo if a backlog of unrouted
+# issues just landed.
+#
+# Idempotent — running twice is a no-op.
+#
+# Usage:
+#   bash claude-skills/scripts/normalize-issue-labels.sh [--repo OWNER/NAME] [--dry-run]
+#
+# Emits one line per normalized issue (JSON). Empty output = nothing to
+# normalize. Exit 0 always (no work is not an error).
+
+set -euo pipefail
+
+REPO_FLAG=()
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "normalize-issue-labels.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Cap per tick — read from .bsg-autopilot.yml.
+MAX_ISSUES=10
+if [[ -f .bsg-autopilot.yml ]]; then
+  configured=$(grep -E '^\s*max_issues_per_tick\s*:' .bsg-autopilot.yml 2>/dev/null \
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  if [[ -n "$configured" ]]; then
+    MAX_ISSUES="$configured"
+  fi
+fi
+
+# Bus labels we route to. Order matters for inference fallback.
+BUS_LABELS_OUTPUT_COMMIT=("tech" "qa" "seo")
+
+infer_bus_label() {
+  # $1 = title + body lowercased.
+  local text="$1"
+  if echo "$text" | grep -qE 'test coverage|flaky test|regression test|coverage report|test suite|\bpytest\b|\bvitest\b|\bjest\b|ci flake|ci-flake'; then
+    echo "qa"
+  elif echo "$text" | grep -qE 'meta tag|meta description|<meta |canonical url|sitemap\.xml|robots\.txt|og:|schema\.org|hreflang|open graph|structured data'; then
+    echo "seo"
+  else
+    echo "tech"
+  fi
+}
+
+has_label() {
+  # $1 = labels JSON array, $2 = label name to check
+  jq -e --arg n "$2" 'any(.name == $n)' <<<"$1" >/dev/null 2>&1
+}
+
+has_any_bus_label() {
+  # $1 = labels JSON array
+  local lbl
+  for lbl in "${BUS_LABELS_OUTPUT_COMMIT[@]}"; do
+    if has_label "$1" "$lbl"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Pull all open issues with their labels, milestone, title, body.
+all_open=$(gh issue list "${REPO_FLAG[@]}" \
+  --state open \
+  --json number,title,body,labels,milestone \
+  --limit 200 2>/dev/null || echo "[]")
+
+count=0
+echo "$all_open" | jq -c '.[]' | while read -r issue; do
+  # Stop when we hit the cap (writing to a counter file because subshell).
+  if [[ $count -ge $MAX_ISSUES ]]; then
+    break
+  fi
+
+  num=$(jq -r '.number' <<<"$issue")
+  title=$(jq -r '.title' <<<"$issue")
+  body=$(jq -r '.body // ""' <<<"$issue")
+  labels=$(jq -c '.labels' <<<"$issue")
+  milestone=$(jq -r '.milestone.title // empty' <<<"$issue")
+
+  has_type=false
+  has_bus=false
+  has_label "$labels" "bug" && has_type=true
+  has_label "$labels" "enhancement" && has_type=true
+  has_any_bus_label "$labels" && has_bus=true
+
+  # Skip if already fully labeled.
+  if [[ "$has_type" == "true" && "$has_bus" == "true" ]]; then
+    continue
+  fi
+
+  # Cas C requires a milestone (otherwise the issue is too raw to route).
+  if [[ "$has_type" == "false" && "$has_bus" == "false" && -z "$milestone" ]]; then
+    continue
+  fi
+
+  added_labels=()
+  case_name=""
+
+  if [[ "$has_bus" == "true" && "$has_type" == "false" ]]; then
+    case_name="A"
+    added_labels+=("enhancement")
+  elif [[ "$has_bus" == "false" && "$has_type" == "true" ]]; then
+    case_name="B"
+    inferred=$(infer_bus_label "$(echo "$title $body" | tr '[:upper:]' '[:lower:]')")
+    added_labels+=("$inferred")
+    added_labels+=("needs:$inferred")
+  elif [[ "$has_bus" == "false" && "$has_type" == "false" && -n "$milestone" ]]; then
+    case_name="C"
+    inferred=$(infer_bus_label "$(echo "$title $body" | tr '[:upper:]' '[:lower:]')")
+    added_labels+=("$inferred")
+    added_labels+=("needs:$inferred")
+    added_labels+=("enhancement")
+  else
+    continue
+  fi
+
+  # Emit JSON record (always, dry-run or not).
+  jq -nc --arg n "$num" --arg t "$title" --arg c "$case_name" \
+        --argjson labels "$(printf '%s\n' "${added_labels[@]}" | jq -R . | jq -s .)" \
+        '{number: ($n | tonumber), title: $t, case: $c, added: $labels}'
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    count=$((count + 1))
+    continue
+  fi
+
+  # Apply the labels.
+  for lbl in "${added_labels[@]}"; do
+    gh issue edit "$num" "${REPO_FLAG[@]}" --add-label "$lbl" >/dev/null 2>&1 || true
+  done
+
+  # For Cas B and C, post a transparency comment so the inferred route is
+  # visible and a human or another agent can correct it cheaply.
+  if [[ "$case_name" != "A" ]]; then
+    inferred_only=""
+    for lbl in "${added_labels[@]}"; do
+      case "$lbl" in
+        tech|qa|seo) inferred_only="$lbl"; break ;;
+      esac
+    done
+    gh issue comment "$num" "${REPO_FLAG[@]}" --body "Auto-routed to \`${inferred_only}\` by \`normalize-issue-labels.sh\` (case ${case_name}, keyword inference). If the inference is wrong, swap the bus label — the next sweep will pick up the correct routing." >/dev/null 2>&1 || true
+  fi
+
+  count=$((count + 1))
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Closes #416. Implements the **counter-proposition** posted on the issue:
auto-route aggressively, accept mis-routes as self-correcting, escalate
to humans only with explicit reason + assignee + @-mention. The goal is
to keep the autopilot pipeline moving without humans gatekeeping label
decisions.

**Four leverage points** ([thread on #416](https://github.com/beyond-scale-group/bsg-stack/issues/416#issuecomment-4371176672)):

1. **Auto-route aggressively** via `normalize-issue-labels.sh`. Three
   cases (A: missing type → add `enhancement`; B: missing bus → infer
   from keywords; C: missing both with milestone → apply both). `tech`
   is the strong default; `qa`/`seo` require multi-word phrases. Each
   inferred route posts a transparency comment so swapping a mis-route
   is one click.
2. **Auto-decompose oversized issues** via `decompose-issue.sh`. The PO
   reads the parent's body and proposes the split; the script files
   children inheriting bus label + milestone + a `parent:<N>` label,
   and posts a single audit-trail comment on the parent.
3. **Tag + assign on `needs-human-review`** via `file-issue.sh --reason
   spec-clarification|tech-decision --assign-to <login>`. Reads
   `default_human_reviewer: guillaumebadin` from `.bsg-autopilot.yml`,
   sets the GitHub assignee, prepends an @-mention to the body. Forces
   the review label even in autopilot mode (the only legitimate
   override).
4. **Detect stuck flow** via `detect-stuck-issues.sh`. Tier 1 (>2d)
   posts an `@<bus_label>` nudge and applies idempotent `stuck:nudged`.
   Tier 2 (>5d) assigns the human reviewer + applies
   `needs:spec-clarification` + `needs-human-review`, getting the
   issue out of the agent loop until a human un-stucks it.

## Implementation

- **3 new scripts** (557 LOC): `normalize-issue-labels.sh`,
  `decompose-issue.sh`, `detect-stuck-issues.sh`.
- **`file-issue.sh`** extended with `--reason` and `--assign-to` flags.
- **`po-manager.md`** tick frontmatter and body wired with new steps
  1.4 (normalize) and 1.6 (detect-stuck); decomposition section
  rewritten for the auto-split flow.
- **`.bsg-autopilot.yml`** gains `default_human_reviewer: guillaumebadin`.
- **`INSTALL.md`** documents 4 new labels (`needs:spec-clarification`,
  `needs:tech-decision`, `stuck:nudged`, `parent:<N>`) with bootstrap
  commands.

## Bootstrap fix (already applied)

The 6 backlog issues from #416's "Fix immédiat" section now carry the
required labels: #330, #331, #237, #241, #266, #365. After this PR
merges, the next `@po-manager tick` will find the backlog clean and
the new normalization step will keep it that way.

## Testing

- Dry-runs of all three new scripts against the live backlog —
  normalize emits the 7 expected normalizations, then 1 remaining after
  the bootstrap; detect-stuck emits zero (no stuck issues yet);
  decompose passes `--help` cleanly.
- `pytest claude-skills/tests/test_skills.py
  claude-skills/tests/test_validate_plan.py
  claude-skills/tests/test_po_milestone_reconcile.py
  claude-skills/tests/test_po_report_integration.py` — 41 passed.
- All bash tests pass except a pre-existing failure in
  `test_github_bus.sh` (auto-merge bus_unlock — unrelated, untouched
  in this PR).

## Trade-offs

- Keyword inference will mis-route some issues (e.g. `test suite` in
  body routes to `qa`). The accepted trade-off per the user framing:
  agent-tick cost for a mis-route is 1 tick; human-wait cost for
  silent missing-label is days.
- Auto-decompose without a clear breakdown in the parent body falls
  back to refiling with `--reason spec-clarification` rather than
  guessing — decomposition without a spec is a separate problem.
