### PR TITLE
fix(browser): replace stale Chrome MCP with native Chrome integration

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -81,8 +81,6 @@ Currently-managed keys:
 |---|---|
 | `autoMemoryEnabled` | Set to `false` — disables the Claude Code auto-memory system globally so durable context lives in project `CLAUDE.md` files and committed agent outputs (`po/`, reports, etc.) instead of per-project memory stores. |
 | `mcpServers.context7` | Pre-registers the [Context7](https://context7.com) MCP server so documentation lookups (React, Next.js, library APIs, …) are available in every session with no per-session setup. Honors `CONTEXT7_API_KEY` if set; works on the public-rate tier otherwise. |
-| `mcpServers.claude-in-chrome` | Pre-registers the [Chrome MCP](https://www.npmjs.com/package/@anthropic-ai/claude-code-chrome-mcp) server as a fallback when `agent-browser` gets blocked by anti-bot detection, CAPTCHAs, or device-trust checks (LinkedIn, Pappers, Gmail passkey flows, etc.). Connects to the user's real Chrome instance with existing sessions and extensions. |
-
 The merge is **idempotent** and **narrow**:
 
 - Only the keys listed in `BSG_MANAGED_SETTINGS_KEYS` and

--- a/claude-skills/scripts/update-bsg-skills.py
+++ b/claude-skills/scripts/update-bsg-skills.py
@@ -62,7 +62,11 @@ SCRIPT_NAME = "update-bsg-skills.py"
 BSG_MANAGED_SETTINGS_KEYS = ["autoMemoryEnabled"]
 # Sub-keys under `mcpServers` that the updater owns. Other MCP servers the
 # user has configured are preserved.
-BSG_MANAGED_MCP_SERVERS = ["context7", "claude-in-chrome"]
+BSG_MANAGED_MCP_SERVERS = ["context7"]
+# MCP servers previously managed by BSG that should be removed from user
+# settings on the next update run (e.g. stale entries for packages that no
+# longer exist).
+BSG_RETIRED_MCP_SERVERS = ["claude-in-chrome"]
 
 CLAUDE_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
 COMMANDS_DIR = CLAUDE_DIR / "commands"
@@ -466,6 +470,11 @@ def merge_bsg_settings() -> None:
                 if name in t_servers and servers.get(name) != t_servers[name]:
                     servers[name] = t_servers[name]
                     changed = True
+            for name in BSG_RETIRED_MCP_SERVERS:
+                if name in servers:
+                    del servers[name]
+                    changed = True
+                    log(f"  removed retired MCP server '{name}'")
 
     if not changed:
         return

--- a/claude-skills/settings.json
+++ b/claude-skills/settings.json
@@ -8,10 +8,6 @@
       "env": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
-    },
-    "claude-in-chrome": {
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/claude-code-chrome-mcp"]
     }
   }
 }

--- a/claude-skills/skills/browser/SKILL.md
+++ b/claude-skills/skills/browser/SKILL.md
@@ -32,7 +32,8 @@ at the onboarding orchestrator:
 bash scripts/onboard.sh
 ```
 
-It walks through **4 services** in headed mode, one at a time:
+It walks through **5 steps** — 4 service logins in headed mode plus a Chrome
+integration check:
 
 | Step | Profile | Service |
 |------|---------|---------|
@@ -40,16 +41,19 @@ It walks through **4 services** in headed mode, one at a time:
 | 2 | `github` | GitHub |
 | 3 | `hubspot` | HubSpot (CRM, Marketing, Sales) |
 | 4 | `yousign` | Yousign (e-signatures) |
+| 5 | — | Chrome integration (extension + native messaging check) |
 
 For each service a browser window opens, the user logs in (including 2FA /
 passkey), and the session is saved as a named profile. After onboarding,
 every `agent-browser --profile <name>` call reuses the saved session
-headlessly -- no more manual logins.
+headlessly — no more manual logins. The Chrome step verifies that the
+Claude in Chrome extension and native messaging host are properly configured.
 
 Re-run a single step:
 ```bash
 bash scripts/onboard.sh --step google
 bash scripts/onboard.sh --step yousign
+bash scripts/onboard.sh --step chrome
 ```
 
 Check all profiles:
@@ -62,17 +66,47 @@ List available services:
 bash scripts/onboard.sh --list
 ```
 
-## Chrome MCP fallback
+## Chrome integration (Claude in Chrome) — fallback for anti-bot sites
 
 **Default tool is always `agent-browser`.** Try it first for every task.
 
 Some sites actively block headless browsers and Playwright-based automation
 (anti-bot walls, aggressive CAPTCHAs, device fingerprinting). When
 `agent-browser` gets stuck — page won't load, CAPTCHA loop, login rejected —
-**fall back to Chrome MCP** (`claude-in-chrome`), which connects to the user's
-real Chrome instance with all existing sessions, cookies, and extensions.
+**fall back to Claude's built-in Chrome integration**, which connects to the
+user's real Chrome browser with all existing sessions, cookies, and extensions.
 
-Known sites that frequently require Chrome MCP fallback:
+Chrome integration is a **native Claude Code feature** (not an MCP server).
+It works through the
+[Claude in Chrome](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn)
+browser extension + native messaging. No npm package involved.
+
+### Prerequisites
+
+- Google Chrome or Microsoft Edge
+- [Claude in Chrome extension](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) v1.0.36+
+- Claude Code v2.0.73+
+
+### Enabling Chrome integration
+
+```bash
+# Launch Claude Code with Chrome connected:
+claude --chrome
+
+# Or enable from within a running session:
+/chrome
+```
+
+To enable by default (avoids `--chrome` every session), run `/chrome` and
+select "Enabled by default".
+
+The onboarding script can verify the setup:
+```bash
+bash scripts/onboard.sh --step chrome
+bash scripts/onboard.sh --check         # includes Chrome status
+```
+
+### Known sites that frequently require Chrome fallback
 
 | Site | Typical blocker |
 |---|---|
@@ -82,18 +116,19 @@ Known sites that frequently require Chrome MCP fallback:
 | HubSpot | SSO redirect loops |
 | Yousign | Session validation |
 
-Decision flow:
+### Decision flow
 
 ```
 1. Try agent-browser (with --profile if authenticated)
 2. Blocked? (CAPTCHA, anti-bot, login rejected, blank page)
-   → Switch to Chrome MCP — the user's real Chrome is already logged in
-3. Chrome MCP unavailable? (no Chrome open, extension not running)
-   → Ask the user to open Chrome and enable the MCP extension
+   → Switch to Chrome integration — claude --chrome or /chrome
+   → The user's real Chrome is already logged in
+3. Chrome not connected?
+   → Ask the user to open Chrome, install the extension, and run /chrome
 ```
 
-Chrome MCP is **not** a replacement for `agent-browser` — it cannot run
-headlessly, cannot save/replay profiles, and depends on the user's live
+Chrome integration is **not** a replacement for `agent-browser` — it cannot
+run headlessly, cannot save/replay profiles, and depends on the user's live
 Chrome session. Use it only when `agent-browser` hits a wall.
 
 ## Hard rules
@@ -189,12 +224,14 @@ bash scripts/with-profile.sh github open https://github.com/settings
 
 ```
 First time using agent-browser?  -> npm install -g agent-browser && agent-browser install
-First time at BSG / new machine? -> bash scripts/onboard.sh         (all services)
+First time at BSG / new machine? -> bash scripts/onboard.sh         (all services + Chrome check)
 Need to log in to Google?        -> bash scripts/onboard.sh --step google
 Need to log in to another site?  -> bash scripts/with-profile.sh <name> open <url> --headed
+Set up Chrome integration?       -> bash scripts/onboard.sh --step chrome
 Check all logins still valid?    -> bash scripts/onboard.sh --check
 Replay an authenticated session? -> bash scripts/with-profile.sh <name> open <url>
 One-off page interaction?        -> agent-browser open <url> [--headed]
+Anti-bot / CAPTCHA blocked?      -> claude --chrome  (or /chrome in-session)
 Screenshot a page?               -> agent-browser screenshot [path] [--full]
 Extract page text?               -> agent-browser snapshot | jq
 ```
@@ -291,7 +328,8 @@ if the app keeps open connections.
 | "Log in to GitHub" | `bash scripts/onboard.sh --step github` |
 | "Log in to HubSpot" | `bash scripts/onboard.sh --step hubspot` |
 | "Log in to Yousign" | `bash scripts/onboard.sh --step yousign` |
-| "Blocked by CAPTCHA / anti-bot on LinkedIn, Pappers…" | Fall back to **Chrome MCP** (user's real Chrome) |
+| "Set up Chrome", "check Chrome extension" | `bash scripts/onboard.sh --step chrome` |
+| "Blocked by CAPTCHA / anti-bot on LinkedIn, Pappers…" | Fall back to **Chrome integration** (`claude --chrome` or `/chrome`) |
 | "Check my logins", "are sessions still valid?" | `bash scripts/onboard.sh --check` |
 | "Log in to X" (non-BSG site) | `bash scripts/with-profile.sh <name> open <url> --headed` |
 | "Open this URL", "go to site" | `agent-browser open <url> [--headed]` |

--- a/claude-skills/skills/browser/scripts/onboard.sh
+++ b/claude-skills/skills/browser/scripts/onboard.sh
@@ -8,11 +8,11 @@ set -euo pipefail
 # the session headlessly.
 #
 # Usage:
-#   bash onboard.sh                  # full onboarding (all services)
+#   bash onboard.sh                  # full onboarding (all services + Chrome check)
 #   bash onboard.sh --step google    # single service
-#   bash onboard.sh --step github    # single service
+#   bash onboard.sh --step chrome    # verify Chrome extension + native messaging
 #   bash onboard.sh --list           # show services and profile status
-#   bash onboard.sh --check          # verify all profiles are logged in
+#   bash onboard.sh --check          # verify all profiles are logged in + Chrome
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -27,6 +27,9 @@ SERVICES=(
 
 TIMEOUT=120000  # 2 minutes per login
 
+# Chrome extension ID (Claude in Chrome)
+CHROME_EXTENSION_ID="fcoeoabgfenejglbffodgkkbkcdhcgfn"
+
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 parse_field() { echo "$1" | cut -d'|' -f"$2"; }
@@ -37,6 +40,120 @@ check_agent_browser() {
     echo "  npm install -g agent-browser && agent-browser install" >&2
     exit 1
   }
+}
+
+check_chrome_integration() {
+  local all_ok=true
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Step: Chrome integration (Claude in Chrome)"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # 1. Check Claude Code version
+  printf "  Claude Code version: "
+  if command -v claude >/dev/null 2>&1; then
+    local cc_version
+    cc_version=$(claude --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    echo "$cc_version"
+  else
+    echo "NOT FOUND"
+    echo "    Install: https://claude.com/claude-code"
+    all_ok=false
+  fi
+
+  # 2. Check Chrome extension
+  printf "  Chrome extension:    "
+  local ext_found=false
+  local ext_dir=""
+
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS: check both Chrome and Edge
+    for browser_dir in \
+      "$HOME/Library/Application Support/Google/Chrome" \
+      "$HOME/Library/Application Support/Microsoft Edge"; do
+      if [ -d "$browser_dir" ]; then
+        # Search across all profiles (Default, Profile 1, etc.)
+        local match
+        match=$(find "$browser_dir" -path "*/Extensions/$CHROME_EXTENSION_ID" -maxdepth 4 2>/dev/null | head -1)
+        if [ -n "$match" ]; then
+          ext_found=true
+          local ext_version
+          ext_version=$(ls -1 "$(dirname "$match")/$CHROME_EXTENSION_ID/" 2>/dev/null | sort -V | tail -1 | sed 's/_0$//')
+          echo "OK (v${ext_version:-unknown})"
+          break
+        fi
+      fi
+    done
+  elif [[ "$(uname)" == "Linux" ]]; then
+    for browser_dir in \
+      "$HOME/.config/google-chrome" \
+      "$HOME/.config/microsoft-edge"; do
+      if [ -d "$browser_dir" ]; then
+        local match
+        match=$(find "$browser_dir" -path "*/Extensions/$CHROME_EXTENSION_ID" -maxdepth 4 2>/dev/null | head -1)
+        if [ -n "$match" ]; then
+          ext_found=true
+          local ext_version
+          ext_version=$(ls -1 "$(dirname "$match")/$CHROME_EXTENSION_ID/" 2>/dev/null | sort -V | tail -1 | sed 's/_0$//')
+          echo "OK (v${ext_version:-unknown})"
+          break
+        fi
+      fi
+    done
+  fi
+
+  if [ "$ext_found" = false ]; then
+    echo "NOT FOUND"
+    echo "    Install from Chrome Web Store:"
+    echo "    https://chromewebstore.google.com/detail/claude/$CHROME_EXTENSION_ID"
+    all_ok=false
+  fi
+
+  # 3. Check native messaging host
+  printf "  Native messaging:    "
+  local nmh_found=false
+
+  if [[ "$(uname)" == "Darwin" ]]; then
+    for nmh_path in \
+      "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.anthropic.claude_code_browser_extension.json" \
+      "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts/com.anthropic.claude_code_browser_extension.json"; do
+      if [ -f "$nmh_path" ]; then
+        nmh_found=true
+        echo "OK"
+        break
+      fi
+    done
+  elif [[ "$(uname)" == "Linux" ]]; then
+    for nmh_path in \
+      "$HOME/.config/google-chrome/NativeMessagingHosts/com.anthropic.claude_code_browser_extension.json" \
+      "$HOME/.config/microsoft-edge/NativeMessagingHosts/com.anthropic.claude_code_browser_extension.json"; do
+      if [ -f "$nmh_path" ]; then
+        nmh_found=true
+        echo "OK"
+        break
+      fi
+    done
+  fi
+
+  if [ "$nmh_found" = false ]; then
+    echo "NOT FOUND"
+    echo "    Run 'claude --chrome' once to generate the native messaging host config,"
+    echo "    then restart Chrome."
+    all_ok=false
+  fi
+
+  echo ""
+  if [ "$all_ok" = true ]; then
+    echo "  Chrome integration is ready. Use 'claude --chrome' or '/chrome' in-session."
+  else
+    echo "  Chrome integration needs setup. Follow the steps above, then re-run:"
+    echo "    bash onboard.sh --step chrome"
+  fi
+  echo ""
+
+  [ "$all_ok" = true ]
 }
 
 list_services() {
@@ -51,6 +168,7 @@ list_services() {
     desc=$(parse_field "$entry" 5)
     printf "  %-12s %-12s %s\n" "$name" "$profile" "$desc"
   done
+  printf "  %-12s %-12s %s\n" "chrome" "—" "Chrome integration (extension + native messaging)"
 }
 
 check_profiles() {
@@ -85,11 +203,18 @@ check_profiles() {
     fi
   done
 
+  # Also check Chrome integration
   echo ""
+  echo "Checking Chrome integration..."
+  echo ""
+  if ! check_chrome_integration 2>/dev/null; then
+    all_ok=false
+  fi
+
   if [ "$all_ok" = true ]; then
-    echo "All profiles are logged in."
+    echo "All profiles are logged in and Chrome integration is ready."
   else
-    echo "Some profiles need login. Run: bash onboard.sh"
+    echo "Some items need attention. Run: bash onboard.sh"
   fi
 }
 
@@ -158,6 +283,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -n "$SINGLE_STEP" ]; then
+  if [ "$SINGLE_STEP" = "chrome" ]; then
+    check_chrome_integration
+    exit $?
+  fi
   # Run a single service
   found=false
   for entry in "${SERVICES[@]}"; do
@@ -179,6 +308,7 @@ if [ -n "$SINGLE_STEP" ]; then
     for entry in "${SERVICES[@]}"; do
       echo "  $(parse_field "$entry" 1)" >&2
     done
+    echo "  chrome" >&2
     exit 1
   fi
 else
@@ -193,10 +323,12 @@ else
   echo "║  automatic headless reuse.                                 ║"
   echo "╚══════════════════════════════════════════════════════════════╝"
   echo ""
-  echo "Services to onboard: ${#SERVICES[@]}"
+  total=$(( ${#SERVICES[@]} + 1 ))  # services + Chrome check
+  echo "Steps to complete: $total"
   for entry in "${SERVICES[@]}"; do
     echo "  - $(parse_field "$entry" 5)"
   done
+  echo "  - Chrome integration (extension + native messaging)"
   echo ""
 
   completed=0
@@ -208,11 +340,14 @@ else
       "$(parse_field "$entry" 4)" \
       "$(parse_field "$entry" 5)"
     completed=$((completed + 1))
-    remaining=$(( ${#SERVICES[@]} - completed ))
+    remaining=$(( total - completed ))
     if [ "$remaining" -gt 0 ]; then
-      echo "  ($remaining service(s) remaining)"
+      echo "  ($remaining step(s) remaining)"
     fi
   done
+
+  # Final step: Chrome integration check
+  check_chrome_integration || true
 
   echo ""
   echo "╔══════════════════════════════════════════════════════════════╗"
@@ -220,6 +355,8 @@ else
   echo "╠══════════════════════════════════════════════════════════════╣"
   echo "║  All profiles saved. Future agent-browser calls using      ║"
   echo "║  --profile <name> will reuse these sessions headlessly.    ║"
+  echo "║  Chrome integration checked — use claude --chrome or       ║"
+  echo "║  /chrome in-session for anti-bot fallback.                 ║"
   echo "╚══════════════════════════════════════════════════════════════╝"
   echo ""
   echo "Profiles created:"
@@ -229,4 +366,5 @@ else
   echo ""
   echo "Verify with:  bash onboard.sh --check"
   echo "Re-run one:   bash onboard.sh --step <service>"
+  echo "              bash onboard.sh --step chrome"
 fi


### PR DESCRIPTION
## Summary

- **Removes the broken `claude-in-chrome` MCP server** from `settings.json` — the npm package `@anthropic-ai/claude-code-chrome-mcp` never existed on the registry (404). Chrome integration is a native Claude Code feature (`claude --chrome` / `/chrome`), not an MCP server.
- **Adds `BSG_RETIRED_MCP_SERVERS` cleanup** in `update-bsg-skills.py` so the stale entry is auto-removed from every developer's `~/.claude/settings.json` on next SessionStart update.
- **Adds `--step chrome` to `onboard.sh`** — verifies Claude Code version, Chrome extension presence, and native messaging host config (macOS + Linux). Included in `--check` and full onboarding flow.
- **Rewrites the Chrome section in `SKILL.md`** with correct prerequisites, enablement instructions, and decision flow.

## Test plan

- [x] `bash onboard.sh --step chrome` — reports OK for extension + native messaging
- [x] `bash onboard.sh --list` — shows Chrome as a step
- [x] `python3 -m pytest claude-skills/tests/test_skills.py` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)