### PR TITLE
feat(237): wire consumer scripts to _bsg-paths.sh resolver (Phase 1)

### DIFF
--- a/claude-skills/skills/marketing-report/scripts/collect.sh
+++ b/claude-skills/skills/marketing-report/scripts/collect.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
 # collect.sh — marketing snapshot.
 #
-# Parses marketing/CALENDAR.md, lists recent releases and milestones
-# via gh, globs marketing / README / docs files and extracts their
-# H1/H2 headings as "claims" for alignment analysis.
+# Parses CALENDAR.md (resolved via _bsg-paths.sh — `.bsg/CALENDAR.md`
+# preferred, legacy `marketing/CALENDAR.md` fallback per ADR-001),
+# lists recent releases and milestones via gh, globs marketing /
+# README / docs files and extracts their H1/H2 headings as "claims"
+# for alignment analysis.
 
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
 
+# shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+
 TODAY=$(date +%F)
 TODAY_EPOCH=$(date -j -f "%Y-%m-%d" "$TODAY" +%s 2>/dev/null || date -d "$TODAY" +%s 2>/dev/null || echo 0)
 
 # -------------------------------------------- calendar
 
-CALENDAR_PATH="marketing/CALENDAR.md"
+CALENDAR_PATH="$(bsg_doc_path calendar)"
 CALENDAR_FOUND="false"
 CALENDAR_ITEMS_JSON='[]'
 if [[ -f "$CALENDAR_PATH" ]]; then

--- a/claude-skills/skills/md-to-office/scripts/scan-brand.py
+++ b/claude-skills/skills/md-to-office/scripts/scan-brand.py
@@ -88,12 +88,17 @@ def _rel(path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 def _scan_name() -> str:
-    narrative = ROOT / "brand" / "NARRATIVE.md"
+    # NARRATIVE.md path follows ADR-001: prefer `.bsg/NARRATIVE.md`,
+    # fall back to legacy `brand/NARRATIVE.md`.
+    narrative = ROOT / ".bsg" / "NARRATIVE.md"
+    legacy_narrative = ROOT / "brand" / "NARRATIVE.md"
+    if not narrative.exists() and legacy_narrative.exists():
+        narrative = legacy_narrative
     if narrative.exists():
         m = re.search(r"^#\s+(.+)$", narrative.read_text(errors="replace"), re.MULTILINE)
         if m:
             val = m.group(1).strip()
-            _audit("name", "brand/NARRATIVE.md H1", val)
+            _audit("name", f"{narrative.relative_to(ROOT)} H1", val)
             return val
 
     pkg = ROOT / "package.json"
@@ -361,7 +366,10 @@ def _scan_logos() -> list[str]:
 # ---------------------------------------------------------------------------
 
 def _scan_identity_docs() -> list[str]:
+    # `.bsg/` paths preferred over legacy per ADR-001.
     candidates = [
+        ".bsg/NARRATIVE.md",
+        ".bsg/DESIGN.md",
         "brand/NARRATIVE.md",
         "brand/identity.md",
         "DESIGN.md",

--- a/claude-skills/skills/po/scripts/parse-plan.sh
+++ b/claude-skills/skills/po/scripts/parse-plan.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# parse-plan.sh — parse po/PLAN.md into JSON plan items with bindings.
+# parse-plan.sh — parse PLAN.md into JSON plan items with bindings.
 #
-# Reads PLAN.md (default: $PWD/po/PLAN.md, override with `--plan <path>`)
-# and emits a JSON array. Each object describes one bullet that carries
-# at least one binding tag. See `references/plan-schema.md` for the
-# grammar.
+# Reads PLAN.md (default: resolved via `_bsg-paths.sh` → `.bsg/PLAN.md`
+# with `po/PLAN.md` legacy fallback per ADR-001; override with
+# `--plan <path>`) and emits a JSON array. Each object describes one
+# bullet that carries at least one binding tag. See
+# `references/plan-schema.md` for the grammar.
 #
 # Default output (backward-compatible):
 #
@@ -36,7 +37,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$PLAN_PATH" ]]; then
-  PLAN_PATH="$PWD/po/PLAN.md"
+  # Source the shared resolver so the default tracks ADR-001 (`.bsg/`
+  # preferred, legacy fallback) without every caller having to know.
+  # shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+  source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+  PLAN_PATH="$PWD/$(bsg_doc_path plan)"
 fi
 
 if [[ ! -f "$PLAN_PATH" ]]; then

--- a/claude-skills/skills/pr-comms-report/scripts/collect.sh
+++ b/claude-skills/skills/pr-comms-report/scripts/collect.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
 
+# shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+
 TODAY=$(date +%F)
 TODAY_EPOCH=$(date -j -f "%Y-%m-%d" "$TODAY" +%s 2>/dev/null || date -d "$TODAY" +%s 2>/dev/null || echo 0)
 
@@ -65,9 +68,10 @@ fi
 
 # --------------------------------------------- ANNOUNCED.md
 
+ANNOUNCED_PATH="$(bsg_doc_path announced)"
 ANNOUNCED_JSON='[]'
-if [[ -f comms/ANNOUNCED.md ]]; then
-  ANNOUNCED_JSON=$({ grep -oE '(v?[0-9]+\.[0-9]+\.[0-9]+|milestone #[0-9]+)' comms/ANNOUNCED.md || true; } \
+if [[ -f "$ANNOUNCED_PATH" ]]; then
+  ANNOUNCED_JSON=$({ grep -oE '(v?[0-9]+\.[0-9]+\.[0-9]+|milestone #[0-9]+)' "$ANNOUNCED_PATH" || true; } \
     | sort -u | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
 fi
 

--- a/claude-skills/skills/security-report/scripts/collect.sh
+++ b/claude-skills/skills/security-report/scripts/collect.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
 
+# shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+
 # ---------------------------------------------------------------- helpers
 
 emit_jsonl_file() {
@@ -72,10 +75,13 @@ TRACKED_ENV_FILES_JSON=$(git ls-files 2>/dev/null \
   | awk -F/ '{base=$NF} base ~ /^\.env(\..+)?$/ {print}' \
   | jq -Rn '[inputs]' || echo '[]')
 
-# .securityignore content (raw) for downstream reporters.
+# SECURITYIGNORE content (raw) for downstream reporters. Resolves via
+# _bsg-paths.sh — `.bsg/SECURITYIGNORE` preferred, legacy
+# `.securityignore` fallback per ADR-001.
+SECURITYIGNORE_PATH="$(bsg_doc_path securityignore)"
 SECURITYIGNORE_JSON='""'
-if [[ -f .securityignore ]]; then
-  SECURITYIGNORE_JSON=$(jq -Rs . < .securityignore)
+if [[ -f "$SECURITYIGNORE_PATH" ]]; then
+  SECURITYIGNORE_JSON=$(jq -Rs . < "$SECURITYIGNORE_PATH")
 fi
 
 # ---------------------------------------------------------- server kind

--- a/claude-skills/skills/seo-report/scripts/collect.sh
+++ b/claude-skills/skills/seo-report/scripts/collect.sh
@@ -2,12 +2,17 @@
 # collect.sh — SEO snapshot.
 #
 # Enumerates pages, extracts meta tags and internal links, parses
-# sitemap/robots, loads KEYWORDS.md. Outputs a single JSON document.
+# sitemap/robots, loads KEYWORDS.md (resolved via _bsg-paths.sh —
+# `.bsg/KEYWORDS.md` preferred, legacy `seo/KEYWORDS.md` fallback per
+# ADR-001). Outputs a single JSON document.
 
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
+
+# shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
 
 # -------------------------------------------- page file enumeration
 
@@ -129,9 +134,10 @@ fi
 
 # ---------------------------------------------------- keywords
 
+KEYWORDS_PATH="$(bsg_doc_path keywords)"
 KEYWORDS_JSON='null'
-if [[ -f seo/KEYWORDS.md ]]; then
-  KEYWORDS_JSON=$({ grep -oE '^-[[:space:]]+.+' seo/KEYWORDS.md || true; } \
+if [[ -f "$KEYWORDS_PATH" ]]; then
+  KEYWORDS_JSON=$({ grep -oE '^-[[:space:]]+.+' "$KEYWORDS_PATH" || true; } \
     | sed -E 's/^-[[:space:]]+//' \
     | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
 fi

--- a/claude-skills/skills/storytelling-report/scripts/collect.sh
+++ b/claude-skills/skills/storytelling-report/scripts/collect.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 # collect.sh — brand narrative snapshot.
 #
-# Parses brand/NARRATIVE.md, enumerates public-facing assets, computes
-# voice signals (words / sentences / passive / jargon / Flesch).
+# Parses NARRATIVE.md (resolved via _bsg-paths.sh — `.bsg/NARRATIVE.md`
+# preferred, legacy `brand/NARRATIVE.md` fallback per ADR-001),
+# enumerates public-facing assets, computes voice signals
+# (words / sentences / passive / jargon / Flesch).
 
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
 
-NARRATIVE_PATH="brand/NARRATIVE.md"
+# shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+
+NARRATIVE_PATH="$(bsg_doc_path narrative)"
 NARRATIVE_FOUND="false"
 
 # --------------------------------------------- narrative parsing

--- a/claude-skills/tests/test_consumers_use_resolver.sh
+++ b/claude-skills/tests/test_consumers_use_resolver.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test_consumers_use_resolver.sh — guard that every consumer script of a
+# BSG custom doc sources `_bsg-paths.sh` instead of hardcoding legacy paths.
+#
+# Implements ADR-001 enforcement: once a script's read of a custom doc is
+# routed through `bsg_doc_path`, it must stay routed. Catches regressions
+# where someone re-introduces `marketing/CALENDAR.md` etc. without the
+# resolver.
+#
+# Each row in CONSUMERS pairs a script path with the doc kinds it must
+# resolve. A kind is "covered" if the script either:
+#   - calls `bsg_doc_path <kind>`, or
+#   - references the variable form `$(bsg_doc_path ...)` for that kind.
+#
+# Run locally:
+#   bash claude-skills/tests/test_consumers_use_resolver.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+check() {
+  local file="$1" kind="$2"
+  local path="$REPO_ROOT/$file"
+  if [[ ! -f "$path" ]]; then
+    echo "FAIL: $file does not exist"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if grep -q "bsg_doc_path $kind\b" "$path"; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $file does not call \`bsg_doc_path $kind\`"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Consumer → doc kind pairs. Add a row when a new consumer script reads a
+# custom doc; the test will fail until the script routes through the resolver.
+check "claude-skills/skills/po/scripts/parse-plan.sh"               "plan"
+check "claude-skills/skills/marketing-report/scripts/collect.sh"    "calendar"
+check "claude-skills/skills/storytelling-report/scripts/collect.sh" "narrative"
+check "claude-skills/skills/seo-report/scripts/collect.sh"          "keywords"
+check "claude-skills/skills/pr-comms-report/scripts/collect.sh"     "announced"
+check "claude-skills/skills/security-report/scripts/collect.sh"     "securityignore"
+check "claude-skills/scripts/validate-plan.sh"                      "plan"
+
+echo ""
+echo "PASS: $PASS, FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Phase 1 of #237 (per `docs/technical-plan-237.md` from #591). Wires every consumer of a BSG custom doc through the shared `bsg_doc_path` resolver in `_bsg-paths.sh` instead of hardcoding a legacy path. Each consumer now reads `.bsg/<DOC>` first and falls back to its legacy location during the migration window, exactly as ADR-001 prescribes.

**Consumers updated** (7 files, 7 doc kinds):

| Script | Doc kind | New → legacy |
|---|---|---|
| `po/scripts/parse-plan.sh` | `plan` | `.bsg/PLAN.md` → `po/PLAN.md` |
| `marketing-report/scripts/collect.sh` | `calendar` | `.bsg/CALENDAR.md` → `marketing/CALENDAR.md` |
| `storytelling-report/scripts/collect.sh` | `narrative` | `.bsg/NARRATIVE.md` → `brand/NARRATIVE.md` |
| `seo-report/scripts/collect.sh` | `keywords` | `.bsg/KEYWORDS.md` → `seo/KEYWORDS.md` |
| `pr-comms-report/scripts/collect.sh` | `announced` | `.bsg/ANNOUNCED.md` → `comms/ANNOUNCED.md` |
| `security-report/scripts/collect.sh` | `securityignore` | `.bsg/SECURITYIGNORE` → `.securityignore` |
| `md-to-office/scripts/scan-brand.py` | NARRATIVE/DESIGN probe order | `.bsg/` paths preferred |

**New regression guard**: `tests/test_consumers_use_resolver.sh` greps each consumer for `bsg_doc_path <kind>` and fails if the wiring is removed. Adding a new consumer is a one-line addition to the test.

This is a pure resolution-layer change — no behaviour change for repos that only have legacy paths, and the new `.bsg/` paths start working transparently once the file exists. No flag-day cutover.

## Testing

- `bash claude-skills/tests/test_bsg_paths.sh` → `PASS: 19, FAIL: 0`
- `bash claude-skills/tests/test_consumers_use_resolver.sh` → `PASS: 7, FAIL: 0`
- `python3 -m pytest claude-skills/tests/test_skills.py claude-skills/tests/test_validate_plan.py claude-skills/tests/test_skill_invariants.py` → `29 passed`
- Manual end-to-end: in a fresh tmpdir, `parse-plan.sh` correctly resolves `po/PLAN.md` when only legacy exists, and switches to `.bsg/PLAN.md` once that file is created — both runs produce valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
