### PR TITLE
feat(init): --init scripts for tech-lead + qa, fix Linux enforcement test

### DIFF
--- a/claude-skills/skills/qa-report/scripts/init-qa-baseline.sh
+++ b/claude-skills/skills/qa-report/scripts/init-qa-baseline.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# init-qa-baseline.sh — generate a draft QA baseline from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for
+# existing test files and CI coverage artifacts, then emits a draft
+# QA baseline snapshot to stdout (destined for
+# `.bsg/reports/qa/<date>-baseline.md`). The orchestrator
+# (`/bsg-stack init`) captures stdout and opens a PR for human
+# review — this script never writes to disk.
+#
+# Usage:
+#   bash init-qa-baseline.sh            # auto-scan current repo
+#   bash init-qa-baseline.sh --repo OWNER/NAME
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error (missing tool, etc.)
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-qa-baseline.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+repo_name="unknown"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  repo_name=$(gh repo view "${REPO_FLAG[@]}" --json name -q '.name' 2>/dev/null || echo unknown)
+fi
+
+# ----------------------------------------------- signal collection
+
+# Count test files by common naming conventions, skipping vendor dirs.
+test_count=$(find . \
+  -path ./.git -prune -o \
+  -path ./node_modules -prune -o \
+  -path ./.venv -prune -o \
+  -path ./vendor -prune -o \
+  -type f \( \
+       -name '*_test.go' \
+    -o -name 'test_*.py' \
+    -o -name '*_test.py' \
+    -o -name '*.test.js' \
+    -o -name '*.test.ts' \
+    -o -name '*.spec.js' \
+    -o -name '*.spec.ts' \
+    -o -name '*Test.java' \
+  \) -print 2>/dev/null | wc -l | tr -d ' ')
+
+# Detect dedicated test directories.
+test_dirs=()
+for d in test tests spec __tests__ src/test; do
+  [[ -d "$d" ]] && test_dirs+=("$d/")
+done
+
+# Coverage artifacts already present in the repo.
+coverage_artifacts=()
+for f in lcov.info coverage.xml coverage/lcov.info .coverage \
+         coverage-final.json clover.xml; do
+  [[ -e "$f" ]] && coverage_artifacts+=("$f")
+done
+
+# CI test wiring (best-effort grep).
+ci_tests="no test step detected"
+if [[ -d .github/workflows ]]; then
+  if grep -rqiE 'test|pytest|jest|vitest|go test' .github/workflows 2>/dev/null; then
+    ci_tests="GitHub Actions references a test step"
+  else
+    ci_tests="GitHub Actions present, no obvious test step"
+  fi
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# QA baseline — ${repo_name}
+
+_Draft bootstrapped ${today}. Review and commit to
+\`.bsg/reports/qa/${today}-baseline.md\` — the qa agent uses this as
+the starting point for tracking coverage and risk drift over time._
+
+## Test inventory
+
+HEAD
+
+echo "- Test files detected: **${test_count}**"
+
+if [[ ${#test_dirs[@]} -gt 0 ]]; then
+  echo "- Test directories:"
+  for d in "${test_dirs[@]}"; do echo "  - \`${d}\`"; done
+else
+  echo "- Test directories: _none found — no dedicated test tree detected._"
+fi
+
+echo ""
+echo "## Coverage artifacts"
+echo ""
+if [[ ${#coverage_artifacts[@]} -gt 0 ]]; then
+  for f in "${coverage_artifacts[@]}"; do echo "- \`${f}\` present"; done
+else
+  echo "- _No coverage artifact found — wire coverage reporting in CI so"
+  echo "  the qa agent can track the trend._"
+fi
+
+echo ""
+echo "## CI integration"
+echo ""
+echo "- ${ci_tests}"
+
+cat <<'TAIL'
+
+## Risk hotspots
+
+_Seed this list with the modules that are most fragile or least
+covered. The qa agent will keep it current on each tick — leave it
+empty on first commit if you have no prior signal._
+
+## Notes
+
+_Adjust the inventory above if the heuristic missed a non-standard
+test layout (the scan only knows common naming conventions)._
+TAIL

--- a/claude-skills/skills/tech-report/scripts/init-adr.sh
+++ b/claude-skills/skills/tech-report/scripts/init-adr.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# init-adr.sh — generate a draft bootstrap ADR from repo scan.
+#
+# Part of #237 (per-agent --init contract): scans the repo for
+# architecture signals — primary language/ecosystem, major
+# dependencies, and CI setup — then emits a draft first ADR
+# (`.bsg/adr/001-bootstrap.md`) to stdout. The orchestrator
+# (`/bsg-stack init`) captures stdout and opens a PR for human
+# review — this script never writes to disk.
+#
+# Usage:
+#   bash init-adr.sh                # auto-scan current repo
+#   bash init-adr.sh --repo OWNER/NAME
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error (missing tool, etc.)
+
+set -euo pipefail
+
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-adr.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signal collection
+
+repo_name="unknown"
+description=""
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  meta=$(gh repo view "${REPO_FLAG[@]}" --json name,description 2>/dev/null || echo '{}')
+  repo_name=$(jq -r '.name // "unknown"' <<<"$meta" 2>/dev/null || echo unknown)
+  description=$(jq -r '.description // ""' <<<"$meta" 2>/dev/null || echo "")
+fi
+
+# Detect ecosystem(s) from manifest files at repo root.
+ecosystems=()
+[[ -f package.json ]]      && ecosystems+=("Node.js (package.json)")
+[[ -f requirements.txt ]]  && ecosystems+=("Python (requirements.txt)")
+[[ -f pyproject.toml ]]    && ecosystems+=("Python (pyproject.toml)")
+[[ -f go.mod ]]            && ecosystems+=("Go (go.mod)")
+[[ -f Cargo.toml ]]        && ecosystems+=("Rust (Cargo.toml)")
+[[ -f pom.xml ]]           && ecosystems+=("Java (Maven)")
+[[ -f Gemfile ]]           && ecosystems+=("Ruby (Gemfile)")
+[[ -f composer.json ]]     && ecosystems+=("PHP (composer.json)")
+
+# Top runtime dependencies (best-effort, first few).
+deps=""
+if [[ -f package.json ]] && command -v jq >/dev/null 2>&1; then
+  deps=$(jq -r '(.dependencies // {}) | keys[]' package.json 2>/dev/null | head -10 || echo "")
+elif [[ -f requirements.txt ]]; then
+  deps=$(grep -vE '^\s*#|^\s*$' requirements.txt 2>/dev/null \
+    | sed -E 's/[<>=!~].*//' | head -10 || echo "")
+fi
+
+# CI setup.
+ci="none detected"
+if [[ -d .github/workflows ]]; then
+  wf_count=$(find .github/workflows -maxdepth 1 -type f \
+    \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | wc -l | tr -d ' ')
+  ci="GitHub Actions (${wf_count} workflow(s))"
+elif [[ -f .gitlab-ci.yml ]]; then
+  ci="GitLab CI"
+elif [[ -f .circleci/config.yml ]]; then
+  ci="CircleCI"
+fi
+
+# ----------------------------------------------- emit
+
+cat <<HEAD
+# 001 — Bootstrap architecture record
+
+_Draft bootstrapped ${today}. Review, correct, and commit to
+\`.bsg/adr/001-bootstrap.md\` — the tech-lead agent reads \`.bsg/adr/\`
+every tick to flag undocumented decisions. Split into focused ADRs
+(\`002-…\`, \`003-…\`) as decisions accumulate._
+
+## Status
+
+Proposed — needs human review.
+
+## Context
+
+HEAD
+
+if [[ -n "$description" ]]; then
+  echo "Repository: **${repo_name}** — ${description}"
+else
+  echo "Repository: **${repo_name}**"
+fi
+
+echo ""
+echo "### Detected stack"
+echo ""
+if [[ ${#ecosystems[@]} -gt 0 ]]; then
+  for e in "${ecosystems[@]}"; do echo "- ${e}"; done
+else
+  echo "- _No package manifest detected at repo root — document the stack manually._"
+fi
+
+echo ""
+echo "### CI / automation"
+echo ""
+echo "- ${ci}"
+
+echo ""
+echo "### Notable dependencies"
+echo ""
+if [[ -n "$deps" ]]; then
+  while IFS= read -r d; do
+    [[ -n "$d" ]] && echo "- ${d}"
+  done <<<"$deps"
+else
+  echo "- _None inventoried — list the load-bearing libraries here._"
+fi
+
+cat <<'TAIL'
+
+## Decision
+
+_Document the key architectural decision(s) already implicit in this
+codebase: framework choice, persistence, deployment target, language
+boundaries. One ADR per decision once the backlog grows._
+
+## Consequences
+
+_What does this decision make easy? What does it make hard? What are
+the migration costs if it is reversed later?_
+TAIL

--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -50,7 +50,10 @@ check_script() {
     bash "$path" > /tmp/init-script-output.$$ 2>/dev/null || true
   )
   local pre_files=$(find "$tmp" -mindepth 1 -not -path '*/.git*' 2>/dev/null | wc -l | tr -d ' ')
-  local out_size=$(stat -f %z /tmp/init-script-output.$$ 2>/dev/null || stat -c %s /tmp/init-script-output.$$ 2>/dev/null || echo 0)
+  # Portable byte count: `stat -f %z` is macOS, `stat -c %s` is GNU/Linux.
+  # On Linux `stat -f` means "filesystem status" and exits 0, so it never
+  # falls through — `wc -c` is portable and avoids the ambiguity entirely.
+  local out_size=$(wc -c < /tmp/init-script-output.$$ 2>/dev/null | tr -d ' ' || echo 0)
   rm -rf "$tmp" /tmp/init-script-output.$$
 
   assert "$name emits non-empty stdout in empty repo" "[[ '$out_size' -gt 50 ]]"
@@ -63,6 +66,8 @@ check_script "claude-skills/skills/marketing-report/scripts/init-calendar.sh"
 check_script "claude-skills/skills/pr-comms-report/scripts/init-announced.sh"
 check_script "claude-skills/skills/security-report/scripts/init-securityignore.sh"
 check_script "claude-skills/skills/storytelling-report/scripts/init-narrative.sh"
+check_script "claude-skills/skills/tech-report/scripts/init-adr.sh"
+check_script "claude-skills/skills/qa-report/scripts/init-qa-baseline.sh"
 
 echo ""
 echo "PASS: $PASS, FAIL: $FAIL"


### PR DESCRIPTION
Refs #237 (partial — one slice of the multi-PR epic, not a full close).

The issue's core complaint: **only md-to-office had a proper `--init` flag
that auto-extracts**. Most of #237 is already implemented, but two agents
still declared `init:` in frontmatter with no working, contract-compliant
script behind it: **tech-lead** and **qa**.

## Changes

- **`tech-report/scripts/init-adr.sh`** — scans architecture signals (ecosystem
  manifests, top dependencies, CI setup); emits a draft
  `.bsg/adr/001-bootstrap.md` to stdout (stdout-only #237 contract).
- **`qa-report/scripts/init-qa-baseline.sh`** — scans test files, test dirs,
  coverage artifacts and CI test wiring; emits a draft
  `.bsg/reports/qa/<date>-baseline.md` to stdout.
- **`tests/test_init_scripts.sh`**:
  - Registers the two new scripts (now 7 scripts × 5 assertions = 35 checks).
  - Fixes a pre-existing **Linux portability bug**: `stat -f %z` is macOS-only;
    on GNU/Linux `stat -f` is "filesystem status" and exits 0, so the
    `stat -c %s` fallback never ran and `out_size` captured garbage filesystem
    text — aborting the whole #237 enforcement test under `set -u` in CI.
    Replaced with portable `wc -c`.

Both new scripts conform to the contract: `--help` exits 0, non-empty stdout
in an empty repo, never writes to cwd, `--repo OWNER/NAME` supported.

## Test

```
$ bash claude-skills/tests/test_init_scripts.sh
PASS: 35, FAIL: 0
```

Previously failed on Linux with `line 30: File: unbound variable` before the
`stat` fix (verified before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)