### PR TITLE
fix(@seo): Next.js JSX/TSX link detection, jq robustness, opt-in --prod mode

### DIFF
--- a/claude-skills/skills/seo-report/SKILL.md
+++ b/claude-skills/skills/seo-report/SKILL.md
@@ -34,8 +34,11 @@ For a **full audit**, run `generate-report.sh`.
    script's output.
 2. **Always write the final report to `seo/reports/YYYY-MM-DD-*.md`**
    — dated and version-controllable.
-3. **Source-at-rest only.** No `curl`, no `wget` against production.
-   The skill analyzes templates and static files in this repo.
+3. **Source-at-rest by default.** No `curl`/`wget` against production
+   unless the operator explicitly opts in with `generate-report.sh
+   --prod`. The default audit analyzes templates and static files in
+   this repo only; `--prod` adds a clearly-labelled, read-only
+   `## Production checks` section (see "Production checks" below).
 4. **Respect `.seoignore`** (gitignore-style) for marketing-only
    landing pages that legitimately lack some tags.
 5. **Confirm before posting** to GitHub (issue comments, labels).
@@ -53,13 +56,18 @@ template fetch; reporters transform it.
 | `links.sh`            | Orphan detector + broken-link checker based on the adjacency list from `collect.sh`. |
 | `content.sh`          | Keyword coverage: for each entry in `seo/KEYWORDS.md`, find pages mentioning it in title or H1; emit `uncoveredKeywords[]` for the gaps. |
 | `technical.sh`        | Sitemap presence + page-coverage diff, robots.txt presence, canonical URL consistency. |
-| `generate-report.sh`  | Collects once, runs every reporter, composes the full markdown audit. |
+| `generate-report.sh`  | Collects once, runs every reporter, composes the full markdown audit. Accepts `--prod [url]` to append production checks. |
+| `prod-checks.sh`      | Opt-in. Read-only HTTP probes against the live site (sitemap/robots status, canonical absoluteness, JSON-LD types, OG image reachability, GA4/Pixel presence, pillar-page status, www-vs-apex redirect code). Emits a `## Production checks` markdown section. Always exits 0. |
 
 **Invocation patterns:**
 
 ```bash
-# Full audit
+# Full audit (source-at-rest only)
 bash scripts/generate-report.sh > seo/reports/$(date +%F)-audit.md
+
+# Full audit + production verification
+bash scripts/generate-report.sh --prod https://www.the-shift.ai \
+  > seo/reports/$(date +%F)-audit.md
 
 # Reuse one snapshot
 bash scripts/collect.sh > /tmp/seo-snap.json
@@ -78,6 +86,43 @@ seo/reports/2026-04-20-audit.md   # full audit
 seo/reports/2026-04-20-meta.md    # meta-only
 seo/reports/2026-04-20-links.md   # link-graph
 ```
+
+## Runtime layout
+
+Every collector sources the shared BSG path resolver to locate
+`KEYWORDS.md` (`.bsg/KEYWORDS.md` preferred, legacy `seo/KEYWORDS.md`
+fallback, per ADR-001). The resolver is **not** part of this skill
+directory — it lives three levels up:
+
+```
+<skills-root>/
+├── scripts/_bsg-paths.sh          ← resolver (REQUIRED)
+└── skills/seo-report/scripts/collect.sh   ← sources ../../../scripts/_bsg-paths.sh
+```
+
+When the skill is installed standalone (e.g. the Donna bucket on Clever
+Cloud) the resolver must be vendored alongside it at that relative
+path. If it is missing, `collect.sh` now fails fast with an explicit
+`ERROR: _bsg-paths.sh not found at <path>` instead of crashing
+silently.
+
+## Production checks
+
+Source-at-rest analysis cannot validate a live deployment (missing env
+vars, 404 OG image, 307-vs-301 host redirects, JSON-LD stripped at
+build, analytics that never shipped). `generate-report.sh --prod`
+appends a read-only `## Production checks` section.
+
+URL resolution order: `--prod <url>` arg → `SEO_SITE_URL` →
+`SITE_URL` → `site_url:` in `AUTOPILOT.yml`. If none resolve, the
+section reports "skipped" rather than failing the audit.
+
+Checks: sitemap/robots HTTP status (+ URL count, `Sitemap:` presence),
+canonical absoluteness on homepage + 2 sampled internal pages, JSON-LD
+`@type`s in rendered HTML, OG image reachability, GA4/Meta-Pixel
+presence, pillar-page status codes, and www-vs-apex redirect (expects
+301). `prod-checks.sh` always exits 0 so a flaky network never aborts
+`tick`.
 
 ## Tick action
 

--- a/claude-skills/skills/seo-report/scripts/collect.sh
+++ b/claude-skills/skills/seo-report/scripts/collect.sh
@@ -12,7 +12,28 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"
 
 # shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
-source "$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+BSG_PATHS="$(dirname "$0")/../../../scripts/_bsg-paths.sh"
+if [[ ! -f "$BSG_PATHS" ]]; then
+  echo "ERROR: _bsg-paths.sh not found at $BSG_PATHS" >&2
+  echo "  The seo-report skill expects the BSG path resolver three levels" >&2
+  echo "  up from this script (<skills-root>/scripts/_bsg-paths.sh). When the" >&2
+  echo "  skill is installed standalone (e.g. the Donna bucket) the resolver" >&2
+  echo "  must be vendored alongside it. See SKILL.md -> 'Runtime layout'." >&2
+  exit 1
+fi
+# shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+source "$BSG_PATHS"
+
+# Read newline-separated lines from stdin and emit a JSON array. Blank
+# lines are dropped. Always emits valid JSON (`[]` on empty input) and
+# always exits 0, so it is safe under `set -euo pipefail` even when the
+# upstream grep matched nothing. Previously the pattern
+# `grep ... | jq -Rn '[inputs]' || echo '[]'` double-emitted (`jq`
+# printed `[]`, then the failed pipeline triggered the `|| echo '[]'`)
+# producing `[]\n[]`, which `jq --argjson` rejects as invalid JSON.
+to_json_array() {
+  jq -Rn '[inputs | select(length > 0)]'
+}
 
 # -------------------------------------------- page file enumeration
 
@@ -62,13 +83,17 @@ while IFS= read -r f; do
   og_desc=$(grep -oEi '<meta[^>]*property="og:description"[^>]*>' "$f" 2>/dev/null | head -1 || true)
   og_image=$(grep -oEi '<meta[^>]*property="og:image"[^>]*>' "$f" 2>/dev/null | head -1 || true)
 
-  # Pull out internal link targets: href="/something" (not starting with http: or mailto: or tel:).
-  targets=$(grep -oE 'href="[^"]+"' "$f" 2>/dev/null \
-    | sed 's/href="//; s/"$//' \
-    | grep -E '^/' \
-    | grep -v '^#' \
+  # Pull out internal link targets rooted at "/". Matches plain HTML
+  # (href="/x"), Next.js / JSX <Link> expression containers
+  # (href={"/x"}, href={'/x'}, href={`/x`}) and single-quoted JSX
+  # (href='/x'). External (http:, mailto:, tel:) and in-page (#anchor)
+  # links are filtered out by the `^/` / `^#` guards below.
+  targets=$( { grep -oE 'href=\{?["'\''`]?/[^"'\''`<>} ]*' "$f" 2>/dev/null || true; } \
+    | sed -E 's/^href=\{?["'\''`]?//' \
+    | { grep -E '^/' || true; } \
+    | { grep -v '^#' || true; } \
     | sort -u \
-    | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+    | to_json_array )
 
   has_jsonld="false"
   if grep -qE 'type="application/ld\+json"' "$f" 2>/dev/null; then
@@ -120,9 +145,9 @@ ROBOTS_PATH=$(find_first robots.txt public/robots.txt static/robots.txt dist/rob
 
 SITEMAP_URLS_JSON='[]'
 if [[ -n "$SITEMAP_PATH" ]]; then
-  SITEMAP_URLS_JSON=$(grep -oE '<loc>[^<]+</loc>' "$SITEMAP_PATH" 2>/dev/null \
+  SITEMAP_URLS_JSON=$( { grep -oE '<loc>[^<]+</loc>' "$SITEMAP_PATH" 2>/dev/null || true; } \
     | sed -E 's|<loc>||; s|</loc>||' \
-    | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+    | to_json_array )
 fi
 
 ROBOTS_BLANKET="false"
@@ -137,9 +162,9 @@ fi
 KEYWORDS_PATH="$(bsg_doc_path keywords)"
 KEYWORDS_JSON='null'
 if [[ -f "$KEYWORDS_PATH" ]]; then
-  KEYWORDS_JSON=$({ grep -oE '^-[[:space:]]+.+' "$KEYWORDS_PATH" || true; } \
+  KEYWORDS_JSON=$( { grep -oE '^-[[:space:]]+.+' "$KEYWORDS_PATH" 2>/dev/null || true; } \
     | sed -E 's/^-[[:space:]]+//' \
-    | jq -Rn '[inputs]' 2>/dev/null || echo '[]')
+    | to_json_array )
 fi
 
 # ---------------------------------------------------------- emit

--- a/claude-skills/skills/seo-report/scripts/generate-report.sh
+++ b/claude-skills/skills/seo-report/scripts/generate-report.sh
@@ -1,9 +1,56 @@
 #!/usr/bin/env bash
 # generate-report.sh — compose the full SEO audit report.
+#
+# Usage:
+#   generate-report.sh                 source-at-rest audit only
+#   generate-report.sh --prod          + production checks, URL resolved
+#                                       from SEO_SITE_URL / SITE_URL /
+#                                       AUTOPILOT.yml `site_url:`
+#   generate-report.sh --prod <url>    + production checks against <url>
 
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# ---------------------------------------------------------- arg parsing
+
+PROD=0
+PROD_URL=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prod)
+      PROD=1
+      # Optional inline URL: `--prod https://...`
+      if [[ ${2:-} =~ ^https?:// ]]; then
+        PROD_URL="$2"
+        shift
+      fi
+      ;;
+    *)
+      echo "generate-report.sh: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# Resolve the production URL: explicit arg > env > AUTOPILOT.yml.
+if [[ "$PROD" -eq 1 && -z "$PROD_URL" ]]; then
+  PROD_URL="${SEO_SITE_URL:-${SITE_URL:-}}"
+fi
+if [[ "$PROD" -eq 1 && -z "$PROD_URL" ]]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  BSG_PATHS="$SCRIPT_DIR/../../../scripts/_bsg-paths.sh"
+  if [[ -f "$BSG_PATHS" ]]; then
+    # shellcheck source=../../../scripts/_bsg-paths.sh disable=SC1091
+    source "$BSG_PATHS"
+    AUTOPILOT="$REPO_ROOT/$BSG_AUTOPILOT_FILE"
+    if [[ -f "$AUTOPILOT" ]]; then
+      PROD_URL=$( { grep -oE '^[[:space:]]*site_url:[[:space:]]*\S+' "$AUTOPILOT" 2>/dev/null || true; } \
+        | head -1 | sed -E 's/^[[:space:]]*site_url:[[:space:]]*//; s/^["'\'']//; s/["'\'']$//' )
+    fi
+  fi
+fi
 
 SNAPSHOT=$(mktemp -t seo-snap.XXXXXX.json)
 trap 'rm -f "$SNAPSHOT"' EXIT
@@ -109,3 +156,12 @@ $(jq -r '
 ' <<<"$TECH")
 
 EOF
+
+if [[ "$PROD" -eq 1 ]]; then
+  echo
+  echo "---"
+  echo
+  # Non-fatal: a failing prod-checks.sh must not abort the audit.
+  bash "$SCRIPT_DIR/prod-checks.sh" "$PROD_URL" || \
+    echo "_Production checks failed to run (see logs); source-at-rest audit above is unaffected._"
+fi

--- a/claude-skills/skills/seo-report/scripts/prod-checks.sh
+++ b/claude-skills/skills/seo-report/scripts/prod-checks.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# prod-checks.sh — opt-in production verification for the SEO audit.
+#
+# Source-at-rest analysis (collect.sh) cannot tell what is actually
+# deployed: missing env vars, 404 on the OG image, 307-vs-301 host
+# redirects, JSON-LD that exists in source but is stripped at build,
+# analytics that never shipped. This script makes a small number of
+# targeted, read-only HTTP requests against the live site and emits a
+# `## Production checks` markdown section for generate-report.sh.
+#
+# It is OPT-IN (never runs during the default source-at-rest audit) and
+# NON-FATAL: any failure degrades to a reported warning rather than
+# aborting the report, so `@seo tick` stays robust.
+#
+# Usage:
+#   bash prod-checks.sh https://www.example.com
+#
+# Exit code is always 0 — findings are in the markdown, not the status.
+
+set -uo pipefail
+
+UA='bsg-seo-report/1.0 (+https://github.com/beyond-scale-group/bsg-stack)'
+CONNECT_TIMEOUT=10
+MAX_TIME=20
+
+emit_section_header() { printf '## Production checks\n\n'; }
+
+BASE="${1:-}"
+
+if [[ -z "$BASE" ]]; then
+  emit_section_header
+  printf '_Skipped: no production URL resolved (pass `--prod <url>`, or set '
+  printf '`SEO_SITE_URL`/`SITE_URL`, or add `site_url:` to AUTOPILOT.yml)._\n'
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  emit_section_header
+  printf '_Skipped: `curl` is not available in this environment._\n'
+  exit 0
+fi
+
+# Normalise: strip trailing slash, ensure scheme.
+BASE="${BASE%/}"
+[[ "$BASE" =~ ^https?:// ]] || BASE="https://$BASE"
+
+# host without scheme, and the apex/www counterpart for the redirect check.
+HOST="${BASE#*://}"
+HOST="${HOST%%/*}"
+SCHEME="${BASE%%://*}"
+if [[ "$HOST" == www.* ]]; then
+  ALT_HOST="${HOST#www.}"
+else
+  ALT_HOST="www.$HOST"
+fi
+
+# ----------------------------------------------------------- http helpers
+
+# http_status URL -> "000" on transport failure, else the HTTP code.
+# curl already prints "000" on connection failure; capture once and
+# default — appending `|| echo 000` would double-emit ("000000").
+http_status() {
+  local c
+  c=$(curl -s -o /dev/null -w '%{http_code}' -A "$UA" -L \
+    --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+    "$1" 2>/dev/null)
+  printf '%s' "${c:-000}"
+}
+
+# http_body URL -> response body (follows redirects).
+http_body() {
+  curl -sS -A "$UA" -L \
+    --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+    "$1" 2>/dev/null || true
+}
+
+# redirect_status URL -> "<code> <location>" WITHOUT following redirects.
+redirect_status() {
+  local out code loc
+  out=$(curl -s -o /dev/null \
+    -w '%{http_code} %{redirect_url}' -A "$UA" \
+    --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+    "$1" 2>/dev/null)
+  out="${out:-000 }"
+  code="${out%% *}"
+  loc="${out#* }"
+  printf '%s|%s' "$code" "$loc"
+}
+
+ok() { [[ "$1" == "200" ]] && printf 'ok' || printf '**HTTP %s**' "$1"; }
+
+# --------------------------------------------------------- sitemap / robots
+
+SITEMAP_URL="$BASE/sitemap.xml"
+ROBOTS_URL="$BASE/robots.txt"
+
+SITEMAP_CODE=$(http_status "$SITEMAP_URL")
+SITEMAP_BODY=""
+SITEMAP_COUNT=0
+if [[ "$SITEMAP_CODE" == "200" ]]; then
+  SITEMAP_BODY=$(http_body "$SITEMAP_URL")
+  SITEMAP_COUNT=$(printf '%s' "$SITEMAP_BODY" | grep -c '<loc>' 2>/dev/null || true)
+  SITEMAP_COUNT=${SITEMAP_COUNT:-0}
+fi
+
+ROBOTS_CODE=$(http_status "$ROBOTS_URL")
+ROBOTS_HAS_SITEMAP="no"
+if [[ "$ROBOTS_CODE" == "200" ]]; then
+  if http_body "$ROBOTS_URL" | grep -qiE '^[[:space:]]*sitemap:' 2>/dev/null; then
+    ROBOTS_HAS_SITEMAP="yes"
+  fi
+fi
+
+# --------------------------------------------------- homepage-derived data
+
+HOME_BODY=$(http_body "$BASE/")
+HOME_CODE=$(http_status "$BASE/")
+
+# Canonical: prefer rel="canonical" link; must be an absolute URL.
+extract_canonical() {
+  printf '%s' "$1" \
+    | grep -oiE '<link[^>]*rel=["'\'']canonical["'\''][^>]*>' 2>/dev/null \
+    | head -1 \
+    | grep -oiE 'href=["'\''][^"'\'']*["'\'']' 2>/dev/null \
+    | head -1 \
+    | sed -E 's/^href=["'\'']//; s/["'\'']$//' || true
+}
+
+HOME_CANONICAL=$(extract_canonical "$HOME_BODY")
+if [[ -z "$HOME_CANONICAL" ]]; then
+  HOME_CANON_STATUS='**missing**'
+elif [[ "$HOME_CANONICAL" =~ ^https?:// ]]; then
+  HOME_CANON_STATUS="absolute (\`$HOME_CANONICAL\`)"
+else
+  HOME_CANON_STATUS="**relative** (\`$HOME_CANONICAL\`)"
+fi
+
+# JSON-LD @type values present in the rendered HTML.
+JSONLD_TYPES=$(printf '%s' "$HOME_BODY" \
+  | grep -oiE '"@type"[[:space:]]*:[[:space:]]*"[^"]+"' 2>/dev/null \
+  | sed -E 's/.*:[[:space:]]*"//; s/"$//' \
+  | sort -u | paste -sd ',' - 2>/dev/null || true)
+[[ -n "$JSONLD_TYPES" ]] || JSONLD_TYPES=""
+
+# OG image URL + reachability.
+OG_IMAGE=$(printf '%s' "$HOME_BODY" \
+  | grep -oiE '<meta[^>]*property=["'\'']og:image["'\''][^>]*>' 2>/dev/null \
+  | head -1 \
+  | grep -oiE 'content=["'\''][^"'\'']*["'\'']' 2>/dev/null \
+  | sed -E 's/^content=["'\'']//; s/["'\'']$//' || true)
+OG_STATUS='**missing**'
+if [[ -n "$OG_IMAGE" ]]; then
+  [[ "$OG_IMAGE" =~ ^https?:// ]] || OG_IMAGE="$BASE/${OG_IMAGE#/}"
+  OG_CODE=$(http_status "$OG_IMAGE")
+  OG_STATUS="$(ok "$OG_CODE")"
+fi
+
+# Analytics: GA4 / Meta Pixel signatures in rendered HTML.
+ANALYTICS=()
+if printf '%s' "$HOME_BODY" | grep -qiE 'googletagmanager\.com/gtag/js|gtag\(|G-[A-Z0-9]{6,}' 2>/dev/null; then
+  ANALYTICS+=("GA4")
+fi
+if printf '%s' "$HOME_BODY" | grep -qiE 'connect\.facebook\.net|fbq\(' 2>/dev/null; then
+  ANALYTICS+=("Meta Pixel")
+fi
+if [[ ${#ANALYTICS[@]} -gt 0 ]]; then
+  ANALYTICS_STATUS="detected ($(IFS=,; echo "${ANALYTICS[*]}"))"
+else
+  ANALYTICS_STATUS='**none detected**'
+fi
+
+# ------------------------------------------- internal / pillar page checks
+
+# Derive a few internal pages from the live sitemap (excludes homepage).
+mapfile -t SITEMAP_URLS < <(printf '%s' "$SITEMAP_BODY" \
+  | grep -oE '<loc>[^<]+</loc>' 2>/dev/null \
+  | sed -E 's|<loc>||; s|</loc>||' \
+  | grep -vE "^${BASE}/?$" \
+  | head -5 || true)
+
+CANON_INTERNAL_ROWS=""
+checked=0
+for u in "${SITEMAP_URLS[@]:-}"; do
+  [[ -z "$u" ]] && continue
+  [[ $checked -ge 2 ]] && break
+  body=$(http_body "$u")
+  c=$(extract_canonical "$body")
+  if [[ -z "$c" ]]; then
+    st='**missing**'
+  elif [[ "$c" =~ ^https?:// ]]; then
+    st='absolute'
+  else
+    st='**relative**'
+  fi
+  CANON_INTERNAL_ROWS+="| Canonical — \`$u\` | $st |"$'\n'
+  checked=$((checked + 1))
+done
+[[ -n "$CANON_INTERNAL_ROWS" ]] || CANON_INTERNAL_ROWS="| Canonical — internal pages | _no sitemap URLs to sample_ |"$'\n'
+
+PILLAR_ROWS=""
+PILLAR_FAIL=0
+PILLAR_TARGETS=("$BASE/")
+for u in "${SITEMAP_URLS[@]:-}"; do
+  [[ -z "$u" ]] && continue
+  PILLAR_TARGETS+=("$u")
+done
+for u in "${PILLAR_TARGETS[@]}"; do
+  code=$(http_status "$u")
+  [[ "$code" == "200" ]] || PILLAR_FAIL=$((PILLAR_FAIL + 1))
+  PILLAR_ROWS+="| \`$u\` | $(ok "$code") |"$'\n'
+done
+
+# www vs apex: hitting the non-canonical host should 301 (not 307/302).
+ALT_URL="$SCHEME://$ALT_HOST/"
+REDIR=$(redirect_status "$ALT_URL")
+REDIR_CODE="${REDIR%%|*}"
+REDIR_LOC="${REDIR#*|}"
+if [[ "$REDIR_CODE" == "301" ]]; then
+  REDIR_STATUS="301 → \`${REDIR_LOC:-?}\`"
+elif [[ "$REDIR_CODE" =~ ^30[0-9]$ ]]; then
+  REDIR_STATUS="**$REDIR_CODE (expected 301)** → \`${REDIR_LOC:-?}\`"
+elif [[ "$REDIR_CODE" == "200" ]]; then
+  REDIR_STATUS="**200 (no redirect — duplicate host)**"
+else
+  REDIR_STATUS="**HTTP $REDIR_CODE**"
+fi
+
+# ------------------------------------------------------------------- emit
+
+emit_section_header
+
+printf '_Live checks against `%s` (read-only, opt-in)._\n\n' "$BASE"
+
+printf '| Check | Result |\n|-------|--------|\n'
+printf '| Homepage | %s |\n' "$(ok "$HOME_CODE")"
+printf '| sitemap.xml | %s%s |\n' "$(ok "$SITEMAP_CODE")" \
+  "$( [[ "$SITEMAP_CODE" == "200" ]] && printf ' — %s URLs' "$SITEMAP_COUNT" )"
+printf '| robots.txt | %s%s |\n' "$(ok "$ROBOTS_CODE")" \
+  "$( [[ "$ROBOTS_CODE" == "200" ]] && { [[ "$ROBOTS_HAS_SITEMAP" == "yes" ]] && printf ' — Sitemap: present' || printf ' — **Sitemap: missing**'; } )"
+printf '| Canonical — homepage | %s |\n' "$HOME_CANON_STATUS"
+printf '%s' "$CANON_INTERNAL_ROWS"
+printf '| JSON-LD types | %s |\n' "$( [[ -n "$JSONLD_TYPES" ]] && printf '%s' "$JSONLD_TYPES" || printf '**none detected**' )"
+printf '| OG image | %s%s |\n' "$OG_STATUS" \
+  "$( [[ -n "$OG_IMAGE" ]] && printf ' (`%s`)' "$OG_IMAGE" )"
+printf '| Analytics | %s |\n' "$ANALYTICS_STATUS"
+printf '| www vs apex redirect | %s |\n' "$REDIR_STATUS"
+
+printf '\n### Pillar pages\n\n'
+printf '| Page | Status |\n|------|--------|\n'
+printf '%s' "$PILLAR_ROWS"
+if [[ "$PILLAR_FAIL" -gt 0 ]]; then
+  printf '\n**%s pillar page(s) did not return HTTP 200.**\n' "$PILLAR_FAIL"
+fi
+
+exit 0


### PR DESCRIPTION
Closes #600

## Changes

**Problem 1 — `jq: invalid JSON text passed to --argjson`**
- Root cause: under `set -euo pipefail`, a `grep` matching nothing failed the pipeline, so `|| echo '[]'` fired *after* `jq` had already emitted `[]` → `[]\n[]` passed to `--argjson` (invalid JSON).
- Replaced the fragile `grep … | jq -Rn '[inputs]' … || echo '[]'` pattern with a `to_json_array` helper (guarded greps, always-valid JSON, always exit 0) on the targets / sitemap / keywords pipelines in `collect.sh`.
- Broadened internal-link detection to Next.js / JSX `href` forms: `href={"/x"}`, `href={'/x'}`, `` href={`/x`} ``, `href='/x'` (previously only `href="/x"`).

**Problem 2 — no production verification mode**
- New `scripts/prod-checks.sh`: opt-in, read-only HTTP probes — sitemap/robots status (+ URL count, `Sitemap:` presence), canonical absoluteness (homepage + 2 sampled internal pages), JSON-LD `@type`s in rendered HTML, OG-image reachability, GA4/Meta-Pixel detection, pillar-page status codes, www-vs-apex redirect (expects 301). Always exits 0.
- `generate-report.sh --prod [url]` appends a clearly-labelled `## Production checks` section. URL resolves: arg → `SEO_SITE_URL` → `SITE_URL` → `site_url:` in `AUTOPILOT.yml`. Non-fatal so `@seo tick` stays robust.

**Problem 3 — missing `_bsg-paths.sh` crashed silently**
- `collect.sh` now fails fast with an explicit `ERROR: _bsg-paths.sh not found at <path>` instead of crashing silently in standalone installs (e.g. Donna bucket).
- Expected runtime layout documented in `SKILL.md` (new "Runtime layout" section); hard-rule #3 amended to allow the explicit `--prod` opt-in.

## Test

- `bash -n` on all modified/new scripts — clean.
- `collect.sh` on a synthetic Next.js repo with zero raw `href` links: no `--argjson` crash; `internalLinks: []`; `href={"/contact"}` correctly detected.
- `prod-checks.sh` with no URL → "skipped" note (exit 0); with unreachable host → `HTTP 000` (no double-emit), exit 0.
- `generate-report.sh --prod` → full audit + `## Production checks` section.
- Test suites pass: `test_consumers_use_resolver.sh` (7/7), `test_skill_invariants.py` (5/5), `test_skills.py` (17/17), `test_tick_fingerprint.sh` (7/7). (`test_init_scripts.sh` has a pre-existing unbound-variable bug unrelated to this change, not run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)