### PR TITLE
feat(237): per-agent --init scripts for 5 audit-only agents (Phase 2a)

### DIFF
--- a/claude-skills/skills/marketing-report/scripts/init-calendar.sh
+++ b/claude-skills/skills/marketing-report/scripts/init-calendar.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# init-calendar.sh — generate a draft CALENDAR.md from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo's recent
+# releases and open milestones, emits a draft `.bsg/CALENDAR.md` to
+# stdout. The orchestrator (`/bsg-stack init`) captures stdout and
+# opens a PR for human review — this script never writes to disk.
+#
+# Usage:
+#   bash init-calendar.sh           # auto-scan current repo
+#   bash init-calendar.sh --repo OWNER/NAME
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error (missing tool, no gh auth, etc.)
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-calendar.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signals
+
+repo_name="unknown"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view "${REPO_FLAG[@]}" --json name --jq '.name // "unknown"' 2>/dev/null || echo "unknown")
+fi
+
+releases_json='[]'
+if command -v gh >/dev/null 2>&1; then
+  releases_json=$(gh release list "${REPO_FLAG[@]}" --limit 10 \
+    --json tagName,publishedAt,name 2>/dev/null \
+    | jq '[.[] | {tag: .tagName, date: (.publishedAt | split("T")[0]), title: (.name // .tagName)}]' \
+      2>/dev/null || echo '[]')
+fi
+
+milestones_json='[]'
+if command -v gh >/dev/null 2>&1; then
+  milestones_json=$(gh api "${REPO_FLAG[@]/#--repo/-X GET}" "/repos/{owner}/{repo}/milestones?state=open" 2>/dev/null \
+    | jq '[.[] | {title: .title, due: (.due_on | split("T")[0] // null)}]' \
+      2>/dev/null || echo '[]')
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# Editorial calendar — ${repo_name}
+
+_Draft bootstrapped ${today}. Edit and commit to \`.bsg/CALENDAR.md\` —
+the marketing agent reads this file every tick to audit alignment
+between scheduled comms and shipped features._
+
+## Past releases (already shipped)
+
+_Pulled from \`gh release list\`. Past dates are checked by default._
+
+HEAD
+
+if [[ "$(jq 'length' <<<"$releases_json")" -gt 0 ]]; then
+  jq -r '.[] | "- [x] \(.date) — Release: \(.title)"' <<<"$releases_json"
+else
+  echo "- _No releases found in this repo yet._"
+fi
+
+cat <<'MID'
+
+## Upcoming work (milestones)
+
+_Pulled from open milestones with due dates. Edit to mark explicit comms.
+Add additional rows for blog posts, social, partner mentions._
+
+MID
+
+if [[ "$(jq 'length' <<<"$milestones_json")" -gt 0 ]]; then
+  jq -r '.[] | if .due then "- [ ] \(.due) — Milestone: \(.title)" else "- [ ] TBD — Milestone: \(.title)" end' <<<"$milestones_json"
+else
+  echo "- _No open milestones yet — add comms entries by hand._"
+fi
+
+cat <<'TAIL'
+
+## Cadence
+
+_Document your editorial cadence here (e.g. "blog every 2 weeks",
+"product update each milestone"). The marketing agent uses this to
+detect gaps._
+
+- _Cadence not yet defined._
+TAIL

--- a/claude-skills/skills/pr-comms-report/scripts/init-announced.sh
+++ b/claude-skills/skills/pr-comms-report/scripts/init-announced.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# init-announced.sh — generate a draft ANNOUNCED.md from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo's published
+# releases (and CHANGELOG entries if present), emits a draft
+# `.bsg/ANNOUNCED.md` to stdout listing items that have already been
+# communicated externally. The pr-comms agent reads this file to avoid
+# re-drafting press releases for already-announced events.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and opens a PR
+# for human review — this script never writes to disk.
+#
+# Usage:
+#   bash init-announced.sh           # auto-scan current repo
+#   bash init-announced.sh --repo OWNER/NAME
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-announced.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signals
+
+repo_name="unknown"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view "${REPO_FLAG[@]}" --json name --jq '.name // "unknown"' 2>/dev/null || echo "unknown")
+fi
+
+releases_json='[]'
+if command -v gh >/dev/null 2>&1; then
+  releases_json=$(gh release list "${REPO_FLAG[@]}" --limit 100 \
+    --json tagName,publishedAt,name,isDraft,isPrerelease 2>/dev/null \
+    | jq '[.[] | select(.isDraft == false and .isPrerelease == false)
+           | {tag: .tagName, date: (.publishedAt | split("T")[0]), title: (.name // .tagName)}]' \
+      2>/dev/null || echo '[]')
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# Announced events — ${repo_name}
+
+_Draft bootstrapped ${today}. Edit and commit to \`.bsg/ANNOUNCED.md\` —
+the pr-comms agent reads this file to skip already-communicated events
+when scanning for newsworthy items._
+
+## Already announced
+
+_Pulled from \`gh release list\` (drafts and pre-releases excluded).
+Each line is a release tag plus the date it was published. Add manual
+rows for milestones, partner news, or blog posts that already shipped._
+
+HEAD
+
+if [[ "$(jq 'length' <<<"$releases_json")" -gt 0 ]]; then
+  jq -r '.[] | "- \(.tag) — \(.title) (\(.date))"' <<<"$releases_json"
+else
+  echo "- _No published releases yet._"
+fi
+
+# CHANGELOG version headers as additional signal.
+if [[ -f CHANGELOG.md ]]; then
+  cat <<'CHANGELOG_HEADER'
+
+## CHANGELOG version markers
+
+_Detected from CHANGELOG.md. These usually align with releases but are
+listed separately so you can spot gaps where a CHANGELOG entry exists
+without a matching release announcement._
+
+CHANGELOG_HEADER
+  grep -oE '^##+\s*\[?v?[0-9]+\.[0-9]+(\.[0-9]+)?\]?' CHANGELOG.md 2>/dev/null \
+    | sed -E 's/^##+[[:space:]]*//;s/^\[//;s/\]$//' \
+    | head -20 \
+    | awk '{print "- " $0}' \
+    || echo "- _No version markers parsed._"
+fi
+
+cat <<'TAIL'
+
+## How to use
+
+The pr-comms agent treats any release tag or milestone reference appearing
+in this file as "already communicated" — it won't re-draft an announcement
+for it. Append new entries here when you ship something that's been
+publicly announced (blog post, social media, partner press).
+TAIL

--- a/claude-skills/skills/security-report/scripts/init-securityignore.sh
+++ b/claude-skills/skills/security-report/scripts/init-securityignore.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# init-securityignore.sh — generate a draft SECURITYIGNORE from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for paths
+# that typically contain test fixtures, sample credentials, or example
+# data — i.e. the most common sources of secret-scanner false positives.
+# Emits a draft `.bsg/SECURITYIGNORE` to stdout. The security agent
+# reads this file every tick to suppress known false-positive paths.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and opens a PR
+# for human review — this script never writes to disk.
+#
+# Usage:
+#   bash init-securityignore.sh
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-securityignore.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# Track suggestions so we only emit each once, and report whether
+# anything was found.
+declare -a SUGGESTIONS
+seen=""
+add_suggestion() {
+  local path="$1"
+  case " $seen " in
+    *" $path "*) return ;;
+  esac
+  seen="$seen $path"
+  SUGGESTIONS+=("$path")
+}
+
+# 1. Common test / fixture directories at the top level.
+for d in tests test __tests__ spec fixtures __fixtures__ examples example demo demos sample samples; do
+  if [[ -d "$d" ]]; then
+    add_suggestion "$d/"
+  fi
+done
+
+# 2. Nested test/fixture/example directories anywhere in the repo (one
+#    level deep so we don't recurse forever).
+while IFS= read -r d; do
+  d="${d#./}"
+  # Skip top-level entries already added above.
+  case "$d" in
+    tests/|test/|__tests__/|spec/|fixtures/|__fixtures__/|examples/|example/|demo/|demos/|sample/|samples/)
+      continue
+      ;;
+  esac
+  add_suggestion "$d/"
+done < <(find . -maxdepth 4 -type d \
+    -not -path './.git/*' -not -path './node_modules/*' \( \
+    -name 'fixtures' -o -name '__fixtures__' \
+    -o -name 'samples' -o -name 'sample' \
+    -o -name 'examples' -o -name 'example' \
+    -o -name 'testdata' -o -name 'test_data' \
+  \) 2>/dev/null | head -20)
+
+# 3. Common sample env files. Skip .git/ which contains stock
+# *.sample hook scripts — those are part of git, not the repo.
+while IFS= read -r f; do
+  f="${f#./}"
+  add_suggestion "$f"
+done < <(find . -maxdepth 3 -type f \
+    -not -path './.git/*' -not -path './node_modules/*' \( \
+    -name '*.example' -o -name '*.sample' \
+    -o -name '.env.example' -o -name '.env.sample' -o -name '.env.template' \
+  \) 2>/dev/null | head -20)
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# SECURITYIGNORE — draft bootstrapped ${today}
+#
+# Paths listed here are excluded from secret-pattern scans by the
+# security agent. One pattern per line; trailing slash means "treat
+# as a directory and recurse." Blank lines and lines starting with #
+# are comments.
+#
+# This file was bootstrapped automatically from common test / fixture
+# directory names. Review every entry, delete anything you don't
+# recognise, and add patterns specific to your repo (e.g. a vendored
+# third-party SDK that contains demo credentials).
+#
+# After editing, commit this file to .bsg/SECURITYIGNORE.
+
+HEAD
+
+if [[ "${#SUGGESTIONS[@]}" -eq 0 ]]; then
+  cat <<'EMPTY'
+# No common test or fixture directories detected. Add explicit patterns
+# below as the security agent surfaces false positives, e.g.:
+#
+#   tests/fixtures/
+#   docs/examples/sample-config.yml
+EMPTY
+else
+  printf '%s\n' "${SUGGESTIONS[@]}"
+fi

--- a/claude-skills/skills/seo-report/scripts/init-keywords.sh
+++ b/claude-skills/skills/seo-report/scripts/init-keywords.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# init-keywords.sh — generate a draft KEYWORDS.md from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for seed
+# keywords drawn from the repo description, topics, package metadata,
+# and README headings, then emits a draft `.bsg/KEYWORDS.md` to stdout.
+# The orchestrator (`/bsg-stack init`) captures stdout and opens a PR
+# for human review — this script never writes to disk.
+#
+# Usage:
+#   bash init-keywords.sh           # auto-scan current repo
+#   bash init-keywords.sh --repo OWNER/NAME
+#
+# Exit 0 + content on stdout: success
+# Exit 0 + empty stdout: nothing to seed (no signals found)
+# Exit 1: error (missing tool, no gh auth, etc.)
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-keywords.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signal collection
+
+repo_name="unknown"
+description=""
+topics_json='[]'
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  meta=$(gh repo view "${REPO_FLAG[@]}" --json name,description,repositoryTopics 2>/dev/null || echo '{}')
+  repo_name=$(jq -r '.name // "unknown"' <<<"$meta")
+  description=$(jq -r '.description // ""' <<<"$meta")
+  topics_json=$(jq '[.repositoryTopics[]?.name]' <<<"$meta")
+fi
+
+# README headings (H1/H2) as candidate keywords.
+headings_json='[]'
+if [[ -f README.md ]]; then
+  headings_json=$(grep -E '^#{1,2} ' README.md 2>/dev/null \
+    | sed -E 's/^#+[[:space:]]*//' \
+    | head -10 \
+    | jq -Rn '[inputs | select(length > 0)]' || echo '[]')
+fi
+
+# package.json keywords if present.
+package_keywords_json='[]'
+if [[ -f package.json ]]; then
+  package_keywords_json=$(jq '.keywords // []' package.json 2>/dev/null || echo '[]')
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# Keywords — ${repo_name}
+
+_Draft bootstrapped ${today}. Edit and commit to \`.bsg/KEYWORDS.md\` —
+the seo agent reads this file every tick to score keyword coverage._
+
+## Target keywords
+
+_The bullets below are seeded from repo description, topics, package
+metadata, and README headings. Replace, dedupe, and prioritize._
+
+HEAD
+
+# Merge all signal sources, dedupe, lowercase, emit as bullets.
+{
+  [[ -n "$description" ]] && echo "$description"
+  jq -r '.[]?' <<<"$topics_json"
+  jq -r '.[]?' <<<"$headings_json"
+  jq -r '.[]?' <<<"$package_keywords_json"
+} 2>/dev/null \
+  | tr ',' '\n' \
+  | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' \
+  | awk 'NF > 0 && !seen[tolower($0)]++ { print "- " $0 }' \
+  | head -25 \
+  | { read -r first; if [[ -z "$first" ]]; then
+      echo "- _No signals found — author this list manually._"
+    else
+      printf '%s\n' "$first"
+      cat
+    fi
+  }
+
+cat <<'TAIL'
+
+## Coverage notes
+
+_The seo agent will fill this section on each tick with which keywords
+appear in your public pages (README, docs/, marketing/) and which
+need stronger coverage. Leave it empty on first commit._
+TAIL

--- a/claude-skills/skills/storytelling-report/scripts/init-narrative.sh
+++ b/claude-skills/skills/storytelling-report/scripts/init-narrative.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# init-narrative.sh — generate a draft NARRATIVE.md from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for brand
+# narrative signals (repo description, README "About"/mission sections,
+# package metadata, recent README headings) and emits a draft
+# `.bsg/NARRATIVE.md` to stdout. The storytelling agent reads this file
+# every tick to audit voice consistency across public-facing assets.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and opens a PR
+# for human review — this script never writes to disk.
+#
+# Usage:
+#   bash init-narrative.sh
+#   bash init-narrative.sh --repo OWNER/NAME
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-narrative.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signals
+
+repo_name="unknown"
+description=""
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  meta=$(gh repo view "${REPO_FLAG[@]}" --json name,description 2>/dev/null || echo '{}')
+  repo_name=$(jq -r '.name // "unknown"' <<<"$meta")
+  description=$(jq -r '.description // ""' <<<"$meta")
+fi
+
+# Fallback for repo name from package.json / pyproject.
+if [[ "$repo_name" == "unknown" && -f package.json ]]; then
+  candidate=$(jq -r '.name // empty' package.json 2>/dev/null || true)
+  [[ -n "$candidate" ]] && repo_name="$candidate"
+fi
+
+# Strip a leading "owner/" if gh returned the qualified name.
+repo_name="${repo_name##*/}"
+
+# README first paragraph after the H1 — usually the "about" pitch.
+readme_pitch=""
+if [[ -f README.md ]]; then
+  readme_pitch=$(awk '
+    /^#[^#]/ { found_h1=1; next }
+    found_h1 && /^[[:space:]]*$/ {
+      if (started) exit
+      else next
+    }
+    found_h1 {
+      if (substr($0,1,1) == "#") exit
+      started=1
+      print
+    }
+  ' README.md | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g;s/^[[:space:]]+|[[:space:]]+$//g')
+fi
+
+# Fall back to description when the README pitch is empty.
+positioning="${readme_pitch:-$description}"
+[[ -z "$positioning" ]] && positioning="_Replace this with a one-line positioning statement._"
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# Narrative bible — ${repo_name}
+
+_Draft bootstrapped ${today}. Edit and commit to \`.bsg/NARRATIVE.md\` —
+the storytelling agent reads this file every tick to audit voice and
+positioning across README, docs, and marketing copy._
+
+## Positioning
+
+**Category:** _e.g. "developer tools / infrastructure / SaaS — set this."_
+**Target audience:** _e.g. "platform engineers at growth-stage startups — set this."_
+**Feature anchors:** _3-5 features that anchor the product story._
+
+**One-line positioning:**
+
+> ${positioning}
+
+## Voice Guidelines
+
+**Tone target:** 7.0
+
+_Score on a 1–10 scale (1 = corporate-formal, 10 = friendly-conversational).
+The storytelling agent measures Flesch reading ease against this target._
+
+**Banned vocabulary:** synergy, leverage, paradigm, robust, seamless, holistic, actionable, scalable, disruptive, best-in-class, world-class, cutting-edge, next-generation, enterprise-grade
+
+_Comma-separated terms the agent will flag in any public copy.
+Add domain-specific buzzwords your team wants to avoid._
+
+**Preferred vocabulary:**
+
+_Comma-separated alternatives to push for. Leave empty if no
+team-wide convention exists yet._
+
+## Key Messages
+
+_3-5 core messages that should land in any external communication.
+The storytelling agent checks each public asset for coverage._
+
+1. _Replace this with your primary message — usually the "why" of the product._
+2. _Replace this with the second core message — typically the "what makes us different"._
+3. _Replace this with the third core message — often a proof point or signature feature._
+
+## Value Proposition
+
+_Bullets explaining what makes this product distinctive. The agent
+treats each bullet as a differentiator to look for in copy._
+
+- _Set this — what does this product do that nothing else does?_
+- _Set this — what trade-off does this product make explicit?_
+- _Set this — who is the product NOT for? (Sharper positioning.)_
+HEAD

--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test_init_scripts.sh — contract guard for per-agent `--init` scripts (#237).
+#
+# Every init script must:
+#   1. Exist (path matches the expected pattern)
+#   2. Be executable
+#   3. Respond to --help with exit 0
+#   4. Produce non-empty stdout in an empty tmp repo (so the orchestrator
+#      always has *something* to write — first-tick repos shouldn't fail)
+#   5. Not write to the cwd (the contract is stdout-only; the orchestrator
+#      owns the disk side)
+#
+# Add a row to INIT_SCRIPTS when shipping a new per-agent init script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert() {
+  local label="$1" condition="$2"
+  if eval "$condition"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  condition: $condition"
+  fi
+}
+
+check_script() {
+  local rel_path="$1"
+  local path="$REPO_ROOT/$rel_path"
+  local name="$(basename "$rel_path")"
+
+  assert "$name exists"           "[[ -f '$path' ]]"
+  assert "$name is executable"    "[[ -x '$path' ]]"
+  assert "$name --help exits 0"   "$path --help >/dev/null 2>&1"
+
+  # Run in an empty git repo, capture stdout, verify no disk write
+  # happens inside the tmpdir (the contract is stdout-only).
+  local tmp
+  tmp="$(mktemp -d)"
+  (
+    cd "$tmp"
+    git init -q
+    bash "$path" > /tmp/init-script-output.$$ 2>/dev/null || true
+  )
+  local pre_files=$(find "$tmp" -mindepth 1 -not -path '*/.git*' 2>/dev/null | wc -l | tr -d ' ')
+  local out_size=$(stat -f %z /tmp/init-script-output.$$ 2>/dev/null || stat -c %s /tmp/init-script-output.$$ 2>/dev/null || echo 0)
+  rm -rf "$tmp" /tmp/init-script-output.$$
+
+  assert "$name emits non-empty stdout in empty repo" "[[ '$out_size' -gt 50 ]]"
+  assert "$name does not write to cwd"                "[[ '$pre_files' -eq 0 ]]"
+}
+
+# Add new init scripts here as they ship.
+check_script "claude-skills/skills/seo-report/scripts/init-keywords.sh"
+check_script "claude-skills/skills/marketing-report/scripts/init-calendar.sh"
+check_script "claude-skills/skills/pr-comms-report/scripts/init-announced.sh"
+check_script "claude-skills/skills/security-report/scripts/init-securityignore.sh"
+check_script "claude-skills/skills/storytelling-report/scripts/init-narrative.sh"
+
+echo ""
+echo "PASS: $PASS, FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Phase 2a of #237 (per `docs/technical-plan-237.md` from #591). Ships `--init` scripts for the 5 audit-only agents — each one scans the repo for relevant signals and emits a draft custom doc to stdout. The orchestrator (`/bsg-stack init`, coming in Phase 3) will capture stdout and open a PR for human review.

**Scripts shipped** (5 agents, 5 scripts):

| Script | Agent | Output | Scan sources |
|---|---|---|---|
| `init-keywords.sh` | seo | `.bsg/KEYWORDS.md` | repo description, GitHub topics, package.json keywords, README H1/H2 |
| `init-calendar.sh` | marketing | `.bsg/CALENDAR.md` | `gh release list`, open milestones with due dates |
| `init-announced.sh` | pr-comms | `.bsg/ANNOUNCED.md` | published releases (drafts/prereleases excluded), CHANGELOG version headers |
| `init-securityignore.sh` | security | `.bsg/SECURITYIGNORE` | common test/fixture dirs, `*.example` / `*.sample` env files (excludes `.git/` and `node_modules/`) |
| `init-narrative.sh` | storytelling | `.bsg/NARRATIVE.md` | repo description, README "about" paragraph, voice-guidelines template |

**Contract** (enforced by the new test): every init script
1. Exists at the documented path under `claude-skills/skills/<skill>/scripts/`
2. Is executable
3. Responds to `--help` with exit 0
4. Produces non-empty stdout in an empty git repo (so the orchestrator never blocks on "nothing to write")
5. Never writes to cwd — the orchestrator owns the disk side

Each script degrades gracefully when `gh` is unavailable or the repo has no signals (still emits a valid template with `_Replace this..._` placeholders).

**Remaining for Phase 2**: po-manager (wraps existing `bootstrap-plan.sh`), tech-lead (`init-adr.sh`), qa (`init-qa.sh`), md-to-office (`DESIGN.md`).

## Testing

- `bash claude-skills/tests/test_init_scripts.sh` → `PASS: 25, FAIL: 0` (5 scripts × 5 contract checks each)
- `python3 -m pytest claude-skills/tests/test_skills.py claude-skills/tests/test_skill_invariants.py` → `22 passed`
- Manual: ran each script in a fresh `git init -q` tmpdir; verified output is valid markdown and contains the expected structure (headings, placeholders, draft notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
