### PR TITLE
feat(237): /bsg-stack init/update/status orchestrator (Phase 3)

### DIFF
--- a/claude-skills/skills/bsg-stack/SKILL.md
+++ b/claude-skills/skills/bsg-stack/SKILL.md
@@ -53,10 +53,17 @@ intent and open PRs.
 bash claude-skills/skills/bsg-stack/scripts/doctor.sh
 
 # One-line status
-bash claude-skills/skills/bsg-stack/scripts/doctor.sh --status
+bash claude-skills/skills/bsg-stack/scripts/status.sh
 
-# Bootstrap a fresh repo (interactive, opens PRs)
-@bsg-stack init
+# Preview what /bsg-stack init would create (no writes)
+bash claude-skills/skills/bsg-stack/scripts/init.sh --dry-run
+
+# Bootstrap a fresh repo (writes to disk, prints summary)
+bash claude-skills/skills/bsg-stack/scripts/init.sh
+
+# Refresh stale custom docs (>90 days old by default)
+bash claude-skills/skills/bsg-stack/scripts/update.sh --dry-run
+bash claude-skills/skills/bsg-stack/scripts/update.sh
 ```
 
 ## What `doctor` checks
@@ -85,18 +92,34 @@ one row is `✗`. Soft `⚠` warnings do not raise the exit code, so
 `doctor` is safe to wire as a CI gate without forcing zero-warning
 hygiene.
 
-## What `init` and `update` do (when implemented)
+## What `init` and `update` do
 
-`init` orchestrates per-agent `--init` actions. The agents' frontmatter
-declares what each one's `--init` generates (see the `init:` field in
-each agent file). Today only `md-to-office` ships a working `--init`;
-the others have the contract documented but not the implementation.
-`init` lists what would be generated in dry-run mode until per-agent
-scripts catch up — see `references/init.md` for status.
+`init` orchestrates the per-agent `--init` scripts shipped under
+`claude-skills/skills/<skill>/scripts/init-*.sh`. For each registered
+agent that has a matching init script and whose `.bsg/<DOC>` path is
+not yet present, the orchestrator:
 
-`update` is a future verb that re-runs `--init` for agents whose
-custom doc is stale (older than 90 days, or when README has materially
-changed since the doc was last regenerated). Not yet implemented.
+1. Runs the agent's init script and captures stdout
+2. Writes the captured content to `.bsg/<DOC>`
+3. Skips agents whose doc already exists (idempotent — safe to re-run)
+
+Additionally, `init` creates the `.bsg/` skeleton (reports subdirs,
+adr/, brand/), bootstraps missing GitHub labels (`needs-human-review`,
+`human-reviewed`, every bus label from `agents/registry.json`), and
+drops a disabled `.bsg/AUTOPILOT.yml` scaffold if neither file exists.
+The orchestrator leaves the tree dirty — humans review the generated
+files and commit them. Run `init --dry-run` first to preview.
+
+`update` re-runs `--init` for agents whose custom doc is older than
+the staleness threshold (default: 90 days, override with
+`--threshold N`). Refreshed drafts land in `.bsg/.update-pending/`
+for explicit human diff + merge — `update` never overwrites a
+committed custom doc directly.
+
+Agents whose `--init` script hasn't shipped yet (po-manager, tech-lead,
+qa, md-to-office) are silently skipped during `init`/`update` and
+re-listed as missing in `doctor`'s scorecard. As each script lands,
+the orchestrator picks it up automatically — no SKILL.md edit needed.
 
 ## What `bsg-stack` does NOT do
 

--- a/claude-skills/skills/bsg-stack/scripts/init.sh
+++ b/claude-skills/skills/bsg-stack/scripts/init.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# init.sh — bootstrap the .bsg/ directory for a fresh repo.
+#
+# Orchestrates the per-agent --init scripts shipped under
+# `claude-skills/skills/<skill>/scripts/init-*.sh` to create a complete
+# .bsg/ tree in one shot. Each per-agent init script is responsible
+# for its own scan + draft logic; this orchestrator routes the calls
+# and writes the output files.
+#
+# Per ADR-002 this verb is NOT read-only: it creates files and may
+# create GitHub labels via `gh`. Always run interactively with consent.
+#
+# What this does, in order:
+#
+#   1. Create .bsg/ skeleton (reports/<bus>/ subdirs, adr/, brand/)
+#   2. For each agent with an init script, run it and capture output
+#      to the expected .bsg/<DOC> path. Skip agents whose doc already
+#      exists (idempotent — safe to re-run).
+#   3. Bootstrap missing GitHub labels from agents/registry.json plus
+#      the `needs-human-review` / `human-reviewed` pair.
+#   4. Drop a disabled .bsg/AUTOPILOT.yml scaffold if neither the new
+#      nor legacy autopilot file exists.
+#   5. Print a summary of what was created.
+#
+# This is intentionally a one-shot bootstrap. The orchestrator does not
+# open a PR — it leaves the .bsg/ tree dirty for the human to review,
+# edit, and commit. The `/bsg-stack doctor` verb can then verify the
+# repo is healthy.
+#
+# Usage:
+#   bash init.sh                 # full bootstrap with prompts skipped
+#   bash init.sh --dry-run       # print what would happen, change nothing
+#   bash init.sh --no-labels     # skip GitHub label creation
+#   bash init.sh --skip <agent>  # skip a specific agent's init (repeatable)
+#
+# Exit 0 on success, non-zero on real failure (missing catalog,
+# permission errors). Individual per-agent failures are reported but
+# don't fail the whole bootstrap.
+
+set -euo pipefail
+
+DRY_RUN=0
+NO_LABELS=0
+declare -a SKIP_AGENTS
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)    DRY_RUN=1; shift ;;
+    --no-labels)  NO_LABELS=1; shift ;;
+    --skip)       SKIP_AGENTS+=("$2"); shift 2 ;;
+    -h|--help)    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+# Locate the catalog — walk up from this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CATALOG_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+REGISTRY="$CATALOG_DIR/agents/registry.json"
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "init.sh: cannot find agents/registry.json (looked in $CATALOG_DIR)" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------- helpers
+
+would() {
+  if [[ "$DRY_RUN" == "1" ]]; then printf 'would: %s\n' "$1"
+  else printf '%s\n'        "$1"
+  fi
+}
+
+is_skipped() {
+  local agent="$1"
+  for s in "${SKIP_AGENTS[@]:-}"; do
+    [[ "$s" == "$agent" ]] && return 0
+  done
+  return 1
+}
+
+# Map agent name → its init script path relative to the catalog.
+init_script_for() {
+  case "$1" in
+    po-manager)    echo "skills/po/scripts/bootstrap-plan.sh" ;;
+    seo)           echo "skills/seo-report/scripts/init-keywords.sh" ;;
+    marketing)     echo "skills/marketing-report/scripts/init-calendar.sh" ;;
+    pr-comms)      echo "skills/pr-comms-report/scripts/init-announced.sh" ;;
+    security)      echo "skills/security-report/scripts/init-securityignore.sh" ;;
+    storytelling)  echo "skills/storytelling-report/scripts/init-narrative.sh" ;;
+    *)             echo "" ;;
+  esac
+}
+
+# Map agent name → its expected output path under .bsg/.
+output_path_for() {
+  case "$1" in
+    po-manager)    echo ".bsg/PLAN.md" ;;
+    seo)           echo ".bsg/KEYWORDS.md" ;;
+    marketing)     echo ".bsg/CALENDAR.md" ;;
+    pr-comms)      echo ".bsg/ANNOUNCED.md" ;;
+    security)      echo ".bsg/SECURITYIGNORE" ;;
+    storytelling)  echo ".bsg/NARRATIVE.md" ;;
+    *)             echo "" ;;
+  esac
+}
+
+# ---------------------------------------------------------------- step 1: skeleton
+
+echo ""
+echo "Step 1/4 — Creating .bsg/ skeleton"
+echo "==================================="
+
+SKELETON_DIRS=(
+  ".bsg"
+  ".bsg/adr"
+  ".bsg/brand"
+  ".bsg/brand/templates"
+  ".bsg/reports"
+)
+# One reports subdir per registered agent's bus label.
+while IFS= read -r bus; do
+  SKELETON_DIRS+=(".bsg/reports/$bus")
+done < <(jq -r '.agents[].bus_label' "$REGISTRY")
+
+for d in "${SKELETON_DIRS[@]}"; do
+  if [[ -d "$d" ]]; then
+    echo "  ✓ exists: $d"
+  else
+    would "  create: $d"
+    [[ "$DRY_RUN" == "0" ]] && mkdir -p "$d"
+  fi
+done
+
+# ---------------------------------------------------------------- step 2: per-agent init
+
+echo ""
+echo "Step 2/4 — Running per-agent --init scripts"
+echo "==========================================="
+
+CREATED_COUNT=0
+SKIPPED_COUNT=0
+FAILED_COUNT=0
+
+while IFS= read -r name; do
+  if is_skipped "$name"; then
+    echo "  ⊘ skip:    $name (explicit --skip)"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
+  fi
+
+  script_rel="$(init_script_for "$name")"
+  output_path="$(output_path_for "$name")"
+
+  if [[ -z "$script_rel" || -z "$output_path" ]]; then
+    echo "  ⊘ no-init: $name (no --init script registered yet)"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
+  fi
+
+  script_abs="$CATALOG_DIR/$script_rel"
+  if [[ ! -f "$script_abs" ]]; then
+    # Fall back to cached install.
+    script_abs="$HOME/.claude/$script_rel"
+  fi
+  if [[ ! -f "$script_abs" ]]; then
+    echo "  ✗ missing script for $name: $script_rel"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    continue
+  fi
+
+  if [[ -f "$output_path" ]]; then
+    echo "  ✓ keeps:   $output_path (already present)"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
+  fi
+
+  would "  create:  $output_path  ← bash $script_rel"
+  if [[ "$DRY_RUN" == "0" ]]; then
+    if content="$(bash "$script_abs" 2>/dev/null)" && [[ -n "$content" ]]; then
+      mkdir -p "$(dirname "$output_path")"
+      printf '%s\n' "$content" > "$output_path"
+      CREATED_COUNT=$((CREATED_COUNT + 1))
+    else
+      echo "    └─ ✗ script produced no output; nothing written"
+      FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+  fi
+done < <(jq -r '.agents[].name' "$REGISTRY")
+
+# ---------------------------------------------------------------- step 3: labels
+
+echo ""
+echo "Step 3/4 — Bootstrapping GitHub labels"
+echo "======================================"
+
+if [[ "$NO_LABELS" == "1" ]]; then
+  echo "  ⊘ skip (--no-labels)"
+elif ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+  echo "  ⚠ gh CLI unavailable or not authenticated — skipping label bootstrap"
+else
+  REQUIRED_LABELS=("needs-human-review" "human-reviewed")
+  while IFS= read -r bus; do REQUIRED_LABELS+=("$bus"); done < <(jq -r '.agents[].bus_label' "$REGISTRY")
+
+  EXISTING=$(gh label list --limit 200 --json name --jq '.[].name' 2>/dev/null || echo "")
+  for lbl in "${REQUIRED_LABELS[@]}"; do
+    if grep -qx "$lbl" <<<"$EXISTING"; then
+      echo "  ✓ exists:  $lbl"
+    else
+      would "  create:  $lbl"
+      if [[ "$DRY_RUN" == "0" ]]; then
+        # Pick a sensible color per category.
+        case "$lbl" in
+          needs-human-review) color="fbca04"; desc="Awaiting a human decision (triage, merge, or scope)" ;;
+          human-reviewed)     color="0e8a16"; desc="A human has made a disposition decision" ;;
+          *)                  color="5319e7"; desc="Owned by @$lbl (agent bus label)" ;;
+        esac
+        gh label create "$lbl" --color "$color" --description "$desc" >/dev/null 2>&1 \
+          || echo "    └─ ✗ failed to create label $lbl (may already exist with different case)"
+      fi
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------- step 4: autopilot scaffold
+
+echo ""
+echo "Step 4/4 — Autopilot config scaffold"
+echo "====================================="
+
+if [[ -f .bsg/AUTOPILOT.yml ]]; then
+  echo "  ✓ exists: .bsg/AUTOPILOT.yml"
+elif [[ -f .bsg-autopilot.yml ]]; then
+  echo "  ⚠ legacy: .bsg-autopilot.yml — consider renaming to .bsg/AUTOPILOT.yml"
+else
+  would "  create: .bsg/AUTOPILOT.yml (disabled — edit to enable)"
+  if [[ "$DRY_RUN" == "0" ]]; then
+    cat > .bsg/AUTOPILOT.yml <<'YAML'
+# .bsg/AUTOPILOT.yml — repo-level opt-in for auto-implementation.
+#
+# When `enabled: true` and the calling agent is listed under `agents:`,
+# the agent's tick will pick up eligible issues and attempt one fix per
+# sweep (subject to the per-issue budget). See CLAUDE.md → "Autopilot
+# mode" for the full schema and semantics.
+#
+# This scaffold ships disabled — flip `enabled` to `true` and add agent
+# bus labels under `agents:` when you're ready.
+
+enabled: false
+agents: []
+budget:
+  max_prs_per_tick: 3
+  max_prs_per_day: 200
+  max_loc_per_issue: 200
+  max_files_per_issue: 8
+YAML
+  fi
+fi
+
+# ---------------------------------------------------------------- summary
+
+echo ""
+echo "Summary"
+echo "======="
+echo "  Created: $CREATED_COUNT custom doc(s)"
+echo "  Kept:    $SKIPPED_COUNT (already present or no script registered)"
+echo "  Failed:  $FAILED_COUNT"
+echo ""
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "Dry-run complete — no files written. Re-run without --dry-run to apply."
+elif [[ "$CREATED_COUNT" -gt 0 ]]; then
+  echo "Next steps:"
+  echo "  1. Review the generated files under .bsg/"
+  echo "  2. Edit and replace _placeholder_ text where needed"
+  echo "  3. git add .bsg/ && git commit"
+  echo "  4. Run /bsg-stack doctor to verify the setup"
+else
+  echo "Nothing to write — repo already has its .bsg/ tree set up."
+  echo "Run /bsg-stack doctor to check current health."
+fi

--- a/claude-skills/skills/bsg-stack/scripts/status.sh
+++ b/claude-skills/skills/bsg-stack/scripts/status.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# status.sh — one-line summary of BSG agent configuration health.
+#
+# Thin wrapper around `doctor.sh --status` so the `/bsg-stack status`
+# verb has a stable entry point. Read-only per ADR-002.
+#
+# Usage:
+#   bash status.sh           # one-line summary
+#   bash status.sh --json    # machine-readable JSON output
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "${1:-}" in
+  --json) exec bash "$SCRIPT_DIR/doctor.sh" --json ;;
+  -h|--help)
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+esac
+
+exec bash "$SCRIPT_DIR/doctor.sh" --status "$@"

--- a/claude-skills/skills/bsg-stack/scripts/update.sh
+++ b/claude-skills/skills/bsg-stack/scripts/update.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# update.sh — refresh stale BSG custom docs in the repo.
+#
+# Reads doctor.sh --json to identify docs that exist but are older
+# than the staleness threshold (default: 90 days). For each stale doc,
+# re-runs the corresponding per-agent --init script and writes the
+# refreshed draft alongside a `.bsg/.update-pending/<doc>.draft.md`
+# file so the human can diff against the existing version before
+# committing.
+#
+# Per ADR-002 this verb is NOT read-only: it writes to disk. It does
+# not, however, overwrite existing custom docs — drafts land in
+# `.bsg/.update-pending/` for explicit human merge.
+#
+# Usage:
+#   bash update.sh                  # refresh anything >90 days old
+#   bash update.sh --threshold 30   # custom staleness threshold (days)
+#   bash update.sh --dry-run        # print what would happen, change nothing
+#   bash update.sh --force          # also refresh fresh docs (override threshold)
+
+set -euo pipefail
+
+THRESHOLD=90
+DRY_RUN=0
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --force)     FORCE=1; shift ;;
+    -h|--help)   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "update.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CATALOG_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+REGISTRY="$CATALOG_DIR/agents/registry.json"
+
+# Same agent → script + output path mapping as init.sh; keep in sync.
+init_script_for() {
+  case "$1" in
+    seo)           echo "skills/seo-report/scripts/init-keywords.sh" ;;
+    marketing)     echo "skills/marketing-report/scripts/init-calendar.sh" ;;
+    pr-comms)      echo "skills/pr-comms-report/scripts/init-announced.sh" ;;
+    security)      echo "skills/security-report/scripts/init-securityignore.sh" ;;
+    storytelling)  echo "skills/storytelling-report/scripts/init-narrative.sh" ;;
+    *)             echo "" ;;
+  esac
+}
+
+output_path_for() {
+  case "$1" in
+    seo)           echo ".bsg/KEYWORDS.md" ;;
+    marketing)     echo ".bsg/CALENDAR.md" ;;
+    pr-comms)      echo ".bsg/ANNOUNCED.md" ;;
+    security)      echo ".bsg/SECURITYIGNORE" ;;
+    storytelling)  echo ".bsg/NARRATIVE.md" ;;
+    *)             echo "" ;;
+  esac
+}
+
+file_age_days() {
+  local f="$1"
+  [[ -e "$f" ]] || { echo ""; return; }
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    local mtime; mtime=$(stat -f %m "$f")
+  else
+    local mtime; mtime=$(stat -c %Y "$f")
+  fi
+  echo $(( ( $(date +%s) - mtime ) / 86400 ))
+}
+
+echo ""
+echo "Updating stale custom docs (threshold: ${THRESHOLD}d, force: $FORCE)"
+echo "=================================================================="
+
+REFRESHED=0
+SKIPPED=0
+PENDING_DIR=".bsg/.update-pending"
+
+while IFS= read -r name; do
+  script_rel="$(init_script_for "$name")"
+  output_path="$(output_path_for "$name")"
+  [[ -z "$script_rel" || -z "$output_path" ]] && continue
+
+  if [[ ! -f "$output_path" ]]; then
+    echo "  ⊘ skip:    $output_path (not yet bootstrapped — run /bsg-stack init)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  age="$(file_age_days "$output_path")"
+  if [[ "$FORCE" != "1" && "$age" -lt "$THRESHOLD" ]]; then
+    echo "  ✓ fresh:   $output_path (${age}d old)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  script_abs="$CATALOG_DIR/$script_rel"
+  [[ -f "$script_abs" ]] || script_abs="$HOME/.claude/$script_rel"
+  if [[ ! -f "$script_abs" ]]; then
+    echo "  ✗ missing: $script_rel — cannot refresh $output_path"
+    continue
+  fi
+
+  draft_path="$PENDING_DIR/$(basename "$output_path").draft.md"
+
+  echo "  ⟳ refresh: $output_path (${age}d old) → $draft_path"
+  if [[ "$DRY_RUN" == "0" ]]; then
+    mkdir -p "$PENDING_DIR"
+    if content="$(bash "$script_abs" 2>/dev/null)" && [[ -n "$content" ]]; then
+      printf '%s\n' "$content" > "$draft_path"
+      REFRESHED=$((REFRESHED + 1))
+    else
+      echo "    └─ ✗ init script produced no output"
+    fi
+  fi
+done < <(jq -r '.agents[].name' "$REGISTRY")
+
+echo ""
+echo "Summary"
+echo "======="
+echo "  Refreshed drafts: $REFRESHED"
+echo "  Skipped (fresh or unbootstrapped): $SKIPPED"
+
+if [[ "$REFRESHED" -gt 0 ]]; then
+  echo ""
+  echo "Next steps:"
+  echo "  1. Diff each .bsg/.update-pending/*.draft.md against its committed sibling"
+  echo "  2. Merge or discard each draft based on what's changed in the repo"
+  echo "  3. Remove .bsg/.update-pending/ after merging"
+fi

--- a/claude-skills/tests/test_bsg_stack_orchestrator.sh
+++ b/claude-skills/tests/test_bsg_stack_orchestrator.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test_bsg_stack_orchestrator.sh — guards for /bsg-stack init/update/status.
+#
+# Verifies the orchestrator scripts:
+#   1. Respond to --help with exit 0
+#   2. Run --dry-run cleanly in an empty tmpdir (no crash, no disk writes)
+#   3. Are idempotent: running twice produces the same .bsg/ tree
+#   4. status.sh delegates to doctor.sh --status
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+INIT="$REPO_ROOT/claude-skills/skills/bsg-stack/scripts/init.sh"
+UPDATE="$REPO_ROOT/claude-skills/skills/bsg-stack/scripts/update.sh"
+STATUS="$REPO_ROOT/claude-skills/skills/bsg-stack/scripts/status.sh"
+
+PASS=0
+FAIL=0
+
+assert() {
+  local label="$1" condition="$2"
+  if eval "$condition"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  condition: $condition"
+  fi
+}
+
+# 1. Each script exists, is executable, and responds to --help.
+for s in "$INIT" "$UPDATE" "$STATUS"; do
+  name="$(basename "$s")"
+  assert "$name exists"        "[[ -f '$s' ]]"
+  assert "$name is executable" "[[ -x '$s' ]]"
+  assert "$name --help exits 0" "$s --help >/dev/null 2>&1"
+done
+
+# 2. init.sh --dry-run in an empty git repo:
+#    - exits cleanly
+#    - does NOT create .bsg/ (it's a dry run)
+tmp="$(mktemp -d)"
+(
+  cd "$tmp"
+  git init -q
+)
+assert "init --dry-run exits 0 in empty repo" \
+  "(cd '$tmp' && bash '$INIT' --dry-run --no-labels >/dev/null 2>&1)"
+assert "init --dry-run does NOT create .bsg/" \
+  "[[ ! -d '$tmp/.bsg' ]]"
+rm -rf "$tmp"
+
+# 3. init.sh real run in an empty git repo:
+#    - exits cleanly
+#    - creates .bsg/ with skeleton subdirs
+#    - re-running produces no diff in the .bsg/ tree
+tmp="$(mktemp -d)"
+(
+  cd "$tmp"
+  git init -q
+  bash "$INIT" --no-labels >/dev/null 2>&1
+)
+assert "init creates .bsg/ skeleton"            "[[ -d '$tmp/.bsg' ]]"
+assert "init creates .bsg/adr/"                 "[[ -d '$tmp/.bsg/adr' ]]"
+assert "init creates .bsg/reports/po/"          "[[ -d '$tmp/.bsg/reports/po' ]]"
+assert "init creates .bsg/AUTOPILOT.yml"        "[[ -f '$tmp/.bsg/AUTOPILOT.yml' ]]"
+
+# Capture pre-state, re-run, compare.
+pre="$(find "$tmp/.bsg" -type f | sort | xargs -I{} stat -f '%N %m' {} 2>/dev/null \
+       || find "$tmp/.bsg" -type f | sort | xargs -I{} stat -c '%n %Y' {})"
+(
+  cd "$tmp"
+  bash "$INIT" --no-labels >/dev/null 2>&1
+)
+post="$(find "$tmp/.bsg" -type f | sort | xargs -I{} stat -f '%N %m' {} 2>/dev/null \
+       || find "$tmp/.bsg" -type f | sort | xargs -I{} stat -c '%n %Y' {})"
+assert "init is idempotent (re-run leaves .bsg/ unchanged)" "[[ '$pre' == '$post' ]]"
+rm -rf "$tmp"
+
+# 4. update.sh --dry-run in an empty git repo: exits cleanly.
+tmp="$(mktemp -d)"
+(
+  cd "$tmp"
+  git init -q
+)
+assert "update --dry-run exits 0 in empty repo" \
+  "(cd '$tmp' && bash '$UPDATE' --dry-run >/dev/null 2>&1)"
+rm -rf "$tmp"
+
+# 5. status.sh runs doctor.sh --status.
+tmp="$(mktemp -d)"
+(
+  cd "$tmp"
+  git init -q
+)
+# status.sh exits 1 when missing docs detected — that's expected in
+# an empty repo. We just verify it ran and produced output.
+out="$(cd "$tmp" && bash "$STATUS" 2>&1 || true)"
+assert "status.sh produces summary line" "[[ '$out' == *'BSG:'* ]]"
+rm -rf "$tmp"
+
+echo ""
+echo "PASS: $PASS, FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Phase 3 of #237 (per `docs/technical-plan-237.md` from #591). Ships the three remaining `/bsg-stack` verbs that complete the umbrella skill. `doctor` is the existing read-only scorecard; these three cover the write-side of the contract per ADR-002.

**Scripts shipped**:

| Script | Verb | What it does |
|---|---|---|
| `init.sh` | `/bsg-stack init` | Create `.bsg/` skeleton, run per-agent `--init` scripts, bootstrap GitHub labels, drop disabled `AUTOPILOT.yml` scaffold. Idempotent. |
| `update.sh` | `/bsg-stack update` | Refresh custom docs older than `--threshold N` (default 90d). Drafts land in `.bsg/.update-pending/` for human diff + merge — never overwrites committed docs. |
| `status.sh` | `/bsg-stack status` | Thin wrapper around `doctor.sh --status` / `--json` so the `status` verb has a stable entry point. |

**Init flags**: `--dry-run` (preview without writing), `--no-labels` (skip `gh label create`), `--skip <agent>` (repeatable).

**Update flags**: `--threshold N` (days, default 90), `--dry-run`, `--force` (override threshold).

**Graceful degradation**: when a per-agent `--init` script isn't in the catalog yet (Phase 2a covers 5 of 8; po/tech/qa/md-to-office remain), the orchestrator lists it as `✗ missing` and continues. As each script lands the orchestrator picks it up automatically — no SKILL.md edit needed.

**SKILL.md updated** to mark `init`/`update` as implemented and to document the staleness threshold behavior.

## Testing

- `bash claude-skills/tests/test_bsg_stack_orchestrator.sh` → `PASS: 18, FAIL: 0` covering:
  - All three scripts respond to `--help`
  - `init.sh --dry-run` does NOT create `.bsg/`
  - `init.sh` real-run creates `.bsg/adr/`, `.bsg/reports/po/`, `.bsg/AUTOPILOT.yml`
  - `init.sh` is idempotent (re-running leaves `.bsg/` unchanged at mtime granularity)
  - `update.sh --dry-run` works in an empty repo
  - `status.sh` delegates to `doctor.sh` and produces the `BSG:` summary line
- `python3 -m pytest claude-skills/tests/test_skills.py claude-skills/tests/test_skill_invariants.py` → `22 passed`
- End-to-end manual run in a fresh tmpdir: orchestrator handles every error case (missing script, empty output, `gh` unavailable) without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
