### PR TITLE
fix(pilot): bootstrap-plan.sh seeds epics from open issues (#115)

### DIFF
--- a/claude-skills/skills/po/scripts/bootstrap-plan.sh
+++ b/claude-skills/skills/po/scripts/bootstrap-plan.sh
@@ -82,15 +82,49 @@ EPICS
 # Infer epic candidates: issues that are referenced by >= 2 closing PRs
 # are likely parents of sub-work. Fall back to issues with sub-issue
 # labels (`epic`, `type:epic`) if any exist.
+# When neither exists and >= 3 open issues are present, cluster by title
+# token similarity and emit auto-suggested epics (issue #115).
 printf '%s' "$snapshot" | jq -r '
-  ([.pullRequests[].closingIssues[]] | group_by(.) | map({num: .[0], refs: length}) | map(select(.refs >= 2))) as $by_refs
-  | ([.issues[] | select(.labels | index("epic") or index("type:epic"))] | map({num: .number, title: .title})) as $by_label
-  | ($by_refs | map(.num) | map(. as $n | (.[$n] // null))) as $_skip
+  ["feat","fix","add","the","and","for","with","from","into","that","this","when",
+   "page","flow","base","data","query","adds","sets","gets","puts","runs","make",
+   "move","also","both","each","some","upon","have","been","will",
+   "were","more","than","then","back","like","such","only"] as $stops
+  | [.issues[] | select(.state == "OPEN")] as $open
+  | ([.pullRequests[].closingIssues[]] | group_by(.) | map({num: .[0], refs: length}) | map(select(.refs >= 2))) as $by_refs
+  | ([.issues[] | select(.labels | (type == "array") and any(.[]; . == "epic" or . == "type:epic"))] | map({num: .number, title: .title})) as $by_label
   | ($by_refs | map("- #\(.num) (referenced by \(.refs) PRs)    [epic:#\(.num)]")) as $lines_refs
   | ($by_label | map("- \(.title)    [epic:#\(.num)]")) as $lines_label
-  | ($lines_refs + $lines_label)
-  | if (. | length) == 0 then "- _No epic candidates detected. Add parent issues manually._"
-    else (. | join("\n"))
+  | ($lines_refs + $lines_label) as $traditional
+  | if ($traditional | length) > 0 then
+      ($traditional | join("\n"))
+    elif ($open | length) >= 3 then
+      (($open | map({
+          num: .number,
+          title: .title,
+          tokens: (.title | ascii_downcase | gsub("[^a-z0-9]"; " ") | split(" ")
+                   | map(select(length >= 4))
+                   | map(select(. as $t | $stops | any(.[]; . == $t) | not)))
+        })) as $tagged
+      | ([$tagged[].tokens[]] | group_by(.) | map({tok: .[0], cnt: length})
+         | map(select(.cnt >= 2)) | sort_by(-.cnt)) as $hot_toks
+      | ($hot_toks | map(.tok as $tok | {
+          label: $tok,
+          issues: [$tagged[] | select(.tokens | any(.[]; . == $tok)) | {num: .num, title: .title}]
+        }) | map(select((.issues | length) >= 2))) as $clusters
+      | if ($clusters | length) == 0 then
+          "- _No epic candidates detected. Add parent issues manually._"
+        else
+          (["_Auto-suggested epic clusters based on title similarity. Review wording before committing._"] +
+           ($clusters | map(
+             "### E-\(.label) _auto-suggested, review wording_\n\n" +
+             "> Scope: _set this_\n\n" +
+             "**Binds:** \(.issues | map("#" + (.num | tostring)) | join(", "))\n" +
+             "**Done when:** _set this_\n" +
+             (.issues | map("- #\(.num) \(.title)    [epic:#\(.num)]") | join("\n"))
+           ))) | join("\n\n")
+        end)
+    else
+      "- _No epic candidates detected. Add parent issues manually._"
     end
 '
 

--- a/claude-skills/tests/test_po_report_integration.py
+++ b/claude-skills/tests/test_po_report_integration.py
@@ -472,5 +472,97 @@ class TestPoReportIntegration(unittest.TestCase):
         self.assertIn("plan-schema.md", out)
 
 
+
+    def test_bootstrap_plan_seeds_epics_from_issues_when_no_milestones(self) -> None:
+        """#115: when no milestones and no epic labels exist, bootstrap seeds
+        epics from open issues by token-clustering — not a bare placeholder."""
+        snapshot = {
+            'repo': 'test-org/test-repo',
+            'generatedAt': '2026-05-04T00:00:00Z',
+            'meta': {},
+            'issues': [
+                {
+                    'number': 1,
+                    'title': 'feat: add authentication login page',
+                    'state': 'OPEN',
+                    'labels': ['enhancement'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+                {
+                    'number': 2,
+                    'title': 'feat: add authentication logout flow',
+                    'state': 'OPEN',
+                    'labels': ['enhancement'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+                {
+                    'number': 3,
+                    'title': 'feat: authentication session refresh',
+                    'state': 'OPEN',
+                    'labels': ['enhancement'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+                {
+                    'number': 4,
+                    'title': 'fix: database query timeout',
+                    'state': 'OPEN',
+                    'labels': ['bug'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+            ],
+            'pullRequests': [],
+            'milestones': [],
+            'releases': [],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False, dir=self.workdir
+        ) as fh:
+            json.dump(snapshot, fh)
+            snap_path = fh.name
+
+        result = subprocess.run(
+            ['bash', str(SCRIPTS / 'bootstrap-plan.sh'), '--snapshot', snap_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f'bootstrap-plan.sh failed: {result.stderr}',
+        )
+        out = result.stdout
+        # Must not emit the bare placeholder when >= 3 issues are available.
+        self.assertNotIn(
+            '- _No epic candidates detected. Add parent issues manually._',
+            out,
+            'bootstrap-plan.sh fell back to bare placeholder despite >= 3 open issues',
+        )
+        # Must contain at least one auto-suggested epic cluster.
+        self.assertIn(
+            '_auto-suggested',
+            out,
+            'bootstrap-plan.sh did not emit any _auto-suggested epic clusters',
+        )
+        # The issues should be bound in the suggestion.
+        self.assertIn('#1', out)
+        self.assertIn('#2', out)
+        self.assertIn('#3', out)
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds title-token clustering to `bootstrap-plan.sh` so repos with 3+ open issues but no milestones or epic labels get auto-suggested epic clusters instead of a bare placeholder
- Traditional detection (PRs-by-refs, `epic`/`type:epic` labels) still takes priority — clustering is a fallback
- Each suggested cluster is clearly marked `_auto-suggested, review wording_` so humans know what to sharpen

## Test plan

- [x] `test_bootstrap_plan_seeds_epics_from_issues_when_no_milestones` added and passes: verifies `_auto-suggested` text and issue bindings appear, placeholder does not
- [x] `test_bootstrap_plan_emits_draft_markdown` still passes against real repo (edomata)
- [x] Full test suite: 119 passed, 0 failures

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)