### PR TITLE
feat(google-workspace): auto-append signature on direct +send

### DIFF
--- a/claude-skills/skills/google-workspace/SKILL.md
+++ b/claude-skills/skills/google-workspace/SKILL.md
@@ -428,6 +428,30 @@ discover via `gws <svc> --help` and `gws schema <svc.res.method>`.
   (both send and `--draft`). Compose the `--body` as HTML (`<p>`, `<a>`,
   `<img>`, `<strong>`). HTML renders clickable links, inline images, and
   proper formatting. Plain text looks broken in modern email clients.
+- **Auto-append the signature on direct `+send` / `+send --draft`** —
+  Gmail's web composer auto-adds the account signature; a direct
+  `gws gmail +send` does **not**. When you compose an HTML body yourself
+  (i.e. *not* going through `email-md-send.sh`, which already appends it),
+  fetch the default sendAs signature and append it after the body so
+  drafts and sent mail match what the user sees in Gmail web:
+
+  ```bash
+  SIG=$(gws gmail users settings sendAs list --params '{"userId":"me"}' \
+    | jq -r '.sendAs[] | select(.isDefault==true) | .signature // empty')
+  BODY='<p>Hi Alice!</p>'
+  [ -n "$SIG" ] && BODY="${BODY}<br><br>${SIG}"
+  gws gmail +send --to alice@x.com --subject 'Ping' --body "$BODY" --html --draft
+  ```
+
+  Rules:
+  - Only when `--html` is used; skip silently when the signature is
+    empty/`null` (no separator added).
+  - Fetch once per session and reuse — it doesn't change mid-task.
+  - Honour an explicit **`--no-signature`** intent from the user (e.g.
+    "send without signature"): skip the fetch/append entirely. Same
+    opt-out keyword as `email-md-send.sh --no-signature`.
+  - The markdown pipeline (`email-md-send.sh` / `email-from-md.sh`)
+    already does this — do **not** double-append when routing through it.
 - **`--dry-run`** validates the request locally without calling Google. Use
   it to verify shape before any mutating call.
 - **`--format json`** (default) for parsing; `--format table` for humans;

--- a/claude-skills/skills/google-workspace/references/gmail.md
+++ b/claude-skills/skills/google-workspace/references/gmail.md
@@ -310,6 +310,20 @@ gws gmail +send --to "$TO" --from "$FROM" --subject "$SUBJECT" \
   --body "$(cat /tmp/body.html)" --html --draft
 ```
 
+**Direct compose (no markdown source).** When you build the HTML body
+yourself instead of from a `.md` file, `gws gmail +send` still won't add
+the signature. Fetch the default sendAs signature and append it so
+drafts/sent mail match Gmail web (skip if empty, or on a `--no-signature`
+intent — see SKILL.md "Agent-friendly conventions"):
+
+```bash
+SIG=$(gws gmail users settings sendAs list --params '{"userId":"me"}' \
+  | jq -r '.sendAs[] | select(.isDefault==true) | .signature // empty')
+BODY='<p>Hi Alice!</p>'
+[ -n "$SIG" ] && BODY="${BODY}<br><br>${SIG}"
+gws gmail +send --to alice@x.com --subject 'Ping' --body "$BODY" --html --draft
+```
+
 ## Cheap patterns
 
 ```bash


### PR DESCRIPTION
Closes #588

## Context

Gmail's web composer auto-appends the account signature, but a direct
`gws gmail +send` / `+send --draft` does not. The markdown pipeline
(`email-md-send.sh` / `email-from-md.sh`) already handles this, but when
an agent composes an HTML body directly the signature is silently dropped.

## Changes

- `claude-skills/skills/google-workspace/SKILL.md` — new "Agent-friendly
  conventions" bullet: before a direct `+send`/`+send --draft` with
  `--html`, fetch the default sendAs signature and append after
  `<br><br>`. Skip silently when the signature is empty/`null`; honour an
  explicit `--no-signature` intent (same opt-out keyword as
  `email-md-send.sh`); fetch once per session; do not double-append when
  routing through the markdown pipeline.
- `claude-skills/skills/google-workspace/references/gmail.md` — companion
  "Direct compose (no markdown source)" snippet next to the existing
  signature workaround for discoverability.

Doc/convention-only change — no scripts or frontmatter modified.

## Test

- `git diff --stat` → only the two doc files changed.
- Snippet verified manually: `jq -r '.sendAs[] | select(.isDefault==true) | .signature // empty'` yields empty string (not `null`) when no signature, so the `[ -n "$SIG" ]` guard correctly skips the separator.
- No skill/agent frontmatter, footers, or INSTALL.md catalogs touched, so `test_skill_invariants.py` is unaffected.

---
⚠️ Dispatch note: the automation template arrived unrendered with four issues concatenated (#588, #597, #237, and an unnumbered SEO-skill issue). This PR implements **only #588** (smallest, fully-specified, lowest-risk). #597, #237, and the SEO issue still need separate triage.