### PR TITLE
chore: rename GitHub username guillaumebadin → g-dumas

### DIFF
--- a/.bsg-autopilot.yml
+++ b/.bsg-autopilot.yml
@@ -18,7 +18,7 @@ enabled: true
 # --reason spec-clarification or --reason tech-decision (file-issue.sh)
 # or when detect-stuck-issues.sh fires a tier-2 escalation. The named
 # user gets the issue assigned + an @-mention in the body. See #416.
-default_human_reviewer: guillaumebadin
+default_human_reviewer: g-dumas
 
 agents:
   - tech

--- a/docs/prd-237-bsg-directory-init.md
+++ b/docs/prd-237-bsg-directory-init.md
@@ -3,7 +3,7 @@
 **Issue:** #237  
 **Status:** In Progress (~25% complete)  
 **Date:** 2026-05-05  
-**Owner:** @guillaumebadin
+**Owner:** @g-dumas
 
 ## Problem Statement
 

--- a/po/reports/2026-05-05-status.md
+++ b/po/reports/2026-05-05-status.md
@@ -69,7 +69,7 @@ _Generated: 2026-05-05T08:09:41Z_
 | Assignee | Open |
 | --- | --- |
 | unassigned | 3 |
-| guillaumebadin | 1 |
+| g-dumas | 1 |
 
 ## Milestone progress
 


### PR DESCRIPTION
## Summary
- Update `default_human_reviewer` in `.bsg-autopilot.yml` (critical — agents use this for @mentions)
- Update @mention in PRD doc
- Update assignee table in PO status report

## Context
GitHub account renamed from `guillaumebadin` to `g-dumas`.

## Test plan
- [ ] Verify `.bsg-autopilot.yml` has correct reviewer handle
- [ ] Verify @mention renders correctly on GitHub