### PR TITLE
fix(bsg-paths): DESIGN.md has no legacy fallback (ADR-003)

### DIFF
--- a/claude-skills/scripts/_bsg-paths.sh
+++ b/claude-skills/scripts/_bsg-paths.sh
@@ -39,7 +39,7 @@ bsg_doc_path() {
     calendar)      new=".bsg/CALENDAR.md";      legacy="marketing/CALENDAR.md" ;;
     announced)     new=".bsg/ANNOUNCED.md";     legacy="comms/ANNOUNCED.md" ;;
     securityignore) new=".bsg/SECURITYIGNORE";  legacy=".securityignore" ;;
-    design)        new=".bsg/DESIGN.md";        legacy="brand/DESIGN.md" ;;
+    design)        new=".bsg/DESIGN.md";        legacy="" ;;  # net-new, ADR-003 (no legacy path)
     adr)           new=".bsg/adr";              legacy="adr" ;;
     brand)         new=".bsg/brand";            legacy="brand" ;;
     reports)       new=".bsg/reports";          legacy="" ;;

--- a/claude-skills/tests/test_bsg_paths.sh
+++ b/claude-skills/tests/test_bsg_paths.sh
@@ -83,6 +83,16 @@ out="$(cd "$tmp" && bash -c "source $SUT; bsg_doc_path plan")"
 assert_eq "both present: .bsg/ wins" ".bsg/PLAN.md" "$out"
 rm -rf "$tmp"
 
+# 4b. DESIGN.md is net-new (ADR-003): it has NO legacy path, so even
+#     when a stray brand/DESIGN.md exists the resolver must still
+#     return .bsg/DESIGN.md rather than falling back to it.
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/brand"
+touch "$tmp/brand/DESIGN.md"
+out="$(cd "$tmp" && bash -c "source $SUT; bsg_doc_path design")"
+assert_eq "design: no legacy fallback (ADR-003 net-new)" ".bsg/DESIGN.md" "$out"
+rm -rf "$tmp"
+
 # 5. Unknown doc kind → rc=2.
 set +e
 out="$(bash -c "source $SUT; bsg_doc_path bogus" 2>&1)"


### PR DESCRIPTION
Refs #237 (deliverable #1 / ADR-003)

## Context

#237 is a large multi-PR epic. The core infrastructure (`.bsg/`
convention, `_bsg-paths.sh` resolver, `bsg-stack` skill, `custom-doc:`
/ `init:` frontmatter + `test_agent_frontmatter.py` enforcement,
ADRs 001–003, `MIGRATION-bsg-paths.md`) is already in place. This PR
is a small, self-contained correctness fix surfaced while reviewing
the resolver — it does **not** attempt the remaining per-agent
`--init` deliverables (PRs 3–12), which still need their own PRs.

## The bug

`claude-skills/scripts/_bsg-paths.sh` resolved the `design` doc kind
with `legacy="brand/DESIGN.md"`. But per **ADR-003** and the
**MIGRATION-bsg-paths.md** table, `.bsg/DESIGN.md` is a *net-new*
artifact — it is explicitly listed as "(new — ADR-003)" with **no**
legacy path (the prior brand artifact is `brand/tokens.json`,
covered by the separate `brand` kind).

Consequence: in any consumer repo that happens to contain a
`brand/DESIGN.md` (not part of any BSG convention), the resolver
returned that path instead of `.bsg/DESIGN.md`, silently misdirecting
md-to-office / frontend-design / storytelling away from the canonical
design system file.

## Changes

- `_bsg-paths.sh`: `design` now uses `legacy=""` (same treatment as
  the other net-new kind, `reports`), so it always resolves to
  `.bsg/DESIGN.md`.
- `tests/test_bsg_paths.sh`: new regression test — with a stray
  `brand/DESIGN.md` present, `bsg_doc_path design` must still return
  `.bsg/DESIGN.md`.

## Test

```
bash claude-skills/tests/test_bsg_paths.sh
# PASS: 20, FAIL: 0  (includes the new "design: no legacy fallback" case)
```

`bash -n` clean on both files.