### PR TITLE
feat(bsg-paths): generalize _bsg-paths.sh resolver + document .bsg/ convention (#237)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,56 @@ for the full list of managed keys and how to add or remove one.
 ### Data lives in the target repo, not centrally
 
 Agents that produce reports or plans write them into the repo they were invoked
-in, at a root-level folder (e.g. `po/`), and commit them. No central portfolio
-folder, no cross-repo database. "One repo, one agent, one plan."
+in, at a root-level folder, and commit them. No central portfolio folder, no
+cross-repo database. "One repo, one agent, one plan." The canonical root
+folder is `.bsg/` — see the next section.
+
+### The `.bsg/` directory convention — ADR-001
+
+All BSG agent custom docs and reports live under a single `.bsg/` folder
+at the repo root, following the dot-prefix-as-infra convention used by
+`.github/` and `.vscode/`:
+
+```
+.bsg/
+├── PLAN.md             # po-manager
+├── NARRATIVE.md        # storytelling
+├── DESIGN.md           # md-to-office (Google Stitch spec, ADR-003)
+├── KEYWORDS.md         # seo
+├── CALENDAR.md         # marketing
+├── ANNOUNCED.md        # pr-comms
+├── SECURITYIGNORE      # security exclusions
+├── AUTOPILOT.yml       # autopilot config (replaces .bsg-autopilot.yml)
+├── adr/                # tech-lead — multi-file by design
+├── brand/              # md-to-office templates + derived tokens.json
+└── reports/            # ALL agent dated reports, one subfolder per agent
+    ├── po/
+    ├── qa/
+    ├── tech/
+    ├── seo/
+    ├── marketing/
+    ├── security/
+    ├── storytelling/
+    └── comms/
+```
+
+Three rules govern adding to the tree:
+
+1. **Flat files** when a single doc per agent suffices. UPPER_CASE.md
+   matches the `CLAUDE.md` / `DESIGN.md` / `README.md` convention.
+2. **Subfolders** only when multi-file is intrinsic (`adr/`, `brand/`,
+   `reports/`). Don't create per-agent subfolders for what's already a
+   single document.
+3. **Path resolution goes through `_bsg-paths.sh`.** Any script that
+   reads a custom doc must source `claude-skills/scripts/_bsg-paths.sh`
+   and call `bsg_doc_path <kind>` (or use `$BSG_AUTOPILOT_FILE` for the
+   common autopilot case). The resolver prefers `.bsg/<NAME>` and falls
+   back to the legacy folder during the migration window — never
+   hardcode either path. Adding a new doc kind is a one-line addition
+   to the `case` block in `_bsg-paths.sh`.
+
+Migration from legacy paths is documented at
+[`claude-skills/MIGRATION-bsg-paths.md`](claude-skills/MIGRATION-bsg-paths.md).
 
 ### Reporting agents output via auto-merge PRs
 
@@ -293,13 +341,15 @@ The `--repo OWNER/NAME` flag on `list-pilot-candidates.sh` allows
 running against a different repository than the current working
 directory — useful for cross-repo sweeps from a central session.
 
-### Autopilot mode (`.bsg-autopilot.yml`) — #221, #286
+### Autopilot mode (`.bsg/AUTOPILOT.yml`) — #221, #286, #237
 
-`.bsg-autopilot.yml` is the single repo-level opt-in for
-auto-implementation. The file is the gate: without it, no
-auto-implementation happens regardless of issue labels.
+`.bsg/AUTOPILOT.yml` is the single repo-level opt-in for
+auto-implementation (legacy name `.bsg-autopilot.yml` still resolves
+during the migration window via `_bsg-paths.sh`). The file is the
+gate: without it, no auto-implementation happens regardless of issue
+labels.
 
-Drop a `.bsg-autopilot.yml` at the repo root:
+Drop a `.bsg/AUTOPILOT.yml` at the repo root:
 
 ```yaml
 enabled: true

--- a/claude-skills/MIGRATION-bsg-paths.md
+++ b/claude-skills/MIGRATION-bsg-paths.md
@@ -1,0 +1,135 @@
+# Migration guide: legacy paths → `.bsg/`
+
+ADR-001 consolidates every per-repo BSG agent custom doc under a single
+`.bsg/` directory at the repo root, replacing the ~9 sibling folders
+(`po/`, `brand/`, `seo/`, `marketing/`, `comms/`, `adr/`, `qa/`, plus
+the dotfile `.bsg-autopilot.yml` and `.securityignore`).
+
+This guide documents what moves, when, and how to migrate a consumer
+repo without breaking cached `claude-skills/` installs.
+
+## Why migrate
+
+- One folder to inspect, archive, `.gitignore`, or pass to `/bsg-stack
+  doctor` instead of nine
+- Dot-prefix matches the `.github/`-style "infra, not product" signal
+- Future agents stop adding new top-level folders
+- Cross-cutting tooling (`/bsg-stack`, `_bsg-paths.sh`) only has to
+  enumerate one tree
+
+## What moves
+
+| Legacy path                      | New path                        | Doc kind          |
+|----------------------------------|---------------------------------|-------------------|
+| `po/PLAN.md`                     | `.bsg/PLAN.md`                  | `plan`            |
+| `po/reports/<date>-*.md`         | `.bsg/reports/po/<date>-*.md`   | `reports`         |
+| `brand/NARRATIVE.md`             | `.bsg/NARRATIVE.md`             | `narrative`       |
+| `brand/templates/`               | `.bsg/brand/templates/`         | `brand`           |
+| `brand/tokens.json`              | `.bsg/brand/tokens.json`        | `brand`           |
+| `seo/KEYWORDS.md`                | `.bsg/KEYWORDS.md`              | `keywords`        |
+| `seo/reports/`                   | `.bsg/reports/seo/`             | `reports`         |
+| `marketing/CALENDAR.md`          | `.bsg/CALENDAR.md`              | `calendar`        |
+| `marketing/reports/`             | `.bsg/reports/marketing/`       | `reports`         |
+| `comms/ANNOUNCED.md`             | `.bsg/ANNOUNCED.md`             | `announced`       |
+| `comms/reports/`                 | `.bsg/reports/comms/`           | `reports`         |
+| `adr/`                           | `.bsg/adr/`                     | `adr`             |
+| `qa/reports/`                    | `.bsg/reports/qa/`              | `reports`         |
+| `.securityignore`                | `.bsg/SECURITYIGNORE`           | `securityignore`  |
+| `.bsg-autopilot.yml`             | `.bsg/AUTOPILOT.yml`            | `autopilot`       |
+| _(new — ADR-003)_                | `.bsg/DESIGN.md`                | `design`          |
+
+## How resolution works during the migration
+
+`claude-skills/scripts/_bsg-paths.sh` exposes:
+
+```bash
+# shellcheck source=_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/_bsg-paths.sh"
+
+plan="$(bsg_doc_path plan)"          # → ".bsg/PLAN.md" if it exists,
+                                     #   else "po/PLAN.md"
+auto="$BSG_AUTOPILOT_FILE"           # same idea, pre-resolved
+```
+
+The resolver:
+
+1. Returns the `.bsg/` path when it exists on disk
+2. Otherwise returns the legacy path (so `[[ -f "$path" ]]` still
+   doubles as a presence test)
+3. Returns the `.bsg/` path when neither exists, so first writes go
+   into the new tree
+
+**Hard rule for new code: never hardcode either path.** Always go
+through `bsg_doc_path` or `BSG_AUTOPILOT_FILE`. Adding a new doc kind
+is a one-line addition to the `case` block in `_bsg-paths.sh`.
+
+## Migrating a consumer repo
+
+The fallback is intentional — every consumer repo can migrate at its
+own pace without breaking cached installs. The recommended sequence:
+
+1. **Update your cache.** `update-bsg-skills.py` (run automatically on
+   `SessionStart`) refreshes `~/.claude/skills/` with the resolver-aware
+   scripts. No-op if you've session-started since `_bsg-paths.sh`
+   landed.
+
+2. **Bootstrap `.bsg/`** if it doesn't exist:
+
+   ```bash
+   mkdir -p .bsg/{adr,brand/templates,reports/{po,qa,tech,seo,marketing,security,storytelling,comms}}
+   ```
+
+3. **Move docs one at a time** (each is a one-PR move; agents keep
+   working through the resolver during the move):
+
+   ```bash
+   git mv po/PLAN.md          .bsg/PLAN.md
+   git mv brand/NARRATIVE.md  .bsg/NARRATIVE.md
+   git mv seo/KEYWORDS.md     .bsg/KEYWORDS.md
+   git mv marketing/CALENDAR.md .bsg/CALENDAR.md
+   git mv comms/ANNOUNCED.md  .bsg/ANNOUNCED.md
+   git mv .bsg-autopilot.yml  .bsg/AUTOPILOT.yml
+   git mv .securityignore     .bsg/SECURITYIGNORE
+   git mv adr                 .bsg/adr
+   ```
+
+4. **Move dated reports** under the unified `.bsg/reports/<agent>/`
+   tree:
+
+   ```bash
+   for agent in po qa tech seo marketing security storytelling comms; do
+     [[ -d "$agent/reports" ]] && git mv "$agent/reports" ".bsg/reports/$agent"
+   done
+   ```
+
+5. **Verify with `/bsg-stack doctor`.** Each row should show the
+   `.bsg/` path with `✓ present`. Rows still showing `legacy path —
+   migrate to .bsg/` mean the move missed that doc.
+
+6. **Commit and PR.** Auto-merge the move PR. Agents on the next tick
+   write into `.bsg/` because the resolver picks it up.
+
+## Rules for catalog (this repo) vs consumer repos
+
+`bsg-stack` itself is currently mid-migration: the resolver and tests
+already prefer `.bsg/` paths, but `.bsg/PLAN.md`, `.bsg/NARRATIVE.md`,
+etc. don't all exist yet because the agents that own them haven't
+shipped their `--init` (#237 deliverable #2). Until they do, `doctor`
+will report those agents as `✗ missing` here, which is expected.
+
+For consumer repos the fallback is the migration path. For this repo
+the fallback is mostly a holdover — once each agent's `--init` is
+wired and a first run lands its `.bsg/<DOC>`, the legacy fallback
+becomes dead code.
+
+## When the fallback goes away
+
+Per ADR-001, the legacy fallback in `_bsg-paths.sh` is dropped one
+release window after every `output: pr` agent has been observed
+writing to `.bsg/` in production. There is no flag day; the dead
+fallback branch in the resolver is removed in a separate PR with a
+visible deprecation notice in `update-bsg-skills.py` for the prior
+release.
+
+Until then: `bsg_doc_path` and `$BSG_AUTOPILOT_FILE` are the only
+correct way to reference any of the docs in the table above.

--- a/claude-skills/scripts/_bsg-paths.sh
+++ b/claude-skills/scripts/_bsg-paths.sh
@@ -1,32 +1,67 @@
 # _bsg-paths.sh — shared path resolution for BSG agent infrastructure.
 #
-# Sourced (not executed) by other scripts. Exports `BSG_AUTOPILOT_FILE`
-# pointing at the autopilot config file, preferring the new `.bsg/`
-# convention from ADR-001 over the legacy dotfile path.
+# Sourced (not executed) by other scripts. Resolves every per-repo
+# custom doc and the autopilot config to either the new `.bsg/`
+# convention from ADR-001 or its legacy fallback path.
 #
-# Resolution order:
-#   1. .bsg/AUTOPILOT.yml         (ADR-001, .bsg/ directory convention)
-#   2. .bsg-autopilot.yml         (legacy dotfile, kept during migration)
+# Two surfaces:
+#   1. `BSG_AUTOPILOT_FILE` env var — autopilot config (most common
+#      caller pattern; pre-resolved at source time so `[[ -f
+#      "$BSG_AUTOPILOT_FILE" ]]` doubles as a presence test).
+#   2. `bsg_doc_path <kind>` function — resolves any custom doc to its
+#      preferred path. Returns the `.bsg/` path if it exists, otherwise
+#      the legacy path so callers can still presence-test the result.
 #
-# When neither exists, BSG_AUTOPILOT_FILE points at the legacy path so
-# `[[ -f "$BSG_AUTOPILOT_FILE" ]]` checks still work as a presence test.
+# Resolution order for every doc is identical: prefer `.bsg/<NAME>` if
+# it exists on disk, else the agent's legacy folder if THAT exists,
+# else the `.bsg/` path unconditionally so first-write callers (like
+# per-agent `--init`) land in the new tree without further wiring.
+# Either return value is safe for `[[ -f "$path" ]]` presence tests.
 #
 # Usage from a sibling script:
 #
 #     # shellcheck source=_bsg-paths.sh disable=SC1091
 #     source "$(dirname "${BASH_SOURCE[0]}")/_bsg-paths.sh"
-#     # ... use "$BSG_AUTOPILOT_FILE" everywhere
+#     plan="$(bsg_doc_path plan)"
+#     [[ -f "$plan" ]] || { echo "no PLAN.md" >&2; exit 1; }
 #
-# Resolves the path relative to the current working directory of the
-# caller (matches the `[[ -f .bsg-autopilot.yml ]]` checks the legacy
-# scripts use). Idempotent — sourcing twice does no harm.
+# Idempotent — sourcing twice does no harm.
 
-bsg_autopilot_file() {
-  if [[ -f .bsg/AUTOPILOT.yml ]]; then
-    printf '%s\n' '.bsg/AUTOPILOT.yml'
+# bsg_doc_path <kind> — print the preferred path for a known custom-doc
+# kind. Adding a new doc is a one-line addition to the case below.
+bsg_doc_path() {
+  local kind="$1" new legacy
+  case "$kind" in
+    autopilot)     new=".bsg/AUTOPILOT.yml";    legacy=".bsg-autopilot.yml" ;;
+    plan)          new=".bsg/PLAN.md";          legacy="po/PLAN.md" ;;
+    narrative)     new=".bsg/NARRATIVE.md";     legacy="brand/NARRATIVE.md" ;;
+    keywords)      new=".bsg/KEYWORDS.md";      legacy="seo/KEYWORDS.md" ;;
+    calendar)      new=".bsg/CALENDAR.md";      legacy="marketing/CALENDAR.md" ;;
+    announced)     new=".bsg/ANNOUNCED.md";     legacy="comms/ANNOUNCED.md" ;;
+    securityignore) new=".bsg/SECURITYIGNORE";  legacy=".securityignore" ;;
+    design)        new=".bsg/DESIGN.md";        legacy="brand/DESIGN.md" ;;
+    adr)           new=".bsg/adr";              legacy="adr" ;;
+    brand)         new=".bsg/brand";            legacy="brand" ;;
+    reports)       new=".bsg/reports";          legacy="" ;;
+    *)
+      echo "bsg_doc_path: unknown doc kind '$kind'" >&2
+      return 2
+      ;;
+  esac
+  # Resolution order: .bsg/ if it exists, else legacy if it exists,
+  # else .bsg/ unconditionally so first writes go into the new tree.
+  if [[ -e "$new" ]]; then
+    printf '%s\n' "$new"
+  elif [[ -n "$legacy" && -e "$legacy" ]]; then
+    printf '%s\n' "$legacy"
   else
-    printf '%s\n' '.bsg-autopilot.yml'
+    printf '%s\n' "$new"
   fi
+}
+
+# bsg_autopilot_file — back-compat alias for the most common caller.
+bsg_autopilot_file() {
+  bsg_doc_path autopilot
 }
 
 BSG_AUTOPILOT_FILE="$(bsg_autopilot_file)"

--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -5,7 +5,7 @@
 # Default behavior (safe): apply `needs-human-review` and stop. A human
 # decides when to merge via `mark-reviewed.sh`.
 #
-# Auto-merge behavior: if `.bsg-autopilot.yml` exists with
+# Auto-merge behavior: if `$BSG_AUTOPILOT_FILE` exists with
 # `enabled: true`, lists the calling agent under `agents:`, AND has
 # `auto_merge: true`, this script squash-merges the PR, deletes the
 # branch, and stamps `human-reviewed` instead. Use this only on

--- a/claude-skills/scripts/detect-stuck-issues.sh
+++ b/claude-skills/scripts/detect-stuck-issues.sh
@@ -19,7 +19,7 @@
 #     The agent hasn't been able to make progress despite the nudge —
 #     spec is likely ambiguous or the tech choice isn't tranched.
 #     Assign the issue to `default_human_reviewer` from
-#     .bsg-autopilot.yml, post a comment with `@<human>` mention, and
+#     $BSG_AUTOPILOT_FILE, post a comment with `@<human>` mention, and
 #     apply `needs:spec-clarification` + `needs-human-review`.
 #
 # Idempotent: each tier applies its label and won't re-fire on the
@@ -57,7 +57,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Read default_human_reviewer from .bsg-autopilot.yml. If absent, tier 2
+# Read default_human_reviewer from $BSG_AUTOPILOT_FILE. If absent, tier 2
 # escalation falls back to the issue creator (next best human).
 HUMAN_REVIEWER=""
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then

--- a/claude-skills/scripts/file-issue.sh
+++ b/claude-skills/scripts/file-issue.sh
@@ -4,12 +4,12 @@
 # Every BSG agent that files a GitHub issue should use this helper instead
 # of calling `gh issue create` directly. The wrapper:
 #
-#   1. In **non-autopilot** mode (no `.bsg-autopilot.yml` or
+#   1. In **non-autopilot** mode (no `$BSG_AUTOPILOT_FILE` or
 #      `enabled: false`): ensures the `needs-human-review` label exists
 #      on the target repo and adds it to the `--label` list automatically.
 #      Humans own the transition out of "needs review" by merging,
 #      closing, or relabeling the issue.
-#   2. In **autopilot** mode (`.bsg-autopilot.yml` with `enabled: true`):
+#   2. In **autopilot** mode (`$BSG_AUTOPILOT_FILE` with `enabled: true`):
 #      `needs-human-review` is no longer auto-applied — the repo-level
 #      opt-in is the gate, and `filed-by:<agent>` (via --filed-by) is the
 #      traceability marker. See E10 (#286).
@@ -50,7 +50,7 @@
 #   - Applies `needs:<reason>` so the reason for human attention is
 #     visible in label filters
 #   - Applies `needs-human-review` even in autopilot mode
-#   - Reads `default_human_reviewer` from `.bsg-autopilot.yml` and
+#   - Reads `default_human_reviewer` from `$BSG_AUTOPILOT_FILE` and
 #     assigns the issue to that user (or to the value of `--assign-to`
 #     if explicitly passed)
 #   - Prepends `@<human>` to the body so the assignee gets an
@@ -161,7 +161,7 @@ if [[ -n "$HUMAN_REASON" ]]; then
 fi
 
 # Resolve the human assignee for --reason flows. Explicit --assign-to
-# wins; otherwise read default_human_reviewer from .bsg-autopilot.yml.
+# wins; otherwise read default_human_reviewer from $BSG_AUTOPILOT_FILE.
 if [[ -n "$HUMAN_REASON" && -z "$ASSIGN_TO" && -f "$BSG_AUTOPILOT_FILE" ]]; then
   ASSIGN_TO=$(grep -E '^\s*default_human_reviewer\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \
     | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'")

--- a/claude-skills/scripts/list-pilot-candidates.sh
+++ b/claude-skills/scripts/list-pilot-candidates.sh
@@ -16,7 +16,7 @@
 # routing primitive from docs/label-taxonomy.md.
 #
 # Auto-implementation is opt-in at the **repo level** via
-# .bsg-autopilot.yml. Without the file, with `enabled: false`, or when
+# $BSG_AUTOPILOT_FILE. Without the file, with `enabled: false`, or when
 # the calling agent is not listed under `agents:`, no candidates are
 # emitted (the agent's tick becomes audit-only). The previous per-issue
 # gates `safe-to-automate` and `needs-human-review` were dropped in
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Auto-implementation requires a repo-level opt-in via .bsg-autopilot.yml.
+# Auto-implementation requires a repo-level opt-in via $BSG_AUTOPILOT_FILE.
 # Without the file, with `enabled: false`, or when this agent is not
 # listed under `agents:`, we emit no candidates — the agent's tick
 # becomes audit-only. See #286.

--- a/claude-skills/scripts/normalize-issue-labels.sh
+++ b/claude-skills/scripts/normalize-issue-labels.sh
@@ -41,7 +41,7 @@
 #          "open graph", "structured data"
 #   tech:  default — anything that isn't qa or seo
 #
-# Cap at `max_issues_per_tick` from .bsg-autopilot.yml (default 10) per
+# Cap at `max_issues_per_tick` from $BSG_AUTOPILOT_FILE (default 10) per
 # run so a single tick can't flood the repo if a backlog of unrouted
 # issues just landed.
 #
@@ -72,7 +72,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Cap per tick — read from .bsg-autopilot.yml.
+# Cap per tick — read from $BSG_AUTOPILOT_FILE.
 MAX_ISSUES=10
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then
   configured=$(grep -E '^\s*max_issues_per_tick\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \

--- a/claude-skills/scripts/peer-review-candidates.sh
+++ b/claude-skills/scripts/peer-review-candidates.sh
@@ -6,7 +6,7 @@
 #   - Were NOT opened by the reviewing agent itself
 #   - Carry `needs-human-review` label
 #   - Do NOT already carry `peer-reviewed:<reviewer>` label
-#   - Match the review matrix in .bsg-autopilot.yml
+#   - Match the review matrix in $BSG_AUTOPILOT_FILE
 #
 # Usage:
 #   bash claude-skills/scripts/peer-review-candidates.sh --reviewer tech [--repo OWNER/NAME]
@@ -38,7 +38,7 @@ if [[ -z "$REVIEWER" ]]; then
   exit 2
 fi
 
-# Read the review matrix from .bsg-autopilot.yml.
+# Read the review matrix from $BSG_AUTOPILOT_FILE.
 # The reviewer must be listed, and we extract which agents it reviews.
 if [[ ! -f "$BSG_AUTOPILOT_FILE" ]]; then
   exit 0

--- a/claude-skills/scripts/pilot-circuit-breaker.sh
+++ b/claude-skills/scripts/pilot-circuit-breaker.sh
@@ -3,7 +3,7 @@
 #
 # Counts PRs opened today by the pilot agents (title matches
 # `fix(pilot):`) and compares against the max_prs_per_day budget
-# from .bsg-autopilot.yml (default: 3). Exits 0 if under budget,
+# from $BSG_AUTOPILOT_FILE (default: 3). Exits 0 if under budget,
 # exits 1 if at or over budget.
 #
 # max_prs_per_day can be a scalar (global cap) or a map with per-bus

--- a/claude-skills/scripts/po-decompose-oversized.sh
+++ b/claude-skills/scripts/po-decompose-oversized.sh
@@ -3,14 +3,14 @@
 # the autopilot budget so the PO can decompose them into sub-issues.
 #
 # Closes #363 fix #4. The output:commit pilot enforces a per-issue LOC
-# cap (`max_loc_per_issue` from .bsg-autopilot.yml). Issues above the
+# cap (`max_loc_per_issue` from $BSG_AUTOPILOT_FILE). Issues above the
 # cap never get picked up — they sit in the backlog forever. This
 # script identifies them so the PO can split each one into sub-tickets
 # that fit the budget.
 #
 # What it does:
 #
-#   1. Read `max_loc_per_issue` from .bsg-autopilot.yml (default 200)
+#   1. Read `max_loc_per_issue` from $BSG_AUTOPILOT_FILE (default 200)
 #   2. Enumerate open issues that have a bus label (tech/qa/seo) AND
 #      are bound to a milestone — i.e. they would normally be phase-B
 #      candidates if they fit the budget.
@@ -51,7 +51,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Read max_loc_per_issue from .bsg-autopilot.yml — fall back to 200.
+# Read max_loc_per_issue from $BSG_AUTOPILOT_FILE — fall back to 200.
 MAX_LOC=200
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then
   configured=$(grep -E '^\s*max_loc_per_issue\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \

--- a/claude-skills/scripts/validate-plan.sh
+++ b/claude-skills/scripts/validate-plan.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# validate-plan.sh — validate po/PLAN.md and exit non-zero with a diagnostic
+# validate-plan.sh — validate PLAN.md and exit non-zero with a diagnostic
 # when the plan is missing or contains no binding tags (E6-plan-schema-hygiene).
 #
 # Usage:
@@ -11,11 +11,15 @@
 #   2   — PLAN.md exists but contains no binding tags (format drift)
 #   3   — parse-plan.sh not found (installer misconfiguration)
 #
-# By default reads $PWD/po/PLAN.md. Override with --plan <path>.
+# By default resolves PLAN.md via _bsg-paths.sh (`.bsg/PLAN.md` preferred,
+# legacy `po/PLAN.md` as fallback per ADR-001). Override with --plan <path>.
 #
 # Uses parse-plan.sh --typed internally so the same grammar is enforced
 # in both the agent tick and this standalone validator.
 set -euo pipefail
+
+# shellcheck source=_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/_bsg-paths.sh"
 
 PLAN_PATH=""
 while [[ $# -gt 0 ]]; do
@@ -26,7 +30,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$PLAN_PATH" ]]; then
-  PLAN_PATH="$PWD/po/PLAN.md"
+  PLAN_PATH="$PWD/$(bsg_doc_path plan)"
 fi
 
 # Locate parse-plan.sh: prefer the canonical repo path, fall back to cached copy.

--- a/claude-skills/tests/test_bsg_paths.sh
+++ b/claude-skills/tests/test_bsg_paths.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# test_bsg_paths.sh — unit tests for _bsg-paths.sh resolver.
+#
+# Verifies that bsg_doc_path resolves every known doc kind correctly:
+#   - Returns the .bsg/ path when it exists on disk
+#   - Falls back to the legacy path when only legacy exists
+#   - Returns the .bsg/ path when neither exists (so first writes go new)
+#   - Returns rc=2 for unknown kinds
+#
+# Run locally:
+#   bash claude-skills/tests/test_bsg_paths.sh
+#
+# Exit 0 = all pass, exit 1 = failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SUT="$REPO_ROOT/claude-skills/scripts/_bsg-paths.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+# Resolve relative to a tmpdir so we don't pollute the repo's own state.
+run_in_tmp() {
+  local tmp="$(mktemp -d)"
+  ( cd "$tmp" && eval "$1" )
+  local rc=$?
+  rm -rf "$tmp"
+  return $rc
+}
+
+# 1. Empty repo → returns the .bsg/ path (so first writes are new).
+out="$(run_in_tmp 'source "'"$SUT"'"; bsg_doc_path plan')"
+assert_eq "empty repo: plan resolves to .bsg/PLAN.md" ".bsg/PLAN.md" "$out"
+
+out="$(run_in_tmp 'source "'"$SUT"'"; bsg_doc_path autopilot')"
+# Empty repo: returns the .bsg/ path so --init / first-write callers
+# write into the new tree without further wiring.
+assert_eq "empty repo: autopilot resolves to .bsg/AUTOPILOT.yml" ".bsg/AUTOPILOT.yml" "$out"
+
+# 2. Legacy-only repo → fallback path.
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/po"
+touch "$tmp/po/PLAN.md"
+out="$(cd "$tmp" && bash -c "source $SUT; bsg_doc_path plan")"
+assert_eq "legacy-only: plan resolves to po/PLAN.md" "po/PLAN.md" "$out"
+rm -rf "$tmp"
+
+# 3. .bsg/-only repo → new path.
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/.bsg"
+touch "$tmp/.bsg/PLAN.md"
+touch "$tmp/.bsg/AUTOPILOT.yml"
+out="$(cd "$tmp" && bash -c "source $SUT; bsg_doc_path plan")"
+assert_eq ".bsg-only: plan resolves to .bsg/PLAN.md" ".bsg/PLAN.md" "$out"
+
+out="$(cd "$tmp" && bash -c "source $SUT; bsg_doc_path autopilot")"
+assert_eq ".bsg-only: autopilot resolves to .bsg/AUTOPILOT.yml" ".bsg/AUTOPILOT.yml" "$out"
+
+out="$(cd "$tmp" && bash -c "source $SUT; printf '%s' \"\$BSG_AUTOPILOT_FILE\"")"
+assert_eq ".bsg-only: BSG_AUTOPILOT_FILE matches resolver" ".bsg/AUTOPILOT.yml" "$out"
+rm -rf "$tmp"
+
+# 4. Both present → .bsg/ wins.
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/.bsg" "$tmp/po"
+touch "$tmp/.bsg/PLAN.md"
+touch "$tmp/po/PLAN.md"
+out="$(cd "$tmp" && bash -c "source $SUT; bsg_doc_path plan")"
+assert_eq "both present: .bsg/ wins" ".bsg/PLAN.md" "$out"
+rm -rf "$tmp"
+
+# 5. Unknown doc kind → rc=2.
+set +e
+out="$(bash -c "source $SUT; bsg_doc_path bogus" 2>&1)"
+rc=$?
+set -e
+assert_eq "unknown kind: rc=2" "2" "$rc"
+
+# 6. Every doc kind in the table is recognized (regression guard).
+for kind in autopilot plan narrative keywords calendar announced \
+            securityignore design adr brand reports; do
+  set +e
+  out="$(run_in_tmp 'source "'"$SUT"'"; bsg_doc_path '"$kind"' >/dev/null')"
+  rc=$?
+  set -e
+  assert_eq "kind '$kind' is recognized (rc=0)" "0" "$rc"
+done
+
+echo ""
+echo "PASS: $PASS, FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Refs #237 — first of three stacked PRs to close the bootstrap-ergonomics ticket.

## Summary

Lays the groundwork for the rest of #237 by promoting `_bsg-paths.sh` from an autopilot-only helper into the canonical resolver for every BSG custom doc, switching the one remaining hardcoded reader (`validate-plan.sh`) onto it, and documenting the `.bsg/` convention in the project's authoritative places (CLAUDE.md + a dedicated migration guide).

## What's in this PR

- **General-purpose resolver** — `_bsg-paths.sh` exposes `bsg_doc_path <kind>` for every per-repo doc. Adding a new doc is a one-line case-arm. Empty-repo default is `.bsg/<NAME>` so per-agent `--init` (PR2) lands writes in the new tree.
- **`validate-plan.sh` cutover** — was hardcoding `po/PLAN.md`; now resolves through `bsg_doc_path plan`, preferring `.bsg/PLAN.md`.
- **Comment hygiene** in 8 autopilot scripts that already routed through `$BSG_AUTOPILOT_FILE` — no behavior change, just stop misleading future readers.
- **`CLAUDE.md`** gets a `.bsg/` directory section explaining the tree, the three rules for adding to it, and the resolver requirement for new code.
- **`claude-skills/MIGRATION-bsg-paths.md`** documents the legacy→new path table and the per-consumer-repo migration sequence.
- **`tests/test_bsg_paths.sh`** locks in resolver semantics with 19 assertions.

## Test results

| Suite | Result |
|---|---|
| `test_bsg_paths.sh` (new) | 19 / 0 |
| `test_agent_frontmatter.py` | 12 / 12 |
| All other shell tests | green |
| `test_github_bus.sh` Test 3 | pre-existing fail on `main` (unrelated) |
| `test_updater_*` py errors | pre-existing on `main` (unrelated) |

## Out of scope (follow-ups)

- **PR2** — `@po-manager init` writes `.bsg/PLAN.md` from milestones + labels + README, opens it as a PR.
- **PR3** — `/bsg-stack init` + `update` + `references/` so the umbrella skill matches its own SKILL.md verb table.
- File movement in this repo or in cached consumer repos. Resolver fallback is intentional during the migration window.

## Closes / refs

- Refs #237 (deliverable #1, ADR-001 cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)