### PR TITLE
feat: --init scripts for tech-lead and qa agents (#237)

### DIFF
--- a/claude-skills/skills/bsg-stack/SKILL.md
+++ b/claude-skills/skills/bsg-stack/SKILL.md
@@ -116,10 +116,12 @@ the staleness threshold (default: 90 days, override with
 for explicit human diff + merge — `update` never overwrites a
 committed custom doc directly.
 
-Agents whose `--init` script hasn't shipped yet (po-manager, tech-lead,
-qa, md-to-office) are silently skipped during `init`/`update` and
-re-listed as missing in `doctor`'s scorecard. As each script lands,
-the orchestrator picks it up automatically — no SKILL.md edit needed.
+`md-to-office` self-hosts its `--init` (the `md-to-office.sh --init`
+flag, not a generic `init-*.sh`) so it is not driven by this
+orchestrator. Any other agent whose `--init` script hasn't shipped
+yet is silently skipped during `init`/`update` and re-listed as
+missing in `doctor`'s scorecard. As each script lands, the
+orchestrator picks it up automatically — no SKILL.md edit needed.
 
 ## What `bsg-stack` does NOT do
 

--- a/claude-skills/skills/bsg-stack/scripts/init.sh
+++ b/claude-skills/skills/bsg-stack/scripts/init.sh
@@ -91,6 +91,8 @@ init_script_for() {
     pr-comms)      echo "skills/pr-comms-report/scripts/init-announced.sh" ;;
     security)      echo "skills/security-report/scripts/init-securityignore.sh" ;;
     storytelling)  echo "skills/storytelling-report/scripts/init-narrative.sh" ;;
+    tech-lead)     echo "skills/tech-report/scripts/init-adr.sh" ;;
+    qa)            echo "skills/qa-report/scripts/init-qa-baseline.sh" ;;
     *)             echo "" ;;
   esac
 }
@@ -104,6 +106,8 @@ output_path_for() {
     pr-comms)      echo ".bsg/ANNOUNCED.md" ;;
     security)      echo ".bsg/SECURITYIGNORE" ;;
     storytelling)  echo ".bsg/NARRATIVE.md" ;;
+    tech-lead)     echo ".bsg/adr/0000-architecture-baseline.md" ;;
+    qa)            echo ".bsg/reports/qa/0000-baseline.md" ;;
     *)             echo "" ;;
   esac
 }

--- a/claude-skills/skills/qa-report/scripts/init-qa-baseline.sh
+++ b/claude-skills/skills/qa-report/scripts/init-qa-baseline.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# init-qa-baseline.sh — generate a draft QA baseline from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for test
+# files and CI coverage artifacts and emits a draft baseline QA
+# snapshot to stdout. The qa agent reads `.bsg/reports/qa/` every
+# tick to track coverage trends and regression risk against a known
+# starting point.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it
+# to `.bsg/reports/qa/0000-baseline.md`, then opens a PR for human
+# review — this script never writes to disk.
+#
+# Usage:
+#   bash init-qa-baseline.sh
+#
+# Exit 0 + content on stdout: success
+# Exit 2: bad arguments
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-qa-baseline.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signals
+
+# 1. Test files — count by common naming conventions, skipping vendored
+#    trees so the number reflects first-party tests.
+test_count=$(find . -type f \
+  -not -path './.git/*' -not -path './node_modules/*' \
+  -not -path './vendor/*' -not -path './.venv/*' \( \
+    -name '*_test.go' -o -name 'test_*.py' -o -name '*_test.py' \
+    -o -name '*.test.js' -o -name '*.test.ts' -o -name '*.test.jsx' \
+    -o -name '*.test.tsx' -o -name '*.spec.js' -o -name '*.spec.ts' \
+    -o -name '*Test.java' -o -name '*_spec.rb' \
+  \) 2>/dev/null | wc -l | tr -d ' ')
+
+# Top-level directories that look like test roots.
+test_dirs=$(find . -maxdepth 2 -type d \
+  -not -path './.git/*' -not -path './node_modules/*' \( \
+    -name 'tests' -o -name 'test' -o -name '__tests__' -o -name 'spec' \
+  \) 2>/dev/null | sed 's|^\./||' | sort -u | head -10 \
+  | awk 'NR>1{printf ", "}{printf "%s",$0}END{if(NR)print ""}')
+
+# 2. CI coverage artifacts — the qa agent parses these every tick.
+COVERAGE=()
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  COVERAGE+=("${f#./}")
+done < <(find . -maxdepth 3 -type f \
+  -not -path './.git/*' -not -path './node_modules/*' \( \
+    -name 'lcov.info' -o -name 'coverage-summary.json' \
+    -o -name 'coverage.xml' -o -name 'cobertura.xml' -o -name '.coverage' \
+  \) 2>/dev/null | head -10)
+
+# 3. CI setup that would produce those artifacts.
+ci_setup="_None detected — wire coverage upload in CI so the qa agent has a trend to track._"
+if [[ -d .github/workflows ]]; then
+  wf_count=$(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | wc -l | tr -d ' ')
+  ci_setup="GitHub Actions — ${wf_count} workflow file(s) under \`.github/workflows/\`."
+elif [[ -f .gitlab-ci.yml ]]; then
+  ci_setup="GitLab CI (\`.gitlab-ci.yml\`)."
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# QA baseline — bootstrapped ${today}
+
+_This snapshot was bootstrapped automatically from a repo scan. It is
+the **starting point** the qa agent measures future coverage and
+regression-risk trends against — review the numbers, correct anything
+the scan got wrong, and commit it to \`.bsg/reports/qa/0000-baseline.md\`._
+
+## Test inventory
+
+- **First-party test files detected:** ${test_count}
+- **Test roots:** ${test_dirs:-_none detected — add a tests/ tree or set this manually._}
+
+## Coverage artifacts
+
+HEAD
+
+if [[ "${#COVERAGE[@]}" -eq 0 ]]; then
+  cat <<'EMPTY'
+_No coverage artifact found in the working tree._
+
+The qa agent reads one of `lcov.info`, `coverage-summary.json`,
+`coverage.xml`, `cobertura.xml`, or `.coverage` to compute coverage
+deltas. Generate one in CI (and, ideally, commit a copy or upload it
+as an artifact) so the agent has a trend to track from this baseline.
+EMPTY
+else
+  echo "Detected — the qa agent will parse these on each tick:"
+  echo ""
+  printf -- '- `%s`\n' "${COVERAGE[@]}"
+fi
+
+cat <<TAIL
+
+## CI
+
+${ci_setup}
+
+## Baseline metrics
+
+_Fill these in from the first real audit so future ticks have a
+reference point. Leave \`—\` until measured._
+
+| Metric                  | Baseline |
+|-------------------------|----------|
+| Line coverage           | —        |
+| Branch coverage         | —        |
+| High-risk files (churn × low coverage) | — |
+| Known flaky tests       | —        |
+
+## Notes
+
+_Replace this section with anything a reviewer should know about the
+current test posture — known gaps, untested critical paths, modules
+deliberately excluded from coverage._
+TAIL

--- a/claude-skills/skills/tech-report/scripts/init-adr.sh
+++ b/claude-skills/skills/tech-report/scripts/init-adr.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# init-adr.sh — generate a draft bootstrap ADR from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for
+# architecture signals (detected ecosystems / major dependencies,
+# CI setup, top-level directory layout) and emits a draft seed ADR
+# to stdout. The tech-lead agent reads `.bsg/adr/` every tick to
+# detect decisions that ship without a matching ADR.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it
+# to `.bsg/adr/0000-architecture-baseline.md`, then opens a PR for
+# human review — this script never writes to disk.
+#
+# Usage:
+#   bash init-adr.sh
+#
+# Exit 0 + content on stdout: success
+# Exit 2: bad arguments
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-adr.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signals
+
+# 1. Ecosystems / major deps from lockfiles & manifests at the top level.
+ECOSYSTEMS=()
+[[ -f package.json ]]      && ECOSYSTEMS+=("Node.js (package.json)")
+[[ -f requirements.txt ]]  && ECOSYSTEMS+=("Python (requirements.txt)")
+[[ -f pyproject.toml ]]    && ECOSYSTEMS+=("Python (pyproject.toml)")
+[[ -f go.mod ]]            && ECOSYSTEMS+=("Go (go.mod)")
+[[ -f Cargo.toml ]]        && ECOSYSTEMS+=("Rust (Cargo.toml)")
+[[ -f pom.xml ]]           && ECOSYSTEMS+=("Java (pom.xml)")
+[[ -f build.gradle || -f build.gradle.kts ]] && ECOSYSTEMS+=("Java/Kotlin (Gradle)")
+[[ -f Gemfile ]]           && ECOSYSTEMS+=("Ruby (Gemfile)")
+[[ -f composer.json ]]     && ECOSYSTEMS+=("PHP (composer.json)")
+
+# Top npm dependencies (names only, capped) when package.json is present.
+top_npm=""
+if [[ -f package.json ]] && command -v jq >/dev/null 2>&1; then
+  top_npm=$(jq -r '(.dependencies // {}) | keys | .[0:10] | join(", ")' package.json 2>/dev/null || true)
+fi
+
+# 2. CI setup.
+CI=()
+[[ -d .github/workflows ]] && CI+=("GitHub Actions ($(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | wc -l | tr -d ' ') workflow file(s))")
+[[ -f .gitlab-ci.yml ]]    && CI+=("GitLab CI")
+[[ -f .circleci/config.yml ]] && CI+=("CircleCI")
+[[ -f Jenkinsfile ]]       && CI+=("Jenkins")
+
+# 3. Top-level directory layout (a coarse architecture signal).
+top_dirs=$(find . -maxdepth 1 -mindepth 1 -type d \
+  -not -name '.git' -not -name 'node_modules' 2>/dev/null \
+  | sed 's|^\./||' | sort | head -20 \
+  | awk 'NR>1{printf ", "}{printf "%s",$0}END{if(NR)print ""}')
+
+# 4. Existing ADRs (so the bootstrap notes whether a tree already exists).
+existing_adr_dir=""
+for d in .bsg/adr adr docs/adr; do
+  if [[ -d "$d" ]] && find "$d" -maxdepth 1 -type f -name '*.md' 2>/dev/null | grep -q .; then
+    existing_adr_dir="$d"
+    break
+  fi
+done
+
+# ----------------------------------------------- emit
+
+fmt_list() {
+  if [[ "$#" -eq 0 ]]; then
+    echo "_None detected — fill this in manually._"
+  else
+    printf -- '- %s\n' "$@"
+  fi
+}
+
+cat <<HEAD
+# 0000 — Architecture baseline
+
+- **Status:** draft (bootstrapped ${today})
+- **Deciders:** _set the people who own this decision_
+- **Tags:** baseline, bootstrap
+
+_This ADR was bootstrapped automatically from a repo scan. It is a
+**starting point**, not a record of a real decision — review every
+section, replace the placeholders, and split it into focused ADRs
+(\`0001-...\`, \`0002-...\`) as concrete decisions are made. The
+tech-lead agent reads \`.bsg/adr/\` every tick to flag major
+dependencies and architecture changes that ship without an ADR._
+
+## Context
+
+The repository currently exhibits the following architecture signals.
+Treat each as a decision that *should* eventually have its own ADR.
+
+### Detected ecosystems
+
+$(fmt_list ${ECOSYSTEMS[@]+"${ECOSYSTEMS[@]}"})
+HEAD
+
+if [[ -n "$top_npm" ]]; then
+  cat <<DEPS
+
+### Top runtime dependencies (npm)
+
+${top_npm}
+
+_Each major dependency above is an implicit architecture decision.
+Document the non-obvious ones (frameworks, data layers, auth) in
+their own ADR._
+DEPS
+fi
+
+cat <<TAIL
+
+### Continuous integration
+
+$(fmt_list ${CI[@]+"${CI[@]}"})
+
+### Top-level layout
+
+${top_dirs:-_empty repository — no top-level directories yet._}
+
+## Decision
+
+_Replace this section. Document the **load-bearing** architectural
+choices that are currently implicit in the layout and dependencies
+above — e.g. "we use Next.js app-router", "Postgres is the system of
+record", "the API is REST, not GraphQL". One decision per future ADR._
+
+## Consequences
+
+_Replace this section. For each decision, note the trade-off accepted
+and what would have to change to reverse it._
+
+## Notes
+
+$(if [[ -n "$existing_adr_dir" ]]; then
+    echo "An existing ADR tree was detected at \`${existing_adr_dir}/\`."
+    echo "Migrate those records under \`.bsg/adr/\` (see #237) and delete"
+    echo "this bootstrap stub once real ADRs exist."
+  else
+    echo "No existing ADR tree was found. Start adding focused ADRs"
+    echo "under \`.bsg/adr/\` and delete this bootstrap stub once the"
+    echo "first real decision is recorded."
+  fi)
+TAIL

--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -63,6 +63,8 @@ check_script "claude-skills/skills/marketing-report/scripts/init-calendar.sh"
 check_script "claude-skills/skills/pr-comms-report/scripts/init-announced.sh"
 check_script "claude-skills/skills/security-report/scripts/init-securityignore.sh"
 check_script "claude-skills/skills/storytelling-report/scripts/init-narrative.sh"
+check_script "claude-skills/skills/tech-report/scripts/init-adr.sh"
+check_script "claude-skills/skills/qa-report/scripts/init-qa-baseline.sh"
 
 echo ""
 echo "PASS: $PASS, FAIL: $FAIL"


### PR DESCRIPTION
Part of #237 (deliverable #2 — **does not close the epic**).

## Context

Most of epic #237 already shipped across prior PRs (`.bsg/` convention,
`custom-doc:`/`init:` frontmatter + `test_agent_frontmatter.py`
enforcement, the `/bsg-stack` orchestrator). The remaining gap in
**deliverable #2 (mandatory `--init` on every agent)** was that
`tech-lead` and `qa` declared an `init:` frontmatter field but had no
actual `--init` script — so `/bsg-stack init` silently skipped them.

This PR ships those last two scripts.

## Changes

- **`claude-skills/skills/tech-report/scripts/init-adr.sh`** — scans
  detected ecosystems / major deps, CI setup, and top-level layout;
  emits a draft seed ADR to stdout (→ `.bsg/adr/0000-architecture-baseline.md`).
- **`claude-skills/skills/qa-report/scripts/init-qa-baseline.sh`** —
  scans first-party test files and CI coverage artifacts; emits a
  baseline QA snapshot to stdout (→ `.bsg/reports/qa/0000-baseline.md`).
- Both follow the established stdout-only contract used by the existing
  5 init scripts: `--help` exits 0, non-empty output in an empty repo,
  never writes to cwd.
- **`bsg-stack/scripts/init.sh`** — added `tech-lead` and `qa` rows to
  the `init_script_for` / `output_path_for` maps so the orchestrator
  picks them up automatically.
- **`tests/test_init_scripts.sh`** — registered both new scripts.
- **`bsg-stack/SKILL.md`** — corrected the "not yet shipped" note:
  `md-to-office` self-hosts its `--init`; all other agents are now
  orchestrator-driven.

## Test

- `python3 claude-skills/tests/test_skills.py` (the CI gate) — 17 passed.
- Full `pytest claude-skills/tests/` — 200 passed, 0 regressions.
- `bash -n` clean on both new scripts; verified `--help` exit 0,
  >50 bytes stdout in an empty git repo, and zero cwd writes.
- `/bsg-stack init --dry-run` now plans both
  `.bsg/adr/0000-architecture-baseline.md` and
  `.bsg/reports/qa/0000-baseline.md`.

## Notes

- `test_init_scripts.sh` has a **pre-existing** portability bug
  (`stat -f %z` is BSD/macOS syntax; on GNU/Linux it reads filesystem
  info instead of size). It fails on the *first existing* script on
  Linux regardless of this change, passes on macOS, and is **not wired
  into CI**. Left as-is to keep this change minimal — worth a
  follow-up.
- This is one slice of epic #237; remaining acceptance criteria
  (po-manager/`bootstrap-plan.sh` rename, DESIGN.md generation, etc.)
  are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)