### PR TITLE
fix: make per-agent --init contract test portable on Linux

### DIFF
--- a/claude-skills/tests/test_init_scripts.sh
+++ b/claude-skills/tests/test_init_scripts.sh
@@ -50,7 +50,13 @@ check_script() {
     bash "$path" > /tmp/init-script-output.$$ 2>/dev/null || true
   )
   local pre_files=$(find "$tmp" -mindepth 1 -not -path '*/.git*' 2>/dev/null | wc -l | tr -d ' ')
-  local out_size=$(stat -f %z /tmp/init-script-output.$$ 2>/dev/null || stat -c %s /tmp/init-script-output.$$ 2>/dev/null || echo 0)
+  # Byte count via `wc -c` is portable across GNU and BSD. Don't use
+  # `stat -f %z` (BSD) with a `stat -c %s` (GNU) fallback: on GNU
+  # coreutils `stat -f` means "filesystem status" and *succeeds*,
+  # printing filesystem info instead of a size, so the `||` fallback
+  # never fires and the result is unusable in `[[ -gt ]]`.
+  local out_size=$(wc -c < /tmp/init-script-output.$$ 2>/dev/null | tr -d ' ' || echo 0)
+  [[ -n "$out_size" ]] || out_size=0
   rm -rf "$tmp" /tmp/init-script-output.$$
 
   assert "$name emits non-empty stdout in empty repo" "[[ '$out_size' -gt 50 ]]"


### PR DESCRIPTION
Part of #237 (deliverable 3 — unit test enforcement).

## Problem

`claude-skills/tests/test_init_scripts.sh`, the contract guard that
validates every per-agent `--init` script, crashed on Linux **before
validating anything**:

```
claude-skills/tests/test_init_scripts.sh: line 30: File: unbound variable
```

Root cause: it computed the script's stdout size with `stat -f %z`
(BSD/macOS) and a `stat -c %s` (GNU/Linux) fallback. On GNU coreutils
`stat -f` means *"display filesystem status"* and **succeeds**, printing
multi-line filesystem info instead of a byte count. The `||` fallback
therefore never fired, `out_size` captured that multi-line text, and the
subsequent `[[ "$out_size" -gt 50 ]]` blew up under `set -u`.

CI runs on Linux, so this guard was effectively dead.

## Changes

- Replace the BSD/GNU `stat` dance with portable `wc -c < file` for the
  byte count, with a `0` guard for the empty case.
- Add a comment explaining why `stat -f`/`stat -c` must not be used here.

## Test

```
$ bash claude-skills/tests/test_init_scripts.sh
PASS: 25, FAIL: 0
```

Before the fix the same command aborted with `File: unbound variable`
and `PASS: 0`. No behavior change on macOS (`wc -c` is portable).