### PR TITLE
perf(skills-updater): add 1-hour cooldown

### DIFF
--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -73,6 +73,13 @@ LOGS_DIR = CLAUDE_DIR / "logs"
 LOG_FILE = LOGS_DIR / "update-bsg-skills.log"
 MANIFEST_FILE = SCRIPTS_DIR / ".bsg-skills-manifest.json"
 SETTINGS_FILE = CLAUDE_DIR / "settings.json"
+COOLDOWN_FILE = SCRIPTS_DIR / ".bsg-skills-last-run"
+COOLDOWN_SECONDS = 3600
+
+# Early exit before any network I/O if we ran recently.
+if COOLDOWN_FILE.exists():
+    if time.time() - COOLDOWN_FILE.stat().st_mtime < COOLDOWN_SECONDS:
+        sys.exit(0)
 
 API_BASE = f"https://api.github.com/repos/{REPO}/contents"
 API_HEADERS = {
@@ -479,6 +486,7 @@ def main() -> int:
     manifest = load_manifest()
     manifest = reconcile(manifest)
     save_manifest(manifest)
+    COOLDOWN_FILE.touch()
     log("done.")
     return 0
 


### PR DESCRIPTION
## Summary
- The `update-bsg-skills.py` SessionStart hook takes ~40s per invocation (GitHub API round-trips for 150+ files)
- Opening multiple Claude sessions in quick succession compounds the delay
- Adds a module-level early exit via a timestamp file (`.bsg-skills-last-run`) — if the script ran successfully less than 1 hour ago, it exits immediately before any network I/O

## Impact
- Session start goes from ~40s blocked to instant (within cooldown window)
- Skills still update at most once per hour — sufficient for shared team scripts

## Test plan
- [x] Verified script exits in <0.1s when cooldown file is fresh
- [x] Verified full sync still runs after removing `.bsg-skills-last-run`