### PR TITLE
fix(@seo): Next.js JSX/TSX link extraction + opt-in production verification

### DIFF
--- a/claude-skills/skills/seo-report/SKILL.md
+++ b/claude-skills/skills/seo-report/SKILL.md
@@ -34,8 +34,13 @@ For a **full audit**, run `generate-report.sh`.
    script's output.
 2. **Always write the final report to `seo/reports/YYYY-MM-DD-*.md`**
    — dated and version-controllable.
-3. **Source-at-rest only.** No `curl`, no `wget` against production.
-   The skill analyzes templates and static files in this repo.
+3. **Source-at-rest by default.** The skill analyzes templates and
+   static files in this repo and makes **no** network calls — unless
+   the user explicitly opts in to production verification with
+   `generate-report.sh --prod [url]`, which runs a bounded set of
+   read-only `curl` probes (status codes, headers, rendered HTML) and
+   appends a `## Production checks` section. Never probe production
+   without the explicit `--prod` flag.
 4. **Respect `.seoignore`** (gitignore-style) for marketing-only
    landing pages that legitimately lack some tags.
 5. **Confirm before posting** to GitHub (issue comments, labels).
@@ -53,13 +58,27 @@ template fetch; reporters transform it.
 | `links.sh`            | Orphan detector + broken-link checker based on the adjacency list from `collect.sh`. |
 | `content.sh`          | Keyword coverage: for each entry in `seo/KEYWORDS.md`, find pages mentioning it in title or H1; emit `uncoveredKeywords[]` for the gaps. |
 | `technical.sh`        | Sitemap presence + page-coverage diff, robots.txt presence, canonical URL consistency. |
-| `generate-report.sh`  | Collects once, runs every reporter, composes the full markdown audit. |
+| `prod-check.sh`       | **Opt-in** (`--prod [url]`) live verification: sitemap/robots HTTP status, absolute canonicals, JSON-LD in rendered HTML, OG image reachability, GA4/Pixel presence, pillar-page status, www↔apex redirect code. Emits a markdown section. |
+| `generate-report.sh`  | Collects once, runs every reporter, composes the full markdown audit. Pass `--prod [url]` to append `prod-check.sh` output. |
+
+## Dependencies
+
+`collect.sh` and `prod-check.sh` source the shared path resolver
+`_bsg-paths.sh`, expected at **`<repo>/claude-skills/scripts/_bsg-paths.sh`**
+— three levels up from this skill's `scripts/` dir. The skill must be
+installed with that sibling `scripts/` tree intact; if the file is
+missing, `collect.sh` exits 1 with an explicit error rather than
+crashing mid-pipeline.
 
 **Invocation patterns:**
 
 ```bash
 # Full audit
 bash scripts/generate-report.sh > seo/reports/$(date +%F)-audit.md
+
+# Full audit + live production verification (opt-in)
+bash scripts/generate-report.sh --prod https://www.the-shift.ai \
+  > seo/reports/$(date +%F)-audit.md
 
 # Reuse one snapshot
 bash scripts/collect.sh > /tmp/seo-snap.json

--- a/claude-skills/skills/seo-report/scripts/collect.sh
+++ b/claude-skills/skills/seo-report/scripts/collect.sh
@@ -11,8 +11,30 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
 
+# Shared path resolver. Lives at <repo>/claude-skills/scripts/_bsg-paths.sh,
+# i.e. three levels up from this skill's scripts/ dir. It can be absent in a
+# stripped Donna install (the skill is synced without the sibling scripts/
+# tree) — fail loud rather than crash mid-pipeline with an opaque error.
+BSG_PATHS="$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+if [[ ! -f "$BSG_PATHS" ]]; then
+  echo "ERROR: _bsg-paths.sh not found at $BSG_PATHS" >&2
+  echo "       expected <repo>/claude-skills/scripts/_bsg-paths.sh relative to the skill dir;" >&2
+  echo "       the seo-report skill must be installed with its sibling scripts/ tree." >&2
+  exit 1
+fi
 # shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
-source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+source "$BSG_PATHS"
+
+# Read stdin lines into a JSON string array, always emitting valid JSON even
+# on empty input. Plain `grep ... | jq -Rn '[inputs]'` crashes `jq --argjson`
+# under `set -euo pipefail` when grep finds nothing (e.g. JSX/TSX files with
+# no raw href attributes): the failed grep trips pipefail and the empty/garbled
+# value reaches --argjson. Routing through this helper guarantees a valid array.
+to_json_array() {
+  local out
+  out=$(jq -Rn '[inputs]' 2>/dev/null) || out='[]'
+  printf '%s' "${out:-[]}"
+}
 
 # -------------------------------------------- page file enumeration
 
@@ -62,13 +84,19 @@ while IFS= read -r f; do
   og_desc=$(grep -oEi '<meta[^>]*property="og:description"[^>]*>' "$f" 2>/dev/null | head -1 || true)
   og_image=$(grep -oEi '<meta[^>]*property="og:image"[^>]*>' "$f" 2>/dev/null | head -1 || true)
 
-  # Pull out internal link targets: href="/something" (not starting with http: or mailto: or tel:).
-  targets=$(grep -oE 'href="[^"]+"' "$f" 2>/dev/null \
-    | sed 's/href="//; s/"$//' \
-    | grep -E '^/' \
-    | grep -v '^#' \
-    | sort -u \
-    | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+  # Pull out internal link targets. Matches plain `<a href="/x">` as well as
+  # Next.js / JSX forms: `<Link href="/x">`, `href={'/x'}`, `href={"/x"}`,
+  # and `to="/x"` (react-router). Each grep is `|| true`-guarded so a no-match
+  # never trips pipefail; to_json_array always yields a valid array.
+  q="[\"']"
+  targets=$(
+    { grep -oE "(href|to)=\{?${q}[^\"'>} ]+" "$f" 2>/dev/null || true; } \
+      | sed -E "s/^(href|to)=\{?${q}//" \
+      | { grep -E '^/' || true; } \
+      | { grep -v '^#' || true; } \
+      | sort -u \
+      | to_json_array
+  )
 
   has_jsonld="false"
   if grep -qE 'type="application/ld\+json"' "$f" 2>/dev/null; then
@@ -120,9 +148,11 @@ ROBOTS_PATH=$(find_first robots.txt public/robots.txt static/robots.txt dist/rob
 
 SITEMAP_URLS_JSON='[]'
 if [[ -n "$SITEMAP_PATH" ]]; then
-  SITEMAP_URLS_JSON=$(grep -oE '<loc>[^<]+</loc>' "$SITEMAP_PATH" 2>/dev/null \
-    | sed -E 's|<loc>||; s|</loc>||' \
-    | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+  SITEMAP_URLS_JSON=$(
+    { grep -oE '<loc>[^<]+</loc>' "$SITEMAP_PATH" 2>/dev/null || true; } \
+      | sed -E 's|<loc>||; s|</loc>||' \
+      | to_json_array
+  )
 fi
 
 ROBOTS_BLANKET="false"
@@ -137,9 +167,11 @@ fi
 KEYWORDS_PATH="$(bsg_doc_path keywords)"
 KEYWORDS_JSON='null'
 if [[ -f "$KEYWORDS_PATH" ]]; then
-  KEYWORDS_JSON=$({ grep -oE '^-[[:space:]]+.+' "$KEYWORDS_PATH" || true; } \
-    | sed -E 's/^-[[:space:]]+//' \
-    | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+  KEYWORDS_JSON=$(
+    { grep -oE '^-[[:space:]]+.+' "$KEYWORDS_PATH" || true; } \
+      | sed -E 's/^-[[:space:]]+//' \
+      | to_json_array
+  )
 fi
 
 # ---------------------------------------------------------- emit

--- a/claude-skills/skills/seo-report/scripts/generate-report.sh
+++ b/claude-skills/skills/seo-report/scripts/generate-report.sh
@@ -5,6 +5,19 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
+# Optional opt-in production verification: `--prod [url]`. When set, a
+# `## Production checks` section (live curl probes) is appended after the
+# source-at-rest audit. URL falls back to $SITE_URL / autopilot config.
+PROD=0
+PROD_URL=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --prod) PROD=1; shift
+            if [[ $# -gt 0 && "$1" != --* ]]; then PROD_URL="$1"; shift; fi ;;
+    *) shift ;;
+  esac
+done
+
 SNAPSHOT=$(mktemp -t seo-snap.XXXXXX.json)
 trap 'rm -f "$SNAPSHOT"' EXIT
 
@@ -109,3 +122,14 @@ $(jq -r '
 ' <<<"$TECH")
 
 EOF
+
+if [[ "$PROD" -eq 1 ]]; then
+  echo
+  echo "---"
+  echo
+  if [[ -n "$PROD_URL" ]]; then
+    bash "$SCRIPT_DIR/prod-check.sh" --prod "$PROD_URL"
+  else
+    bash "$SCRIPT_DIR/prod-check.sh" --prod
+  fi
+fi

--- a/claude-skills/skills/seo-report/scripts/prod-check.sh
+++ b/claude-skills/skills/seo-report/scripts/prod-check.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# prod-check.sh — opt-in production verification for the SEO audit.
+#
+# Source-at-rest analysis cannot see what is actually deployed: missing
+# env vars, 404 assets, 307-vs-301 redirects, analytics not wired. This
+# script makes a bounded set of curl probes against a live site and emits
+# a `## Production checks` markdown section for generate-report.sh.
+#
+# It is OFF by default and only runs when explicitly invoked with --prod.
+#
+# Usage:
+#   bash prod-check.sh --prod https://www.the-shift.ai
+#   bash prod-check.sh --prod                # resolve URL from env / autopilot
+#   SITE_URL=https://x bash prod-check.sh --prod
+#
+# URL resolution order: CLI arg → $SITE_URL → `site_url:` / `url:` /
+# `production_url:` in the autopilot config (.bsg/AUTOPILOT.yml).
+#
+# Never crashes on network failure: every probe degrades to a reported
+# `⚠️` line. Exit 0 unless the URL cannot be resolved at all.
+
+set -uo pipefail
+
+PROD=0
+SITE_URL="${SITE_URL:-}"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --prod) PROD=1; shift
+            if [[ $# -gt 0 && "$1" != --* ]]; then SITE_URL="$1"; shift; fi ;;
+    *) shift ;;
+  esac
+done
+
+[[ "$PROD" -eq 1 ]] || exit 0
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "## Production checks"
+  echo
+  echo "_\`curl\` not available — production verification skipped._"
+  exit 0
+fi
+
+# ----------------------------------------------------- URL resolution
+
+if [[ -z "$SITE_URL" ]]; then
+  BSG_PATHS="$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+  if [[ -f "$BSG_PATHS" ]]; then
+    # shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+    source "$BSG_PATHS"
+    AUTOPILOT="$(bsg_doc_path autopilot 2>/dev/null || true)"
+    if [[ -n "${AUTOPILOT:-}" && -f "$AUTOPILOT" ]]; then
+      SITE_URL=$(grep -ioE '^[[:space:]]*(site_url|production_url|url)[[:space:]]*:[[:space:]]*\S+' "$AUTOPILOT" 2>/dev/null \
+        | head -1 | sed -E 's/^[^:]*:[[:space:]]*//; s/^["'\'']//; s/["'\'']$//' || true)
+    fi
+  fi
+fi
+
+if [[ -z "$SITE_URL" ]]; then
+  echo "## Production checks"
+  echo
+  echo "_No site URL: pass \`--prod <url>\`, set \`\$SITE_URL\`, or add" \
+       "\`site_url:\` to the autopilot config. Production checks skipped._"
+  exit 0
+fi
+
+# Normalize: strip trailing slash, ensure scheme.
+[[ "$SITE_URL" =~ ^https?:// ]] || SITE_URL="https://$SITE_URL"
+SITE_URL="${SITE_URL%/}"
+HOST="${SITE_URL#*://}"; HOST="${HOST%%/*}"
+
+CURL=(curl -sS --max-time 15 -A "bsg-seo-report/prod-check")
+
+# status <url> — print HTTP code following redirects, or 000 on failure.
+status() { "${CURL[@]}" -o /dev/null -w '%{http_code}' -L "$1" 2>/dev/null || echo 000; }
+# raw_status <url> — print HTTP code WITHOUT following redirects.
+raw_status() { "${CURL[@]}" -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || echo 000; }
+# body <url> — print response body (redirects followed), empty on failure.
+body() { "${CURL[@]}" -L "$1" 2>/dev/null || true; }
+
+mark() { [[ "$1" == "1" ]] && printf -- '- [x] ' || printf -- '- [ ] '; }
+
+echo "## Production checks"
+echo
+echo "**Target:** \`$SITE_URL\`  ·  **Probed:** $(date -u +%FT%TZ)"
+echo
+
+# ------------------------------------------------------- sitemap.xml
+SM_CODE=$(status "$SITE_URL/sitemap.xml")
+SM_BODY=$(body "$SITE_URL/sitemap.xml")
+SM_COUNT=$(printf '%s' "$SM_BODY" | grep -oE '<loc>' | wc -l | tr -d ' ')
+SM_OK=$([[ "$SM_CODE" == "200" ]] && echo 1 || echo 0)
+echo "$(mark "$SM_OK")sitemap.xml → HTTP $SM_CODE, $SM_COUNT URLs"
+
+# --------------------------------------------------------- robots.txt
+RB_CODE=$(status "$SITE_URL/robots.txt")
+RB_BODY=$(body "$SITE_URL/robots.txt")
+RB_HASMAP=$(printf '%s' "$RB_BODY" | grep -qiE '^[[:space:]]*Sitemap:' && echo 1 || echo 0)
+RB_OK=$([[ "$RB_CODE" == "200" && "$RB_HASMAP" == "1" ]] && echo 1 || echo 0)
+echo "$(mark "$RB_OK")robots.txt → HTTP $RB_CODE, \`Sitemap:\` $([[ "$RB_HASMAP" == 1 ]] && echo present || echo MISSING)"
+
+# Internal page sample from the live sitemap (paths only, excl. homepage).
+mapfile -t SM_PATHS < <(printf '%s' "$SM_BODY" \
+  | grep -oE '<loc>[^<]+</loc>' \
+  | sed -E 's|<loc>||; s|</loc>||; s|^https?://[^/]+||; s|/$||' \
+  | grep -E '^/.+' | sort -u | head -8)
+
+HOME_HTML=$(body "$SITE_URL/")
+
+abs_canonical() {  # 1 if page has an absolute (http) rel=canonical
+  local html="$1"
+  printf '%s' "$html" \
+    | grep -oiE '<link[^>]*rel="canonical"[^>]*>' | head -1 \
+    | grep -qiE 'href="https?://' && echo 1 || echo 0
+}
+
+# ---------------------------------------- canonical: home + 2 internal
+HOME_CANON=$(abs_canonical "$HOME_HTML")
+CANON_DETAIL="home=$([[ "$HOME_CANON" == 1 ]] && echo ok || echo MISSING)"
+CANON_OK="$HOME_CANON"
+checked=0
+for p in "${SM_PATHS[@]:-}"; do
+  [[ -z "$p" || "$p" == "/" ]] && continue
+  [[ "$checked" -ge 2 ]] && break
+  ph=$(abs_canonical "$(body "$SITE_URL$p")")
+  CANON_DETAIL="$CANON_DETAIL, ${p}=$([[ "$ph" == 1 ]] && echo ok || echo MISSING)"
+  [[ "$ph" == 1 ]] || CANON_OK=0
+  checked=$((checked + 1))
+done
+echo "$(mark "$CANON_OK")Canonical absolute → $CANON_DETAIL"
+
+# ------------------------------------------------- JSON-LD in rendered HTML
+JSONLD_TYPES=$(printf '%s' "$HOME_HTML" \
+  | grep -oiE '"@type"[[:space:]]*:[[:space:]]*"[^"]+"' \
+  | sed -E 's/.*"([^"]+)"$/\1/' | sort -u | paste -sd, - 2>/dev/null)
+JSONLD_OK=$([[ -n "$JSONLD_TYPES" ]] && echo 1 || echo 0)
+echo "$(mark "$JSONLD_OK")JSON-LD types (homepage) → ${JSONLD_TYPES:-none detected}"
+
+# --------------------------------------------------------- OG image
+OG_IMG=$(printf '%s' "$HOME_HTML" \
+  | grep -oiE '<meta[^>]*property="og:image"[^>]*>' | head -1 \
+  | grep -oiE 'content="[^"]+"' | sed -E 's/content="//I; s/"$//')
+if [[ -z "$OG_IMG" ]]; then
+  echo "$(mark 0)OG image → no \`og:image\` meta on homepage"
+else
+  [[ "$OG_IMG" =~ ^https?:// ]] || OG_IMG="$SITE_URL/${OG_IMG#/}"
+  OG_CODE=$(status "$OG_IMG")
+  OG_OK=$([[ "$OG_CODE" == "200" ]] && echo 1 || echo 0)
+  echo "$(mark "$OG_OK")OG image → HTTP $OG_CODE (\`$OG_IMG\`)"
+fi
+
+# ----------------------------------------------- analytics (GA4 / Pixel)
+GA=$(printf '%s' "$HOME_HTML" | grep -qiE 'googletagmanager\.com/gtag|gtag\(|G-[A-Z0-9]{6,}' && echo 1 || echo 0)
+PX=$(printf '%s' "$HOME_HTML" | grep -qiE 'connect\.facebook\.net|fbq\(' && echo 1 || echo 0)
+AN_OK=$([[ "$GA" == 1 || "$PX" == 1 ]] && echo 1 || echo 0)
+echo "$(mark "$AN_OK")Analytics → GA4 $([[ "$GA" == 1 ]] && echo yes || echo no), Pixel $([[ "$PX" == 1 ]] && echo yes || echo no)"
+
+# ------------------------------------------------- pillar pages all 200
+if [[ "${#SM_PATHS[@]}" -eq 0 || -z "${SM_PATHS[0]:-}" ]]; then
+  echo "$(mark 0)Pillar pages → no sitemap URLs to sample"
+else
+  PILLAR_OK=1; PILLAR_DETAIL=""
+  for p in "${SM_PATHS[@]}"; do
+    [[ -z "$p" ]] && continue
+    c=$(status "$SITE_URL$p")
+    [[ "$c" == "200" ]] || PILLAR_OK=0
+    PILLAR_DETAIL="$PILLAR_DETAIL ${p}=$c"
+  done
+  echo "$(mark "$PILLAR_OK")Pillar pages (sitemap sample) →${PILLAR_DETAIL}"
+fi
+
+# ----------------------------------------- www vs apex → 301 (not 307)
+if [[ "$HOST" == www.* ]]; then
+  ALT="${SITE_URL/www./}"
+else
+  SCHEME="${SITE_URL%%://*}"
+  ALT="$SCHEME://www.$HOST"
+fi
+ALT_CODE=$(raw_status "$ALT")
+REDIR_OK=$([[ "$ALT_CODE" == "301" || "$ALT_CODE" == "308" ]] && echo 1 || echo 0)
+echo "$(mark "$REDIR_OK")www↔apex redirect → \`$ALT\` returns HTTP $ALT_CODE (want 301/308, not 307/302)"
+
+echo
+echo "_Production checks are opt-in (\`--prod\`) and probe a live site;" \
+     "transient network errors surface as non-200 codes above._"


### PR DESCRIPTION
Closes #600

## Changements

**Problème 1 — crash JSX/TSX dans `collect.sh`**
- Extraction des liens élargie aux formes Next.js / JSX / react-router : `<Link href="/x">`, `href={'/x'}`, `href={"/x"}`, `to="/x"` (avant : seulement `<a href="/x">`).
- Nouveau helper `to_json_array` : tous les `grep | jq -Rn '[inputs]'` passent par lui. Chaque `grep` susceptible de ne rien matcher est `|| true`-gardé → un fichier TSX sans `href` brut ne déclenche plus `pipefail` et ne corrompt plus `jq --argjson` (la cause du crash). Appliqué aussi aux blocs sitemap & keywords.

**Problème 2 — mode vérification production**
- Nouveau script `scripts/prod-check.sh` + flag `generate-report.sh --prod [url]` (opt-in, off par défaut).
- Résolution de l'URL : arg CLI → `$SITE_URL` → `site_url:`/`url:`/`production_url:` dans `.bsg/AUTOPILOT.yml`.
- Section `## Production checks` couvrant tous les critères d'acceptation : sitemap (200 + nb URLs), robots.txt (200 + `Sitemap:`), canonical absolue (home + 2 pages internes), types JSON-LD dans le HTML rendu, OG image (200), GA4/Pixel, pages piliers (échantillon sitemap, toutes 200), redirect www↔apex (301/308 vs 307/302).
- Robuste : aucune sortie réseau sans `--prod`, dégrade proprement (curl absent, URL introuvable, erreurs réseau → lignes `⚠️`, jamais de crash).

**Problème 3 — dépendance `_bsg-paths.sh`**
- `collect.sh` (et `prod-check.sh`) vérifient explicitement la présence de `_bsg-paths.sh` et sortent en erreur claire au lieu d'un crash silencieux mid-pipeline.
- `SKILL.md` : section `## Dependencies` documentant le path attendu, règle source-at-rest assouplie pour le `--prod` explicite, `prod-check.sh` ajouté au tableau des scripts.

## Test

- `bash -n` OK sur les 3 scripts.
- `collect.sh` produit du JSON valide sur ce repo et sur un cas stress JSX/TSX (`<Link href=`, `href={...}`, `to=`, + fichier sans aucun lien) — plus de crash, liens correctement extraits.
- `prod-check.sh` sans `--prod` : silencieux, exit 0 (comportement par défaut inchangé).
- `prod-check.sh --prod` sans URL : skip gracieux.
- Run live `--prod https://www.the-shift.ai` : tous les checks exécutés ; a détecté un vrai problème prod (apex `the-shift.ai` répond **307** au lieu de 301) — exactement le type de bug invisible en source-at-rest visé par l'issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)