### PR TITLE
fix(pilot): feat(md-to-office): professional DOCX styling by default (#266)

### DIFF
--- a/claude-skills/skills/md-to-office/scripts/generate-templates.py
+++ b/claude-skills/skills/md-to-office/scripts/generate-templates.py
@@ -9,6 +9,26 @@ Creates:
 
 Requires: python-docx, python-pptx, openpyxl
 Run scripts/install-local.sh to install all three.
+
+tokens.json `docx` block (all optional — defaults are applied when absent):
+
+  {
+    "docx": {
+      "margins_cm": 2.5,
+      "body": {
+        "color": "#2A3340",
+        "size": 11,
+        "line_spacing": 1.25,
+        "space_after": 8
+      },
+      "title":     { "size": 32 },
+      "heading_1": { "size": 22, "before": 18, "after": 8 },
+      "heading_2": { "size": 16, "before": 14, "after": 6 },
+      "heading_3": { "size": 13, "before": 10, "after": 4 },
+      "heading_4": { "size": 11, "before": 8,  "after": 3 },
+      "footer":    "{name}  •  Confidentiel"
+    }
+  }
 """
 
 from __future__ import annotations
@@ -49,18 +69,59 @@ def _lighten(h: str, pct: float = 0.85) -> str:
 
 
 # ---------------------------------------------------------------------------
+# DOCX default constants (BPI/investor-grade)
+# ---------------------------------------------------------------------------
+
+_DOCX_DEFAULTS = {
+    "margins_cm": 2.5,
+    "body": {
+        "color": "#2A3340",
+        "size": 11,
+        "line_spacing": 1.25,
+        "space_after": 8,
+    },
+    "title":     {"size": 32},
+    "heading_1": {"size": 22, "before": 18, "after": 8},
+    "heading_2": {"size": 16, "before": 14, "after": 6},
+    "heading_3": {"size": 13, "before": 10, "after": 4},
+    "heading_4": {"size": 11, "before": 8,  "after": 3},
+    "footer":    "{name}  •  Confidentiel",
+}
+
+
+def _merge_docx_cfg(tokens: dict) -> dict:
+    """Deep-merge tokens['docx'] over _DOCX_DEFAULTS."""
+    import copy
+    cfg = copy.deepcopy(_DOCX_DEFAULTS)
+    user = tokens.get("docx", {})
+    for key, val in user.items():
+        if isinstance(val, dict) and isinstance(cfg.get(key), dict):
+            cfg[key].update(val)
+        else:
+            cfg[key] = val
+    return cfg
+
+
+# ---------------------------------------------------------------------------
 # DOCX
 # ---------------------------------------------------------------------------
 
 def _generate_docx(tokens: dict) -> None:
     from docx import Document  # type: ignore
-    from docx.shared import Pt, RGBColor  # type: ignore
+    from docx.shared import Cm, Pt, RGBColor  # type: ignore
+    from docx.enum.text import WD_LINE_SPACING  # type: ignore
 
     primary = tokens["colors"]["primary"]
     font_name = tokens["fonts"]["primary"]
+    project_name = tokens.get("name", "Project")
+
+    cfg = _merge_docx_cfg(tokens)
+
     r, g, b = _hex_to_rgb(primary)
     h2_r, h2_g, h2_b = _hex_to_rgb(_darken(primary, 0.15))
     h3_r, h3_g, h3_b = _hex_to_rgb(_darken(primary, 0.35))
+    # Muted slate for H4 — fixed colour regardless of brand primary
+    h4_r, h4_g, h4_b = 0x6B, 0x74, 0x80  # slate-500 equivalent
 
     # Bootstrap from pandoc's default reference.docx so the XML structure
     # is already what pandoc expects.
@@ -79,24 +140,79 @@ def _generate_docx(tokens: dict) -> None:
         doc = Document()
     tmp_path.unlink(missing_ok=True)
 
-    for style_name, rgb, size_pt, bold in [
-        ("Heading 1", (r, g, b),             18, True),
-        ("Heading 2", (h2_r, h2_g, h2_b),    14, True),
-        ("Heading 3", (h3_r, h3_g, h3_b),    12, True),
-    ]:
+    # --- Page margins ---
+    margins_cm = cfg["margins_cm"]
+    for section in doc.sections:
+        section.left_margin   = Cm(margins_cm)
+        section.right_margin  = Cm(margins_cm)
+        section.top_margin    = Cm(margins_cm)
+        section.bottom_margin = Cm(margins_cm)
+
+    # --- Normal body style ---
+    body_cfg = cfg["body"]
+    body_color = body_cfg.get("color", "#2A3340")
+    bc_r, bc_g, bc_b = _hex_to_rgb(body_color)
+    try:
+        normal = doc.styles["Normal"]
+        normal.font.size = Pt(body_cfg.get("size", 11))
+        normal.font.name = font_name
+        normal.font.color.rgb = RGBColor(bc_r, bc_g, bc_b)
+        normal.paragraph_format.space_after = Pt(body_cfg.get("space_after", 8))
+        normal.paragraph_format.line_spacing = body_cfg.get("line_spacing", 1.25)
+    except (KeyError, Exception):
+        pass
+
+    # --- Title style ---
+    title_cfg = cfg.get("title", {})
+    try:
+        title_style = doc.styles["Title"]
+        title_style.font.size = Pt(title_cfg.get("size", 32))
+        title_style.font.name = font_name
+        title_style.paragraph_format.space_after = Pt(18)
+    except (KeyError, Exception):
+        pass
+
+    # --- Heading styles (H1–H4) ---
+    heading_defs = [
+        ("Heading 1", (r, g, b),             cfg["heading_1"], True),
+        ("Heading 2", (h2_r, h2_g, h2_b),    cfg["heading_2"], True),
+        ("Heading 3", (h3_r, h3_g, h3_b),    cfg["heading_3"], True),
+        ("Heading 4", (h4_r, h4_g, h4_b),    cfg["heading_4"], False),
+    ]
+    for style_name, rgb, hcfg, bold in heading_defs:
         try:
             style = doc.styles[style_name]
             style.font.color.rgb = RGBColor(*rgb)
             style.font.bold = bold
-            style.font.size = Pt(size_pt)
+            style.font.size = Pt(hcfg.get("size", 11))
             style.font.name = font_name
+            if style_name == "Heading 4":
+                style.font.italic = True
+            pf = style.paragraph_format
+            before = hcfg.get("before")
+            after  = hcfg.get("after")
+            if before is not None:
+                pf.space_before = Pt(before)
+            if after is not None:
+                pf.space_after = Pt(after)
         except (KeyError, Exception):
             pass
 
+    # --- Footer ---
+    footer_tpl = cfg.get("footer", "{name}  •  Confidentiel")
+    footer_text = footer_tpl.replace("{name}", project_name)
     try:
-        normal = doc.styles["Normal"]
-        normal.font.size = Pt(11)
-        normal.font.name = font_name
+        for section in doc.sections:
+            footer = section.footer
+            # Clear existing paragraphs content
+            for para in footer.paragraphs:
+                para.clear()
+                run = para.add_run(footer_text)
+                run.font.size = Pt(8)
+                run.font.name = font_name
+                from docx.enum.text import WD_ALIGN_PARAGRAPH  # type: ignore
+                para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+                break  # only set the first paragraph
     except (KeyError, Exception):
         pass
 

--- a/claude-skills/tests/test_md_to_office.py
+++ b/claude-skills/tests/test_md_to_office.py
@@ -1039,5 +1039,224 @@ class TestRenderPptxSmoke(unittest.TestCase):
         self.assertTrue(out.stat().st_size > 0)
 
 
+
+class TestGenerateDocxProfessionalStyling(unittest.TestCase):
+    """#266: _generate_docx must produce BPI/investor-grade styling by default.
+
+    Verifies that the generated reference.docx carries:
+    - Page margins 2.5 cm on all four sides
+    - Normal body: line spacing 1.25, space_after 8pt, body color #2A3340
+    - Heading 1: 22pt, space_before 18pt, space_after 8pt
+    - Heading 2: 16pt, space_before 14pt, space_after 6pt
+    - Heading 3: 13pt, space_before 10pt, space_after 4pt
+    - Heading 4: 11pt, italic, muted slate colour
+    - Title: 32pt
+    - Footer with project name + "Confidentiel"
+    """
+
+    # Load the module once at class level so we don't re-import per test.
+    _mod = None
+
+    @classmethod
+    def _load_mod(cls):
+        if cls._mod is not None:
+            return cls._mod
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "generate_templates", str(GEN_TEMPLATES)
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls._mod = mod
+        return mod
+
+    def setUp(self) -> None:
+        try:
+            import docx  # noqa: F401
+        except ImportError:
+            self.skipTest("python-docx not installed; run scripts/install-local.sh")
+        self.tmp = Path(tempfile.mkdtemp(prefix="bsg-docx-style-"))
+        brand = self.tmp / "brand"
+        brand.mkdir()
+        tokens = {
+            "name": "TestProject",
+            "colors": {"primary": "#1a1a2e"},
+            "fonts": {"primary": "Helvetica Neue"},
+        }
+        (brand / "tokens.json").write_text(json.dumps(tokens))
+        # Redirect TEMPLATES so the module writes to our tmpdir
+        mod = self._load_mod()
+        self._orig_templates = mod.TEMPLATES
+        templates_dir = self.tmp / "brand" / "templates"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        mod.TEMPLATES = templates_dir
+        # Also patch ROOT so relative paths in print() don't error
+        self._orig_root = mod.ROOT
+        mod.ROOT = self.tmp
+
+    def tearDown(self) -> None:
+        mod = self._load_mod()
+        mod.TEMPLATES = self._orig_templates
+        mod.ROOT = self._orig_root
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _make_docx(self, extra_tokens: dict | None = None) -> "Document":  # type: ignore[name-defined]
+        from docx import Document
+        mod = self._load_mod()
+        tokens_path = self.tmp / "brand" / "tokens.json"
+        tokens = json.loads(tokens_path.read_text())
+        if extra_tokens:
+            tokens.update(extra_tokens)
+            tokens_path.write_text(json.dumps(tokens))
+        mod._generate_docx(tokens)
+        docx_path = mod.TEMPLATES / "reference.docx"
+        self.assertTrue(docx_path.exists(), "reference.docx not created")
+        return Document(str(docx_path))
+
+    # --- margin tests ---
+
+    def test_page_margins_are_2_5_cm(self) -> None:
+        """#266: all four page margins must be 2.5 cm (900 000 EMU)."""
+        from docx.shared import Cm
+        doc = self._make_docx()
+        for section in doc.sections:
+            for attr in ("left_margin", "right_margin", "top_margin", "bottom_margin"):
+                val = getattr(section, attr)
+                self.assertIsNotNone(val, f"{attr} is None")
+                self.assertAlmostEqual(
+                    val, Cm(2.5), delta=1000,
+                    msg=f"Expected {attr}=2.5 cm (900 000 EMU), got {val}"
+                )
+
+    # --- Normal body style tests ---
+
+    def test_normal_line_spacing_is_1_25(self) -> None:
+        """#266: Normal paragraph format must have line_spacing=1.25."""
+        doc = self._make_docx()
+        normal = doc.styles["Normal"]
+        ls = normal.paragraph_format.line_spacing
+        self.assertIsNotNone(ls, "Normal line_spacing is None")
+        self.assertAlmostEqual(float(ls), 1.25, places=2,
+                               msg=f"Expected line_spacing=1.25, got {ls}")
+
+    def test_normal_space_after_8pt(self) -> None:
+        """#266: Normal paragraph must have 8pt space after."""
+        from docx.shared import Pt
+        doc = self._make_docx()
+        normal = doc.styles["Normal"]
+        sa = normal.paragraph_format.space_after
+        self.assertIsNotNone(sa, "Normal space_after is None")
+        self.assertAlmostEqual(sa, Pt(8), delta=1000,
+                               msg=f"Expected space_after=8pt ({int(Pt(8))} EMU), got {sa}")
+
+    def test_normal_body_color_is_slate(self) -> None:
+        """#266: Normal font color must be slate #2A3340."""
+        doc = self._make_docx()
+        normal = doc.styles["Normal"]
+        color = normal.font.color.rgb
+        self.assertIsNotNone(color, "Normal font color is None")
+        self.assertEqual(str(color).upper(), "2A3340",
+                         f"Expected body color 2A3340, got {color}")
+
+    # --- Heading spacing tests ---
+
+    def test_heading1_size_and_spacing(self) -> None:
+        """#266: H1 must be 22pt, space_before=18pt, space_after=8pt."""
+        from docx.shared import Pt
+        doc = self._make_docx()
+        h1 = doc.styles["Heading 1"]
+        self.assertAlmostEqual(h1.font.size, Pt(22), delta=1000,
+                               msg=f"H1 size expected 22pt, got {h1.font.size}")
+        self.assertAlmostEqual(h1.paragraph_format.space_before, Pt(18), delta=1000,
+                               msg=f"H1 space_before expected 18pt")
+        self.assertAlmostEqual(h1.paragraph_format.space_after, Pt(8), delta=1000,
+                               msg=f"H1 space_after expected 8pt")
+
+    def test_heading2_size_and_spacing(self) -> None:
+        """#266: H2 must be 16pt, space_before=14pt, space_after=6pt."""
+        from docx.shared import Pt
+        doc = self._make_docx()
+        h2 = doc.styles["Heading 2"]
+        self.assertAlmostEqual(h2.font.size, Pt(16), delta=1000)
+        self.assertAlmostEqual(h2.paragraph_format.space_before, Pt(14), delta=1000)
+        self.assertAlmostEqual(h2.paragraph_format.space_after, Pt(6), delta=1000)
+
+    def test_heading3_size_and_spacing(self) -> None:
+        """#266: H3 must be 13pt, space_before=10pt, space_after=4pt."""
+        from docx.shared import Pt
+        doc = self._make_docx()
+        h3 = doc.styles["Heading 3"]
+        self.assertAlmostEqual(h3.font.size, Pt(13), delta=1000)
+        self.assertAlmostEqual(h3.paragraph_format.space_before, Pt(10), delta=1000)
+        self.assertAlmostEqual(h3.paragraph_format.space_after, Pt(4), delta=1000)
+
+    def test_heading4_exists_and_is_italic(self) -> None:
+        """#266: H4 style must exist, be 11pt, and italic."""
+        from docx.shared import Pt
+        doc = self._make_docx()
+        try:
+            h4 = doc.styles["Heading 4"]
+        except KeyError:
+            self.fail("Heading 4 style not found in generated reference.docx")
+        self.assertAlmostEqual(h4.font.size, Pt(11), delta=1000,
+                               msg=f"H4 size expected 11pt, got {h4.font.size}")
+        self.assertTrue(h4.font.italic, "H4 must be italic")
+
+    def test_title_style_is_32pt(self) -> None:
+        """#266: Title style must be set to 32pt."""
+        from docx.shared import Pt
+        doc = self._make_docx()
+        try:
+            title = doc.styles["Title"]
+        except KeyError:
+            self.skipTest("Title style not in pandoc default reference.docx")
+        self.assertAlmostEqual(title.font.size, Pt(32), delta=1000,
+                               msg=f"Title size expected 32pt, got {title.font.size}")
+
+    def test_footer_contains_project_name_and_confidentiel(self) -> None:
+        """#266: document footer must include project name + Confidentiel."""
+        doc = self._make_docx()
+        footer_text = ""
+        for section in doc.sections:
+            footer = section.footer
+            for para in footer.paragraphs:
+                footer_text += para.text
+        self.assertIn("TestProject", footer_text,
+                      f"Footer must contain project name 'TestProject', got: {footer_text!r}")
+        self.assertIn("Confidentiel", footer_text,
+                      f"Footer must contain 'Confidentiel', got: {footer_text!r}")
+
+    # --- tokens.json override tests ---
+
+    def test_docx_tokens_override_margins(self) -> None:
+        """#266: tokens.json docx.margins_cm must override the default 2.5cm."""
+        from docx.shared import Cm
+        tokens_path = self.tmp / "brand" / "tokens.json"
+        tokens = json.loads(tokens_path.read_text())
+        tokens["docx"] = {"margins_cm": 3.0}
+        tokens_path.write_text(json.dumps(tokens))
+        mod = self._load_mod()
+        doc = self._make_docx()
+        for section in doc.sections:
+            for attr in ("left_margin", "right_margin", "top_margin", "bottom_margin"):
+                val = getattr(section, attr)
+                self.assertAlmostEqual(
+                    val, Cm(3.0), delta=1000,
+                    msg=f"Expected overridden {attr}=3.0 cm, got {val}"
+                )
+
+    def test_docx_tokens_override_body_line_spacing(self) -> None:
+        """#266: tokens.json docx.body.line_spacing must override the default."""
+        tokens_path = self.tmp / "brand" / "tokens.json"
+        tokens = json.loads(tokens_path.read_text())
+        tokens["docx"] = {"body": {"line_spacing": 1.5}}
+        tokens_path.write_text(json.dumps(tokens))
+        doc = self._make_docx()
+        normal = doc.styles["Normal"]
+        ls = normal.paragraph_format.line_spacing
+        self.assertAlmostEqual(float(ls), 1.5, places=2,
+                               msg=f"Expected overridden line_spacing=1.5, got {ls}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tech/reports/2026-05-04-health.md
+++ b/tech/reports/2026-05-04-health.md
@@ -1,8 +1,8 @@
 <!-- fingerprint: none -->
 # Tech Health — 2026-05-04
 
-**Repository:** `bsg-stack`
-**Generated:** 2026-05-04T12:00:00Z
+**Repository:** `agent-a8b2dd796f357da86`
+**Generated:** 2026-05-04T18:01:41Z
 **Ecosystems:** 
 
 ---
@@ -17,14 +17,16 @@ _No major-version-behind dependencies._
 
 ## Code Quality
 
-**Summary:** 11 source files analyzed — 2 oversized (> 500 LOC), 2 function-dense (> 20), 0 circular-import cycles
+**Summary:** 12 source files analyzed — 4 oversized (> 500 LOC), 2 function-dense (> 20), 0 circular-import cycles
 
 ### Largest files
 
 | File | Lines | Functions |
 |------|-------|-----------|
-| claude-skills/tests/test_md_to_office.py | 1000 | 105 |
-| claude-skills/tests/test_skills.py | 599 | 24 |
+| claude-skills/tests/test_md_to_office.py | 1043 | 107 |
+| claude-skills/tests/test_skills.py | 626 | 25 |
+| claude-skills/tests/test_po_report_integration.py | 568 | 18 |
+| claude-skills/skills/md-to-office/scripts/scan-brand.py | 526 | 15 |
 
 
 
@@ -32,9 +34,9 @@ _No major-version-behind dependencies._
 
 ## Tech Debt Inventory
 
-**Summary:** 6 markers — TODO: 6, FIXME: 0, HACK: 0; oldest: 2026-04-22
+**Summary:** 7 markers — TODO: 7, FIXME: 0, HACK: 0; oldest: 2026-04-22
 
-**Debt score:** 6 (no previous)
+**Debt score:** 7 (no previous)
 
 _No stale TODOs (> 90 days)._
 
@@ -44,6 +46,5 @@ _No stale TODOs (> 90 days)._
 
 _No ADR directory found. Consider creating `adr/0001-start.md` to document the first architectural decision of this repo._
 
----
 
-pilot: attempted #392 — PR #405
+

--- a/tech/reports/2026-05-04-health.md
+++ b/tech/reports/2026-05-04-health.md
@@ -46,5 +46,7 @@ _No stale TODOs (> 90 days)._
 
 _No ADR directory found. Consider creating `adr/0001-start.md` to document the first architectural decision of this repo._
 
+---
 
-
+<!-- pilot receipt -->
+pilot: attempted #266 — PR pending


### PR DESCRIPTION
## Summary

- Add BPI/investor-grade DOCX defaults to `_generate_docx` in `generate-templates.py`: 2.5 cm margins, body color #2A3340, line spacing 1.25, space_after 8pt, H1–H4 size+spacing rhythm, Title 32pt, italic H4, footer with project name + "Confidentiel"
- All settings overridable via `tokens.json` `docx:` block (`margins_cm`, `body.*`, `heading_*.*`, `footer`)
- 12 new tests cover every new style property and the tokens.json override path

## Test plan

- [x] `python3 -m pytest claude-skills/tests/test_md_to_office.py -k TestGenerateDocxProfessionalStyling` — 12/12 pass
- [x] Full suite: `python3 -m pytest claude-skills/tests/test_md_to_office.py` — 80 passed, 17 skipped (pandoc/pptx dep-gated), 0 failed
- [x] Existing `TestGenerateTemplatesPartialDeps` tests still pass

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)