### PR TITLE
feat(237): per-agent --init scripts for tech-lead and qa

### DIFF
--- a/claude-skills/skills/bsg-stack/scripts/init.sh
+++ b/claude-skills/skills/bsg-stack/scripts/init.sh
@@ -91,6 +91,8 @@ init_script_for() {
     pr-comms)      echo "skills/pr-comms-report/scripts/init-announced.sh" ;;
     security)      echo "skills/security-report/scripts/init-securityignore.sh" ;;
     storytelling)  echo "skills/storytelling-report/scripts/init-narrative.sh" ;;
+    tech-lead)     echo "skills/tech-report/scripts/init-adr.sh" ;;
+    qa)            echo "skills/qa-report/scripts/init-qa.sh" ;;
     *)             echo "" ;;
   esac
 }
@@ -104,6 +106,8 @@ output_path_for() {
     pr-comms)      echo ".bsg/ANNOUNCED.md" ;;
     security)      echo ".bsg/SECURITYIGNORE" ;;
     storytelling)  echo ".bsg/NARRATIVE.md" ;;
+    tech-lead)     echo ".bsg/adr/000-record-architecture-decisions.md" ;;
+    qa)            echo ".bsg/reports/qa/baseline.md" ;;
     *)             echo "" ;;
   esac
 }

--- a/claude-skills/skills/qa-report/scripts/init-qa.sh
+++ b/claude-skills/skills/qa-report/scripts/init-qa.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# init-qa.sh — generate a draft QA baseline snapshot from repo scan.
+#
+# Part of #237 (per-agent --init contract): detects the repo's test
+# framework, coverage tooling, test file count, and CI test step, then
+# emits a draft `baseline.md` to stdout. The qa agent reads
+# `.bsg/reports/qa/` every tick; this seed gives a fresh repo a
+# starting quality snapshot instead of an empty directory.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it to
+# `.bsg/reports/qa/baseline.md` — this script never writes to disk.
+#
+# Usage:
+#   bash init-qa.sh
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-qa.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signal collection
+
+test_framework="none detected"
+if [[ -f package.json ]]; then
+  pkg=$(cat package.json 2>/dev/null || echo '{}')
+  if   grep -q '"vitest"'  <<<"$pkg"; then test_framework="Vitest"
+  elif grep -q '"jest"'    <<<"$pkg"; then test_framework="Jest"
+  elif grep -q '"mocha"'   <<<"$pkg"; then test_framework="Mocha"
+  elif grep -q '"playwright"' <<<"$pkg"; then test_framework="Playwright"
+  fi
+fi
+if [[ "$test_framework" == "none detected" ]]; then
+  if   [[ -f pytest.ini || -f conftest.py ]] || grep -rqs 'pytest' pyproject.toml setup.cfg 2>/dev/null; then
+    test_framework="pytest"
+  elif [[ -f go.mod ]] && find . -name '*_test.go' -not -path './.git/*' 2>/dev/null | grep -q .; then
+    test_framework="go test"
+  elif [[ -f Cargo.toml ]]; then
+    test_framework="cargo test"
+  fi
+fi
+
+coverage_tool="none detected"
+if   [[ -f lcov.info ]] || find . -name 'lcov.info' -not -path './.git/*' 2>/dev/null | grep -q .; then
+  coverage_tool="lcov (lcov.info present)"
+elif [[ -f .coveragerc ]] || grep -rqs 'coverage' pyproject.toml setup.cfg 2>/dev/null; then
+  coverage_tool="coverage.py"
+elif [[ -f package.json ]] && grep -q '"nyc"\|"c8"\|"istanbul"' package.json 2>/dev/null; then
+  coverage_tool="istanbul/nyc/c8"
+fi
+
+# Count test files across common conventions.
+test_file_count=$(find . \
+  \( -path ./.git -o -path ./node_modules -o -path ./.venv \) -prune -o \
+  -type f \( -name '*.test.*' -o -name '*.spec.*' -o -name 'test_*.py' \
+             -o -name '*_test.go' -o -name '*_test.py' \) -print 2>/dev/null \
+  | wc -l | tr -d ' ')
+
+ci_test_step="not detected"
+if [[ -d .github/workflows ]]; then
+  if grep -rqsE 'test|pytest|jest|vitest|coverage' .github/workflows/ 2>/dev/null; then
+    ci_test_step="GitHub Actions workflow runs tests"
+  else
+    ci_test_step="GitHub Actions present, no obvious test step"
+  fi
+fi
+
+repo_name=$(basename "$REPO_ROOT")
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  n=$(gh repo view --json name --jq '.name' 2>/dev/null || true)
+  [[ -n "$n" ]] && repo_name="$n"
+fi
+
+# ----------------------------------------------- emit
+
+cat <<DOC
+# QA baseline — ${repo_name}
+
+_Draft bootstrapped ${today}. Edit and commit to
+\`.bsg/reports/qa/baseline.md\` — the qa agent reads this directory
+every tick and compares new findings against this baseline. Treat the
+numbers below as a starting point, not ground truth._
+
+## Detected test setup
+
+| Aspect | Detected value |
+|---|---|
+| Test framework | ${test_framework} |
+| Coverage tool | ${coverage_tool} |
+| Test files found | ${test_file_count} |
+| CI test step | ${ci_test_step} |
+
+## Risk hotspots
+
+_The qa agent fills this section each tick with modules that have low
+coverage, high churn, or recurring regressions. Leave it empty on the
+first commit — it is populated from real audit data over time._
+
+## Baseline notes
+
+- If **test framework** is \`none detected\`, the qa agent's first
+  recommendation will be to introduce a test harness.
+- If **coverage tool** is \`none detected\`, add one so coverage deltas
+  can be tracked tick over tick.
+- Update this baseline deliberately (e.g. after a major coverage push)
+  so regressions are measured against an intentional reference point.
+DOC

--- a/claude-skills/skills/tech-report/scripts/init-adr.sh
+++ b/claude-skills/skills/tech-report/scripts/init-adr.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# init-adr.sh — generate a draft bootstrap ADR from repo scan.
+#
+# Part of #237 (per-agent --init contract): detects the repo's primary
+# language/framework, build tooling, and CI system, then emits a draft
+# `000-record-architecture-decisions.md` ADR to stdout. The tech-lead
+# agent reads `.bsg/adr/` every tick; this seed gives a fresh repo a
+# starting decision log instead of an empty directory.
+#
+# The orchestrator (`/bsg-stack init`) captures stdout and writes it to
+# `.bsg/adr/000-record-architecture-decisions.md` — this script never
+# writes to disk.
+#
+# Usage:
+#   bash init-adr.sh
+#
+# Exit 0 + content on stdout: success
+# Exit 1: error
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "init-adr.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+today=$(date -u +%F)
+
+# ----------------------------------------------- signal collection
+
+language="unknown"
+build_tool="unknown"
+if [[ -f package.json ]]; then
+  language="JavaScript/TypeScript (Node.js)"
+  build_tool="npm/package.json"
+  [[ -f tsconfig.json ]] && language="TypeScript (Node.js)"
+elif [[ -f pyproject.toml || -f setup.py || -f requirements.txt ]]; then
+  language="Python"
+  if [[ -f pyproject.toml ]]; then build_tool="pyproject.toml"
+  elif [[ -f setup.py ]]; then build_tool="setup.py"
+  else build_tool="requirements.txt"; fi
+elif [[ -f Cargo.toml ]]; then
+  language="Rust"
+  build_tool="Cargo"
+elif [[ -f go.mod ]]; then
+  language="Go"
+  build_tool="go modules"
+elif [[ -f pom.xml ]]; then
+  language="Java"
+  build_tool="Maven"
+elif [[ -f build.gradle || -f build.gradle.kts ]]; then
+  language="Java/Kotlin"
+  build_tool="Gradle"
+fi
+
+ci_system="none detected"
+if [[ -d .github/workflows ]]; then
+  ci_system="GitHub Actions (.github/workflows/)"
+elif [[ -f .gitlab-ci.yml ]]; then
+  ci_system="GitLab CI (.gitlab-ci.yml)"
+elif [[ -f .circleci/config.yml ]]; then
+  ci_system="CircleCI (.circleci/config.yml)"
+elif [[ -f Jenkinsfile ]]; then
+  ci_system="Jenkins (Jenkinsfile)"
+fi
+
+# Top runtime dependencies as architecture signals.
+deps=""
+if [[ -f package.json ]]; then
+  deps=$(jq -r '(.dependencies // {}) | keys | .[0:8] | join(", ")' package.json 2>/dev/null || echo "")
+elif [[ -f pyproject.toml ]]; then
+  deps=$(grep -E '^[a-zA-Z0-9_-]+ *=' pyproject.toml 2>/dev/null | head -8 \
+    | sed -E 's/ *=.*//' | paste -sd ', ' - 2>/dev/null || echo "")
+fi
+[[ -z "$deps" ]] && deps="_none detected — fill in manually_"
+
+repo_name=$(basename "$REPO_ROOT")
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  n=$(gh repo view --json name --jq '.name' 2>/dev/null || true)
+  [[ -n "$n" ]] && repo_name="$n"
+fi
+
+# ----------------------------------------------- emit
+
+cat <<DOC
+# 000 — Record architecture decisions
+
+- **Status:** accepted
+- **Date:** ${today}
+- **Deciders:** tech-lead agent (draft — bootstrapped, pending human review)
+
+_Draft bootstrapped ${today} for **${repo_name}**. Edit and commit to
+\`.bsg/adr/\` — the tech-lead agent reads this directory every tick.
+This first ADR records the decision to keep an architecture decision
+log; subsequent ADRs document individual decisions._
+
+## Context
+
+This repository did not yet have an architecture decision record (ADR)
+log. The tech-lead agent expects significant technical decisions to be
+captured under \`.bsg/adr/\` so that the rationale behind the current
+design is discoverable and reviewable over time.
+
+The following signals were detected during bootstrap and should anchor
+the first real ADRs:
+
+| Signal | Detected value |
+|---|---|
+| Primary language | ${language} |
+| Build / packaging | ${build_tool} |
+| CI system | ${ci_system} |
+| Key dependencies | ${deps} |
+
+## Decision
+
+We will keep an architecture decision log under \`.bsg/adr/\`, one
+Markdown file per decision, numbered sequentially
+(\`NNN-title.md\`). Each ADR records context, the decision, and its
+consequences. ADRs are immutable once accepted; a superseding decision
+gets a new ADR that references the one it replaces.
+
+## Consequences
+
+- New significant decisions (frameworks, data stores, API style,
+  build tooling) must be recorded as a new ADR before or alongside the
+  change that introduces them.
+- The tech-lead agent will flag undocumented architectural drift on its
+  tick by comparing observed signals against this log.
+
+## Suggested follow-up ADRs
+
+_Replace these stubs with real decisions for this repo:_
+
+- \`001-technology-stack.md\` — why **${language}** / **${build_tool}**
+- \`002-ci-pipeline.md\` — why **${ci_system}**
+- \`003-api-design.md\` — public interface conventions (if applicable)
+DOC

--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -63,6 +63,8 @@ check_script "claude-skills/skills/marketing-report/scripts/init-calendar.sh"
 check_script "claude-skills/skills/pr-comms-report/scripts/init-announced.sh"
 check_script "claude-skills/skills/security-report/scripts/init-securityignore.sh"
 check_script "claude-skills/skills/storytelling-report/scripts/init-narrative.sh"
+check_script "claude-skills/skills/tech-report/scripts/init-adr.sh"
+check_script "claude-skills/skills/qa-report/scripts/init-qa.sh"
 
 echo ""
 echo "PASS: $PASS, FAIL: $FAIL"


### PR DESCRIPTION
Refs #237 (does **not** close the epic — see "Scope" below)

## Context

#237's core complaint: *"only **md-to-office** has a proper `--init` flag that auto-extracts."* Most of the epic already landed across prior PRs (#582 path resolver, #594 5 audit-only init scripts, #595 /bsg-stack orchestrator, #580 doctor). The remaining Phase-2 gap: **tech-lead** and **qa** declared `init:` / `custom-doc:` in frontmatter but shipped no actual init script, so `/bsg-stack init` emitted `no-init` for them.

## Changes

- **`skills/tech-report/scripts/init-adr.sh`** — detects primary language, build tool, CI system and top dependencies; emits a draft `000-record-architecture-decisions.md` bootstrap ADR.
- **`skills/qa-report/scripts/init-qa.sh`** — detects test framework, coverage tool, test-file count and CI test step; emits a draft `.bsg/reports/qa/baseline.md`.
- **`skills/bsg-stack/scripts/init.sh`** — wired `tech-lead` and `qa` into `init_script_for()` + `output_path_for()`.
- **`tests/test_init_scripts.sh`** — registered both scripts in the contract guard (its documented extension point).

Both follow the established stdout-only init contract: `--help` exits 0, non-empty stdout (>50 B) in an empty git repo, zero writes to cwd.

## Test

- `--help` exits 0 for both scripts.
- In an empty git repo: 1889 B / 1074 B stdout, 0 files written.
- `bash skills/bsg-stack/scripts/init.sh --dry-run --no-labels` now routes both agents to their scripts/output paths.
- `python3 claude-skills/tests/test_agent_frontmatter.py` → 12 OK; `test_skill_invariants.py` → 5 OK.

> **Note:** `test_init_scripts.sh` has a *pre-existing* failure on Linux (`line 30: File: unbound variable`, from BSD-only `stat -f`) that exists on `main` independent of this change. Left out of scope to keep this PR minimal; the two new scripts were validated manually against every clause of the contract.

## Scope

This finishes Phase 2 for the two missing agents. Still open under #237: Phase 4 (report-path migration) and Phase 5 (DESIGN.md / Google Stitch generation). Hence **Refs**, not **Closes**.