### PR TITLE
feat(bsg-stack): ship tech-lead + qa --init scripts (part of #237)

### DIFF
--- a/claude-skills/skills/bsg-stack/SKILL.md
+++ b/claude-skills/skills/bsg-stack/SKILL.md
@@ -116,8 +116,8 @@ the staleness threshold (default: 90 days, override with
 for explicit human diff + merge — `update` never overwrites a
 committed custom doc directly.
 
-Agents whose `--init` script hasn't shipped yet (po-manager, tech-lead,
-qa, md-to-office) are silently skipped during `init`/`update` and
+Agents whose `--init` script hasn't shipped yet (md-to-office's
+`.bsg/DESIGN.md`) are silently skipped during `init`/`update` and
 re-listed as missing in `doctor`'s scorecard. As each script lands,
 the orchestrator picks it up automatically — no SKILL.md edit needed.
 

--- a/claude-skills/skills/bsg-stack/scripts/init.sh
+++ b/claude-skills/skills/bsg-stack/scripts/init.sh
@@ -91,6 +91,8 @@ init_script_for() {
     pr-comms)      echo "skills/pr-comms-report/scripts/init-announced.sh" ;;
     security)      echo "skills/security-report/scripts/init-securityignore.sh" ;;
     storytelling)  echo "skills/storytelling-report/scripts/init-narrative.sh" ;;
+    tech-lead)     echo "skills/tech-report/scripts/init-adr.sh" ;;
+    qa)            echo "skills/qa-report/scripts/init-baseline.sh" ;;
     *)             echo "" ;;
   esac
 }
@@ -104,6 +106,8 @@ output_path_for() {
     pr-comms)      echo ".bsg/ANNOUNCED.md" ;;
     security)      echo ".bsg/SECURITYIGNORE" ;;
     storytelling)  echo ".bsg/NARRATIVE.md" ;;
+    tech-lead)     echo ".bsg/adr/000-architecture-baseline.md" ;;
+    qa)            echo ".bsg/reports/qa/baseline.md" ;;
     *)             echo "" ;;
   esac
 }

--- a/claude-skills/skills/qa-report/scripts/init-baseline.sh
+++ b/claude-skills/skills/qa-report/scripts/init-baseline.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# init-baseline.sh — generate a baseline QA snapshot from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for test
+# files, test frameworks, and CI coverage artifacts, then emits a
+# draft QA baseline to stdout. The orchestrator (`/bsg-stack init`)
+# captures stdout and writes it to `.bsg/reports/qa/baseline.md`, then
+# opens a PR for human review. This script never writes to disk.
+#
+# Usage:
+#   bash init-baseline.sh           # auto-scan current repo
+#   bash init-baseline.sh --repo OWNER/NAME
+#
+# Exit 0 + content on stdout: success
+# Exit 0 + minimal stub on stdout: no test signals found
+# Exit 1: error (missing tool, no gh auth, etc.)
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-baseline.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+repo_name="unknown"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view "${REPO_FLAG[@]}" --json name --jq '.name' 2>/dev/null || echo "unknown")
+fi
+if [[ "$repo_name" == "unknown" || -z "$repo_name" ]]; then
+  repo_name=$(basename "$REPO_ROOT")
+fi
+
+# ----------------------------------------------- signal collection
+
+# Count test files by common naming conventions.
+test_count=$(find . -type f \
+  \( -name '*_test.go' -o -name '*.test.js' -o -name '*.test.ts' \
+     -o -name '*.spec.js' -o -name '*.spec.ts' -o -name 'test_*.py' \
+     -o -name '*_test.py' -o -name '*Test.java' -o -name '*_spec.rb' \) \
+  -not -path './.git/*' -not -path './node_modules/*' 2>/dev/null | wc -l | tr -d ' ')
+
+# Detect test framework / runner configuration.
+declare -a frameworks
+[[ -f jest.config.js || -f jest.config.ts ]] && frameworks+=("Jest")
+grep -qs '"jest"' package.json 2>/dev/null && frameworks+=("Jest (package.json)")
+[[ -f pytest.ini || -f tox.ini ]] && frameworks+=("pytest")
+grep -qs '\[tool.pytest' pyproject.toml 2>/dev/null && frameworks+=("pytest (pyproject.toml)")
+[[ -f vitest.config.ts || -f vitest.config.js ]] && frameworks+=("Vitest")
+[[ -d spec ]] && frameworks+=("RSpec (spec/)")
+
+# Coverage artifacts / config.
+declare -a coverage
+[[ -f lcov.info || -f coverage/lcov.info ]] && coverage+=("lcov.info")
+[[ -f .coveragerc ]] && coverage+=(".coveragerc")
+[[ -f coverage.xml ]] && coverage+=("coverage.xml")
+[[ -d coverage ]] && coverage+=("coverage/ directory")
+[[ -d htmlcov ]] && coverage+=("htmlcov/ directory")
+
+# CI presence.
+ci="none detected"
+[[ -d .github/workflows ]] && ci="GitHub Actions (.github/workflows/)"
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# QA baseline — ${repo_name}
+
+_Draft bootstrapped ${today}. This is a first-tick snapshot, not a
+graded report. The qa agent reads this directory every tick and
+appends dated audits alongside it (\`.bsg/reports/qa/YYYY-MM-DD-audit.md\`).
+Use this baseline to track whether coverage and risk move in the right
+direction over time._
+
+## Test inventory
+
+- **Test files detected:** ${test_count}
+HEAD
+
+if [[ ${#frameworks[@]} -gt 0 ]]; then
+  printf -- '- **Frameworks / runners:** %s\n' "$(printf '%s, ' "${frameworks[@]}" | sed 's/, $//')"
+else
+  printf -- '- **Frameworks / runners:** _none detected — document the test setup manually._\n'
+fi
+echo "- **CI:** $ci"
+
+printf '\n## Coverage artifacts\n\n'
+if [[ ${#coverage[@]} -gt 0 ]]; then
+  for c in "${coverage[@]}"; do echo "- \`$c\`"; done
+else
+  echo "- _No coverage artifacts found. Wire up coverage in CI so the qa agent can track trends._"
+fi
+
+cat <<'TAIL'
+
+## Risk hotspots
+
+_The qa agent fills this on each tick: high-churn + low-coverage files
+ranked by regression risk. Leave it empty on first commit._
+
+## Notes
+
+_Anything a reviewer should know about the test strategy: known gaps,
+deliberately untested areas, flaky suites to watch._
+TAIL

--- a/claude-skills/skills/tech-report/scripts/init-adr.sh
+++ b/claude-skills/skills/tech-report/scripts/init-adr.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# init-adr.sh — generate a starter architecture-baseline ADR from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for stack
+# signals — primary language, major dependency manifests, and CI
+# workflows — then emits a draft architecture-baseline ADR to stdout.
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it to
+# `.bsg/adr/000-architecture-baseline.md`, then opens a PR for human
+# review. This script never writes to disk.
+#
+# Usage:
+#   bash init-adr.sh                # auto-scan current repo
+#   bash init-adr.sh --repo OWNER/NAME
+#
+# Exit 0 + content on stdout: success
+# Exit 0 + minimal stub on stdout: no strong signals found
+# Exit 1: error (missing tool, no gh auth, etc.)
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-adr.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signal collection
+
+repo_name="unknown"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view "${REPO_FLAG[@]}" --json name --jq '.name' 2>/dev/null || echo "unknown")
+fi
+if [[ "$repo_name" == "unknown" || -z "$repo_name" ]]; then
+  repo_name=$(basename "$REPO_ROOT")
+fi
+
+# Detect dependency manifests → infer the primary stack.
+declare -a manifests
+[[ -f package.json ]]      && manifests+=("Node.js / npm (package.json)")
+[[ -f requirements.txt ]]  && manifests+=("Python (requirements.txt)")
+[[ -f pyproject.toml ]]    && manifests+=("Python (pyproject.toml)")
+[[ -f go.mod ]]            && manifests+=("Go (go.mod)")
+[[ -f Cargo.toml ]]        && manifests+=("Rust (Cargo.toml)")
+[[ -f composer.json ]]     && manifests+=("PHP (composer.json)")
+[[ -f Gemfile ]]           && manifests+=("Ruby (Gemfile)")
+[[ -f pom.xml ]]           && manifests+=("Java / Maven (pom.xml)")
+
+# A few headline dependencies from package.json, if present.
+declare -a deps
+if [[ -f package.json ]] && command -v jq >/dev/null 2>&1; then
+  while IFS= read -r d; do
+    [[ -n "$d" ]] && deps+=("$d")
+  done < <(jq -r '(.dependencies // {}) | keys[]' package.json 2>/dev/null | head -8)
+fi
+
+# CI workflows.
+declare -a workflows
+if [[ -d .github/workflows ]]; then
+  while IFS= read -r wf; do
+    workflows+=("$(basename "$wf")")
+  done < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | sort | head -10)
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# ADR-000 — Architecture baseline (${repo_name})
+
+_Draft bootstrapped ${today}. This is a **starting point**, not a
+decision record yet. Review the detected signals below, correct them,
+and split distinct decisions into their own numbered ADRs
+(\`.bsg/adr/001-*.md\`, …). The tech-lead agent reads this directory
+every tick to detect undocumented decisions._
+
+- **Status:** draft (auto-bootstrapped)
+- **Date:** ${today}
+- **Deciders:** _add the humans who own these decisions_
+
+## Context
+
+This baseline captures the stack as it exists today so future ADRs
+have a reference point. Replace the inferred notes below with the
+real architectural context.
+
+## Detected stack
+HEAD
+
+if [[ ${#manifests[@]} -gt 0 ]]; then
+  printf '\n'
+  for m in "${manifests[@]}"; do echo "- $m"; done
+else
+  printf '\n- _No dependency manifest detected — document the stack manually._\n'
+fi
+
+if [[ ${#deps[@]} -gt 0 ]]; then
+  printf '\n### Headline dependencies\n\n'
+  for d in "${deps[@]}"; do echo "- \`$d\`"; done
+fi
+
+printf '\n## CI / automation\n\n'
+if [[ ${#workflows[@]} -gt 0 ]]; then
+  for w in "${workflows[@]}"; do echo "- \`.github/workflows/$w\`"; done
+else
+  echo "- _No GitHub Actions workflows detected._"
+fi
+
+cat <<'TAIL'
+
+## Decision
+
+_Record the first real architectural decision here, or delete this
+ADR-000 once the genuine ADRs (001, 002, …) cover the ground. Each
+ADR should state one decision, its alternatives, and its consequences._
+
+## Consequences
+
+_What becomes easier or harder because of the baseline above._
+TAIL

--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -63,6 +63,8 @@ check_script "claude-skills/skills/marketing-report/scripts/init-calendar.sh"
 check_script "claude-skills/skills/pr-comms-report/scripts/init-announced.sh"
 check_script "claude-skills/skills/security-report/scripts/init-securityignore.sh"
 check_script "claude-skills/skills/storytelling-report/scripts/init-narrative.sh"
+check_script "claude-skills/skills/tech-report/scripts/init-adr.sh"
+check_script "claude-skills/skills/qa-report/scripts/init-baseline.sh"
 
 echo ""
 echo "PASS: $PASS, FAIL: $FAIL"


### PR DESCRIPTION
Part of #237 — implementation order step 3 (per-agent `--init`).

`#237` is a 12-PR epic; most has already landed (`.bsg/` convention,
`custom-doc:`/`init:` frontmatter + `test_skills.py` enforcement, the
`/bsg-stack` skill). The remaining concrete gap was the per-agent
`--init` scripts the orchestrator flagged as not-yet-shipped. This PR
closes two of them; only md-to-office's `.bsg/DESIGN.md` (separate
PR 11) remains.

## Changes
- **New** `claude-skills/skills/tech-report/scripts/init-adr.sh` — scans
  dependency manifests, headline deps, CI workflows; emits a draft
  `.bsg/adr/000-architecture-baseline.md` to stdout.
- **New** `claude-skills/skills/qa-report/scripts/init-baseline.sh` —
  scans test files, frameworks, coverage artifacts; emits a draft
  `.bsg/reports/qa/baseline.md` to stdout.
- Both follow the existing stdout-only init contract (`init-keywords.sh`):
  never write to disk, `--help` exits 0, always emit a non-empty draft.
- Wired both into the `/bsg-stack init` orchestrator (`init_script_for`
  + `output_path_for`).
- Registered both in `test_init_scripts.sh` contract guard.
- Refreshed a stale `SKILL.md` note (po-manager already wired to
  `bootstrap-plan.sh`; only md-to-office DESIGN.md pending).

## Test
- `python3 claude-skills/tests/test_skills.py` — 17/17 OK.
- Manual contract verification in an empty `git init` repo: `--help`
  exits 0, stdout > 50 bytes, zero cwd writes.
- `init.sh --dry-run --no-labels` now resolves `tech-lead` and `qa` to
  their `.bsg/` paths (only `cleaner`, no custom-doc, remains no-init).

> Note: `test_init_scripts.sh` has a pre-existing Linux portability
> issue (`stat -f`/`set -u`) that fails before reaching any script row —
> reproduced with this PR's changes stashed. Left out-of-scope; contract
> verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)