### PR TITLE
feat(237): per-agent --init scripts for tech-lead and qa

### DIFF
--- a/claude-skills/skills/bsg-stack/scripts/init.sh
+++ b/claude-skills/skills/bsg-stack/scripts/init.sh
@@ -91,6 +91,8 @@ init_script_for() {
     pr-comms)      echo "skills/pr-comms-report/scripts/init-announced.sh" ;;
     security)      echo "skills/security-report/scripts/init-securityignore.sh" ;;
     storytelling)  echo "skills/storytelling-report/scripts/init-narrative.sh" ;;
+    tech-lead)     echo "skills/tech-report/scripts/init-adr.sh" ;;
+    qa)            echo "skills/qa-report/scripts/init-qa.sh" ;;
     *)             echo "" ;;
   esac
 }
@@ -104,6 +106,8 @@ output_path_for() {
     pr-comms)      echo ".bsg/ANNOUNCED.md" ;;
     security)      echo ".bsg/SECURITYIGNORE" ;;
     storytelling)  echo ".bsg/NARRATIVE.md" ;;
+    tech-lead)     echo ".bsg/adr/000-architecture-baseline.md" ;;
+    qa)            echo ".bsg/reports/qa/baseline.md" ;;
     *)             echo "" ;;
   esac
 }

--- a/claude-skills/skills/qa-report/scripts/init-qa.sh
+++ b/claude-skills/skills/qa-report/scripts/init-qa.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# init-qa.sh — generate a draft QA baseline snapshot from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for its
+# test framework, test files, and coverage tooling, then emits a
+# draft `.bsg/reports/qa/baseline.md` to stdout. The qa agent reads
+# `.bsg/reports/qa/` every tick to track quality signals over time;
+# this baseline gives the first tick something to diff against.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it
+# to `.bsg/reports/qa/baseline.md` for human review — this script
+# never writes to disk.
+#
+# Usage:
+#   bash init-qa.sh           # auto-scan current repo
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-qa.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+repo_name=$(basename "$REPO_ROOT")
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view --json name --jq '.name // empty' 2>/dev/null || echo "$repo_name")
+fi
+
+# Accumulate findings as newline-delimited text rather than bash arrays —
+# referencing an empty array under `set -u` is an "unbound variable"
+# error on bash < 4.4, which the orchestrator may run on.
+
+# ----------------------------------------------- signals: test framework
+
+frameworks=""
+add_fw() {
+  case $'\n'"$frameworks"$'\n' in
+    *$'\n'"$1"$'\n'*) return ;;
+  esac
+  frameworks="${frameworks:+$frameworks$'\n'}$1"
+}
+
+if [[ -f package.json ]] && command -v jq >/dev/null 2>&1; then
+  alldeps=$(jq -r '((.dependencies // {}) + (.devDependencies // {})) | keys[]' \
+    package.json 2>/dev/null || echo "")
+  grep -qx 'jest'       <<<"$alldeps" && add_fw "Jest"
+  grep -qx 'vitest'     <<<"$alldeps" && add_fw "Vitest"
+  grep -qx 'mocha'      <<<"$alldeps" && add_fw "Mocha"
+  grep -qx 'playwright' <<<"$alldeps" && add_fw "Playwright"
+  grep -qx 'cypress'    <<<"$alldeps" && add_fw "Cypress"
+fi
+{ [[ -f pytest.ini ]] || [[ -f tox.ini ]]; } && add_fw "pytest"
+grep -rqs 'pytest' pyproject.toml setup.cfg 2>/dev/null && add_fw "pytest"
+{ [[ -f build.sbt ]] && grep -rqs 'scoverage\|scalatest\|munit' build.sbt 2>/dev/null; } \
+  && add_fw "Scala test (scalatest/munit)"
+[[ -f go.mod ]]     && add_fw "Go testing (go test)"
+[[ -f Cargo.toml ]] && add_fw "Rust test (cargo test)"
+
+# ----------------------------------------------- signals: test files
+
+test_count=$(find . -type f \
+  -not -path './.git/*' -not -path './node_modules/*' \( \
+    -name '*.test.*' -o -name '*.spec.*' \
+    -o -name 'test_*.py' -o -name '*_test.py' \
+    -o -name '*_test.go' -o -name '*Test.scala' -o -name '*Spec.scala' \
+  \) 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+test_dirs=$(find . -maxdepth 4 -type d \
+  -not -path './.git/*' -not -path './node_modules/*' \( \
+    -name 'tests' -o -name 'test' -o -name '__tests__' -o -name 'spec' \
+  \) 2>/dev/null | sed 's#^\./##' | sort -u | head -10 \
+  | awk '{print "- " $0}' || echo "")
+
+# ----------------------------------------------- signals: coverage
+
+coverage=""
+add_cov() {
+  case $'\n'"$coverage"$'\n' in
+    *$'\n'"$1"$'\n'*) return ;;
+  esac
+  coverage="${coverage:+$coverage$'\n'}$1"
+}
+{ [[ -f lcov.info ]] || [[ -f coverage/lcov.info ]]; } && add_cov "lcov.info present"
+[[ -d coverage ]] && add_cov "coverage/ directory present"
+[[ -f cobertura.xml ]] && add_cov "Cobertura report present"
+cov_json=$(find . -maxdepth 3 -name 'coverage-final.json' \
+  -not -path './node_modules/*' 2>/dev/null | head -1 || true)
+[[ -n "$cov_json" ]] && add_cov "Jest coverage-final.json present"
+scoverage_dir=$(find . -maxdepth 4 -type d -name 'scoverage-report' \
+  2>/dev/null | head -1 || true)
+[[ -n "$scoverage_dir" ]] && add_cov "scoverage report present"
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# QA baseline — ${repo_name}
+
+_Draft bootstrapped ${today}. Edit and commit to
+\`.bsg/reports/qa/baseline.md\`. The qa agent reads
+\`.bsg/reports/qa/\` every tick and diffs new findings against this
+snapshot, so an honest baseline keeps the noise down._
+
+## Test framework
+
+HEAD
+
+if [[ -n "$frameworks" ]]; then
+  printf '%s\n' "$frameworks" | sed 's/^/- /'
+else
+  echo "- _No test framework detected — note the intended framework here._"
+fi
+
+cat <<COUNTS
+
+## Test surface
+
+- Test files detected: **${test_count}**
+COUNTS
+
+if [[ -n "$test_dirs" ]]; then
+  echo ""
+  echo "Test directories:"
+  echo ""
+  printf '%s\n' "$test_dirs"
+fi
+
+cat <<'COV_HEADER'
+
+## Coverage tooling
+
+COV_HEADER
+
+if [[ -n "$coverage" ]]; then
+  printf '%s\n' "$coverage" | sed 's/^/- /'
+else
+  echo "- _No coverage artifacts detected. Wire up a coverage tool"
+  echo "  (lcov, scoverage, Jest --coverage) so the qa agent can track"
+  echo "  trends over time._"
+fi
+
+cat <<'TAIL'
+
+## Risk hotspots
+
+_Empty on first commit. The qa agent fills this section each tick with
+modules that lack tests, recently changed code without coverage, and
+flaky test signals. Add any known fragile areas manually so the agent
+prioritizes them._
+TAIL

--- a/claude-skills/skills/tech-report/scripts/init-adr.sh
+++ b/claude-skills/skills/tech-report/scripts/init-adr.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# init-adr.sh — generate a draft baseline ADR from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for
+# architecture signals — primary language / build tooling, major
+# dependencies, CI setup, containerization — and emits a draft
+# `.bsg/adr/000-architecture-baseline.md` to stdout. The tech-lead
+# agent reads `.bsg/adr/` every tick to track which technical
+# decisions are documented.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it
+# to `.bsg/adr/000-architecture-baseline.md` for human review — this
+# script never writes to disk.
+#
+# Usage:
+#   bash init-adr.sh           # auto-scan current repo
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-adr.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+repo_name=$(basename "$REPO_ROOT")
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view --json name --jq '.name // empty' 2>/dev/null || echo "$repo_name")
+fi
+
+# ----------------------------------------------- signals: build tooling
+#
+# Accumulate detected stack as newline-delimited text rather than a bash
+# array — referencing an empty array under `set -u` is an "unbound
+# variable" error on bash < 4.4, which the orchestrator may run on.
+
+stack=""
+add_stack() {
+  case $'\n'"$stack"$'\n' in
+    *$'\n'"$1"$'\n'*) return ;;
+  esac
+  stack="${stack:+$stack$'\n'}$1"
+}
+
+[[ -f package.json ]]       && add_stack "Node.js / npm (package.json)"
+[[ -f pnpm-lock.yaml ]]     && add_stack "pnpm workspace"
+[[ -f yarn.lock ]]          && add_stack "Yarn"
+[[ -f build.sbt ]]          && add_stack "Scala / sbt (build.sbt)"
+[[ -f pom.xml ]]            && add_stack "Java / Maven (pom.xml)"
+{ [[ -f build.gradle ]] || [[ -f build.gradle.kts ]]; } && add_stack "Gradle"
+[[ -f requirements.txt ]]   && add_stack "Python (requirements.txt)"
+[[ -f pyproject.toml ]]     && add_stack "Python (pyproject.toml)"
+[[ -f go.mod ]]             && add_stack "Go modules (go.mod)"
+[[ -f Cargo.toml ]]         && add_stack "Rust / Cargo (Cargo.toml)"
+[[ -f Gemfile ]]            && add_stack "Ruby / Bundler (Gemfile)"
+[[ -f composer.json ]]      && add_stack "PHP / Composer (composer.json)"
+[[ -f Dockerfile ]]         && add_stack "Docker (Dockerfile)"
+{ [[ -f docker-compose.yml ]] || [[ -f docker-compose.yaml ]]; } && add_stack "Docker Compose"
+
+# ----------------------------------------------- signals: major deps
+
+deps=""
+if [[ -f package.json ]] && command -v jq >/dev/null 2>&1; then
+  deps=$(jq -r '(.dependencies // {}) | keys[]' package.json 2>/dev/null \
+    | head -12 | awk '{print "- " $0}' || echo "")
+fi
+
+# ----------------------------------------------- signals: CI
+
+ci_workflows=""
+if [[ -d .github/workflows ]]; then
+  ci_workflows=$(find .github/workflows -maxdepth 1 -type f \
+    \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null \
+    | sed 's#.*/#- #' | sort | head -15 || echo "")
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# ADR 000 — Architecture baseline (${repo_name})
+
+_Draft bootstrapped ${today}. This is a starting point, not a decision
+record. Edit and commit to \`.bsg/adr/000-architecture-baseline.md\`,
+then author follow-up ADRs (\`001-*.md\`, \`002-*.md\`, …) for each
+real decision. The tech-lead agent reads \`.bsg/adr/\` every tick to
+flag undocumented architectural changes._
+
+## Status
+
+Proposed — replace with Accepted once a human has reviewed and
+corrected the inferred stack below.
+
+## Context
+
+This ADR captures the technical baseline detected from the repository
+so future decisions have a documented starting point.
+
+### Detected stack
+
+HEAD
+
+if [[ -n "$stack" ]]; then
+  printf '%s\n' "$stack" | sed 's/^/- /'
+else
+  echo "- _No build tooling detected — describe the stack manually._"
+fi
+
+if [[ -n "$deps" ]]; then
+  cat <<'DEPS_HEADER'
+
+### Major dependencies (top of package.json)
+
+DEPS_HEADER
+  printf '%s\n' "$deps"
+fi
+
+if [[ -n "$ci_workflows" ]]; then
+  cat <<'CI_HEADER'
+
+### CI workflows
+
+CI_HEADER
+  printf '%s\n' "$ci_workflows"
+else
+  cat <<'NO_CI'
+
+### CI workflows
+
+- _No GitHub Actions workflows detected under .github/workflows._
+NO_CI
+fi
+
+cat <<'TAIL'
+
+## Decision
+
+_None yet — this baseline only records what exists. Document the first
+real architectural decision in a new ADR file._
+
+## Consequences
+
+_Fill in as decisions are made. The tech-lead agent cross-references
+this directory against detected architecture drift on each tick._
+TAIL

--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -63,6 +63,8 @@ check_script "claude-skills/skills/marketing-report/scripts/init-calendar.sh"
 check_script "claude-skills/skills/pr-comms-report/scripts/init-announced.sh"
 check_script "claude-skills/skills/security-report/scripts/init-securityignore.sh"
 check_script "claude-skills/skills/storytelling-report/scripts/init-narrative.sh"
+check_script "claude-skills/skills/tech-report/scripts/init-adr.sh"
+check_script "claude-skills/skills/qa-report/scripts/init-qa.sh"
 
 echo ""
 echo "PASS: $PASS, FAIL: $FAIL"


### PR DESCRIPTION
Part of #237 — completes **PRD Deliverable 2** (per-agent `--init` scripts).

tech-lead and qa were the only two agents in the deliverable table still
missing a `--init` script (the other 7 shipped via #594 and the
po-manager `bootstrap-plan.sh`).

## Changes

- **`claude-skills/skills/tech-report/scripts/init-adr.sh`** — scans
  build tooling, top `package.json` deps, and `.github/workflows`, emits
  a draft `.bsg/adr/000-architecture-baseline.md`.
- **`claude-skills/skills/qa-report/scripts/init-qa.sh`** — scans the
  test framework, test file count/dirs, and coverage tooling, emits a
  draft `.bsg/reports/qa/baseline.md`.
- **`claude-skills/skills/bsg-stack/scripts/init.sh`** — wired both into
  `init_script_for()` and `output_path_for()` so `/bsg-stack init` now
  bootstraps these two docs.
- **`claude-skills/tests/test_init_scripts.sh`** — registered both new
  scripts in the contract guard.

Both scripts follow the established stdout-only contract: they never
write to disk (the orchestrator owns the disk side), respond to `--help`
with exit 0, and emit non-empty output even in a bare repo.

## Test

- `bash -n` clean on both scripts.
- Manually verified the #237 init contract for both: `--help` exits 0;
  non-empty stdout (>50 bytes) and exit 0 in both an empty git repo and
  the real bsg-stack repo; zero files written to cwd.
- `/bsg-stack init --dry-run` now lists `.bsg/adr/000-architecture-baseline.md`
  and `.bsg/reports/qa/baseline.md` as would-create targets.
- `python3 claude-skills/tests/test_agent_frontmatter.py` — all 12 pass
  (no regression).

> Note: `test_init_scripts.sh` currently aborts early with a pre-existing
> `line 30: File: unbound variable` error that reproduces on a pristine
> tree (unrelated to this change — it affects all rows equally). Filed
> for separate follow-up; the new rows are correct and the contract was
> validated manually.