### PR TITLE
report(marketing): 2026-05-05-audit

### DIFF
--- a/marketing/reports/2026-05-05-audit.md
+++ b/marketing/reports/2026-05-05-audit.md
@@ -1,0 +1,59 @@
+<!-- fingerprint: none -->
+# Marketing Audit — 2026-05-05
+
+**Repository:** `agent-a5e1db1b322548fdb`
+**Generated:** 2026-05-05T08:09:16Z
+**Releases tracked:** 2
+**Milestones tracked:** 10
+
+---
+
+## Content Calendar
+
+**Summary:** 0 items — 0 overdue, 0 today, 0 upcoming, 0 completed
+
+
+
+
+
+---
+
+## Feature-Marketing Alignment
+
+**Summary:** 2 shipped, 18 marketing files scanned — 0 aligned, 2 unmarketed shipped features, 9 claimed-but-unshipped
+
+
+### Unmarketed shipped features (silence-breaker)
+
+| Release | Feature | Released at |
+|---------|---------|-------------|
+| v2.1.0 | v2.1.0 — Drop Renovate compat stubs | 2026-04-14T10:57:12Z |
+| v2.0.0 | v2.0.0 — Stack reorganisation | 2026-04-14T10:41:10Z |
+
+
+
+### Claimed but not (yet) shipped
+
+- `BSG STACK — THE INFRASTRUCTURE THAT RUNS THE EMPIRE` (found in README.md)
+- `Content calendar — beyond-scale-group/bsg-stack` (found in marketing/CALENDAR.md)
+- `Marketing Audit — 2026-04-23` (found in marketing/reports/2026-04-22-audit.md, marketing/reports/2026-04-23-audit.md)
+- `Marketing Audit — 2026-04-24` (found in marketing/reports/2026-04-24-audit.md)
+- `Marketing Audit — 2026-04-30` (found in marketing/reports/2026-04-30-audit.md)
+- `Marketing Audit — 2026-05-03` (found in marketing/reports/2026-05-02-audit.md)
+- `Marketing Audit — 2026-05-04` (found in marketing/reports/2026-05-03-audit.md, marketing/reports/2026-05-04-audit-0131.md, marketing/reports/2026-05-04-audit-1777927434.md, marketing/reports/2026-05-04-audit-2.md, marketing/reports/2026-05-04-audit-2052.md, marketing/reports/2026-05-04-audit-214216.md, marketing/reports/2026-05-04-audit-7704.md, marketing/reports/2026-05-04-audit-8318.md, marketing/reports/2026-05-04-audit.md)
+- `Marketing Audit — 2026-05-05` (found in marketing/reports/2026-05-04-audit-1777957678.md)
+- `What's in the Box` (found in README.md)
+
+---
+
+## Campaign Briefs
+
+### Plan (not yet written to disk)
+
+_Run the skill with `--write` to generate these stubs._
+
+- `marketing/briefs/2026-04-14-2.1.0-v2-1-0-drop-renovate-compat-stubs.md` — v2.1.0 v2.1.0 — Drop Renovate compat stubs
+- `marketing/briefs/2026-04-14-2.0.0-v2-0-0-stack-reorganisation.md` — v2.0.0 v2.0.0 — Stack reorganisation
+
+
+


### PR DESCRIPTION
Auto-generated marketing audit for 2026-05-05.

Silence-breakers fired:
- 2 unmarketed shipped releases: v2.1.0 (Drop Renovate compat stubs), v2.0.0 (Stack reorganisation)
- Content calendar present but 0 items tracked

See marketing/reports/2026-05-05-audit.md for full findings.