### PR TITLE
report(marketing): 2026-05-04-audit-214216

### DIFF
--- a/marketing/reports/2026-05-04-audit-214216.md
+++ b/marketing/reports/2026-05-04-audit-214216.md
@@ -1,0 +1,58 @@
+<!-- fingerprint: none -->
+# Marketing Audit — 2026-05-04
+
+**Repository:** `agent-ad495134a8224c1e8`
+**Generated:** 2026-05-04T19:41:44Z
+**Releases tracked:** 2
+**Milestones tracked:** 10
+
+---
+
+## Content Calendar
+
+**Summary:** 0 items — 0 overdue, 0 today, 0 upcoming, 0 completed
+
+
+
+
+
+---
+
+## Feature-Marketing Alignment
+
+**Summary:** 2 shipped, 14 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 8 claimed-but-unshipped
+
+
+### Unmarketed shipped features (silence-breaker)
+
+| Release | Feature | Released at |
+|---------|---------|-------------|
+| v2.1.0 | v2.1.0 — Drop Renovate compat stubs | 2026-04-14T10:57:12Z |
+| v2.0.0 | v2.0.0 — Stack reorganisation | 2026-04-14T10:41:10Z |
+
+
+
+### Claimed but not (yet) shipped
+
+- `BSG STACK — THE INFRASTRUCTURE THAT RUNS THE EMPIRE` (found in README.md)
+- `Content calendar — beyond-scale-group/bsg-stack` (found in marketing/CALENDAR.md)
+- `Marketing Audit — 2026-04-23` (found in marketing/reports/2026-04-22-audit.md, marketing/reports/2026-04-23-audit.md)
+- `Marketing Audit — 2026-04-24` (found in marketing/reports/2026-04-24-audit.md)
+- `Marketing Audit — 2026-04-30` (found in marketing/reports/2026-04-30-audit.md)
+- `Marketing Audit — 2026-05-03` (found in marketing/reports/2026-05-02-audit.md)
+- `Marketing Audit — 2026-05-04` (found in marketing/reports/2026-05-03-audit.md, marketing/reports/2026-05-04-audit-0131.md, marketing/reports/2026-05-04-audit-2.md, marketing/reports/2026-05-04-audit-2052.md, marketing/reports/2026-05-04-audit-7704.md, marketing/reports/2026-05-04-audit-8318.md)
+- `What's in the Box` (found in README.md)
+
+---
+
+## Campaign Briefs
+
+### Plan (not yet written to disk)
+
+_Run the skill with `--write` to generate these stubs._
+
+- `marketing/briefs/2026-04-14-2.1.0-v2-1-0-drop-renovate-compat-stubs.md` — v2.1.0 v2.1.0 — Drop Renovate compat stubs
+- `marketing/briefs/2026-04-14-2.0.0-v2-0-0-stack-reorganisation.md` — v2.0.0 v2.0.0 — Stack reorganisation
+
+
+

--- a/marketing/reports/2026-05-04-audit.md
+++ b/marketing/reports/2026-05-04-audit.md
@@ -1,8 +1,8 @@
 <!-- fingerprint: none -->
 # Marketing Audit — 2026-05-04
 
-**Repository:** `agent-aaf014113e9768d2d`
-**Generated:** 2026-05-04T11:21:36Z
+**Repository:** `agent-ad495134a8224c1e8`
+**Generated:** 2026-05-04T19:41:44Z
 **Releases tracked:** 2
 **Milestones tracked:** 10
 
@@ -20,7 +20,7 @@
 
 ## Feature-Marketing Alignment
 
-**Summary:** 2 shipped, 9 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 8 claimed-but-unshipped
+**Summary:** 2 shipped, 14 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 8 claimed-but-unshipped
 
 
 ### Unmarketed shipped features (silence-breaker)
@@ -40,7 +40,7 @@
 - `Marketing Audit — 2026-04-24` (found in marketing/reports/2026-04-24-audit.md)
 - `Marketing Audit — 2026-04-30` (found in marketing/reports/2026-04-30-audit.md)
 - `Marketing Audit — 2026-05-03` (found in marketing/reports/2026-05-02-audit.md)
-- `Marketing Audit — 2026-05-04` (found in marketing/reports/2026-05-03-audit.md)
+- `Marketing Audit — 2026-05-04` (found in marketing/reports/2026-05-03-audit.md, marketing/reports/2026-05-04-audit-0131.md, marketing/reports/2026-05-04-audit-2.md, marketing/reports/2026-05-04-audit-2052.md, marketing/reports/2026-05-04-audit-7704.md, marketing/reports/2026-05-04-audit-8318.md)
 - `What's in the Box` (found in README.md)
 
 ---


### PR DESCRIPTION
Automated marketing audit report — 2026-05-04.

**Silence-breakers fired:**
- 2 unmarketed shipped features: v2.1.0 (Drop Renovate compat stubs) and v2.0.0 (Stack reorganisation) — both released 2026-04-14 with no corresponding marketing content
- 8 claimed-but-unshipped items (prior audit report titles and README section headers parsed as marketing claims — false positives from scanner)

**Calendar:** 0 items tracked.

Auto-generated by `@marketing tick`.