### PR TITLE
feat(bsg-stack): add per-verb intent-routing playbooks

### DIFF
--- a/claude-skills/skills/bsg-stack/references/doctor.md
+++ b/claude-skills/skills/bsg-stack/references/doctor.md
@@ -1,0 +1,51 @@
+# `doctor` — health scorecard workflow
+
+Use this when the user asks "is this repo set up for BSG?", "check BSG
+health", "what's missing from `.bsg/`?", "audit my agent setup", or runs
+`/bsg-stack doctor`.
+
+`doctor` is **strictly read-only** (ADR-002). It never writes a file,
+opens a PR, or mutates GitHub. It is safe to run on a `SessionStart`
+hook, in CI, or inside a `/loop`.
+
+## Steps
+
+1. **Run the scorecard** from the target repo's root:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/doctor.sh
+   ```
+
+   For a machine-readable result (CI gates, piping into another tool):
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/doctor.sh --json
+   ```
+
+2. **Read the exit code.** `0` means nothing is missing. `1` means at
+   least one row is `✗` and the repo needs `/bsg-stack init`. Soft `⚠`
+   warnings (stale, partial, legacy path) never raise the exit code.
+
+3. **Reply to the user** with:
+   - The one-line summary (`N ok / M warn / K missing`)
+   - The specific `✗` rows and their remediation (`run /bsg-stack init`)
+   - Any `⚠` rows worth flagging (stale docs, legacy paths to migrate)
+   - The autopilot state (enabled / disabled / legacy path / missing)
+
+## What to highlight
+
+- `✗ missing` custom docs — these block the owning agent from
+  producing useful output until bootstrapped.
+- Missing required labels (`needs-human-review`, `human-reviewed`, bus
+  labels) — agents cannot route work without them.
+- `⚠ stale` docs older than 90 days — suggest `/bsg-stack update`.
+- Legacy paths (`po/PLAN.md`, `.securityignore`, etc.) — suggest
+  migrating to the `.bsg/` convention (see ADR-001).
+
+## What NOT to do
+
+- Do NOT auto-fix anything from `doctor` findings. `doctor` diagnoses;
+  `init` / `update` write. This separation is the ADR-002 contract.
+- Do NOT open a PR, create a label, or write a file from this verb.
+- Do NOT run agent `tick`s — that is each agent's own job.
+- Do NOT sweep other repos — `doctor` is repo-scoped by design.

--- a/claude-skills/skills/bsg-stack/references/init.md
+++ b/claude-skills/skills/bsg-stack/references/init.md
@@ -1,0 +1,63 @@
+# `init` — first-time bootstrap workflow
+
+Use this when the user asks to "bootstrap BSG", "set up the agents",
+"create the `.bsg/` folder", or runs `/bsg-stack init`. This verb
+turns a fresh repo into one where every BSG agent has its custom doc,
+the required labels exist, and an autopilot scaffold is in place.
+
+Per ADR-002 `init` is **NOT read-only**: it creates files and may
+create GitHub labels. Only run it on explicit user intent.
+
+## Steps
+
+1. **Preview first.** Always show the user what would change before
+   touching the repo:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/init.sh --dry-run
+   ```
+
+2. **Confirm with the user**, then apply:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/init.sh
+   ```
+
+   Useful flags:
+   - `--no-labels` — skip GitHub label creation (e.g. no `gh` auth)
+   - `--skip <agent>` — skip one agent's `--init` (repeatable)
+
+3. **What `init` does, in order:**
+   1. Creates the `.bsg/` skeleton (`reports/<bus>/`, `adr/`, `brand/`)
+   2. Runs each registered agent's `--init` script and writes the
+      captured output to `.bsg/<DOC>` — idempotent, skips docs that
+      already exist
+   3. Bootstraps missing labels (`needs-human-review`,
+      `human-reviewed`, every bus label in `agents/registry.json`)
+   4. Drops a disabled `.bsg/AUTOPILOT.yml` scaffold if neither the
+      new nor legacy autopilot file exists
+
+4. **Hand the tree back to the user for review.** `init` deliberately
+   leaves `.bsg/` dirty — it does not commit or open a PR. Tell the
+   user to:
+   - Review the generated files (replace `_placeholder_` text)
+   - `git add .bsg/ && git commit`
+   - Run `/bsg-stack doctor` to verify the result
+
+## Behaviour to know
+
+- **Idempotent.** Re-running `init` never overwrites a doc that
+  already exists; it only fills gaps. Safe to re-run after adding a
+  new agent.
+- **Partial agents.** Agents whose `--init` script has not shipped yet
+  are silently skipped and re-listed as missing in `doctor`. The
+  orchestrator picks up new scripts automatically — no SKILL.md edit.
+
+## What NOT to do
+
+- Do NOT run `init` without a `--dry-run` preview and user consent.
+- Do NOT commit or open the PR for the user unless they ask — review
+  of generated drafts is a human step by design.
+- Do NOT hand-edit a generated doc and then re-run `init` expecting it
+  to merge — `init` skips existing docs entirely. Use `update` for
+  refreshes.

--- a/claude-skills/skills/bsg-stack/references/status.md
+++ b/claude-skills/skills/bsg-stack/references/status.md
@@ -1,0 +1,44 @@
+# `status` — quick configuration view workflow
+
+Use this when the user asks "what agents are configured?", "BSG
+status", "quick BSG check", or runs `/bsg-stack status`. This is the
+fast, glanceable counterpart to `doctor` — same data, one line.
+
+`status` is **strictly read-only** (ADR-002). It is a thin wrapper
+around `doctor.sh --status` and shares its exit-code contract.
+
+## Steps
+
+1. **Run the one-line summary** from the target repo's root:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/status.sh
+   ```
+
+   For a machine-readable result:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/status.sh --json
+   ```
+
+2. **Read the exit code.** Identical to `doctor`: `0` when nothing is
+   missing, `1` when at least one row is `✗`. Warnings do not raise it.
+
+3. **Reply to the user** with the single summary line, e.g.
+   `BSG: 6 ok / 2 warn / 1 missing (autopilot: disabled)`. If the user
+   wants the breakdown behind those numbers, run `doctor` (see
+   `references/doctor.md`) instead of paraphrasing.
+
+## When to use `status` vs `doctor`
+
+- `status` — a quick pulse: a `SessionStart` greeting, a CI gate, or a
+  `/loop` heartbeat where the full table would be noise.
+- `doctor` — the user wants the per-agent breakdown and remediation
+  steps.
+
+## What NOT to do
+
+- Do NOT write files, open PRs, or create labels — same read-only
+  contract as `doctor`.
+- Do NOT reconstruct the full scorecard from the summary line; if the
+  user needs detail, call `doctor`.

--- a/claude-skills/skills/bsg-stack/references/update.md
+++ b/claude-skills/skills/bsg-stack/references/update.md
@@ -1,0 +1,57 @@
+# `update` — refresh stale custom docs workflow
+
+Use this when the user asks to "refresh my plan", "update stale docs",
+"the `.bsg/` docs are out of date", or runs `/bsg-stack update`. This
+verb re-runs the per-agent `--init` scans for docs that exist but have
+gone stale, producing fresh drafts for the human to diff and merge.
+
+Per ADR-002 `update` is **NOT read-only**: it writes draft files. It
+does **not** overwrite a committed custom doc — drafts land in
+`.bsg/.update-pending/` for explicit human merge.
+
+## Steps
+
+1. **Preview first** to see which docs are stale:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/update.sh --dry-run
+   ```
+
+2. **Confirm with the user**, then apply:
+
+   ```bash
+   bash claude-skills/skills/bsg-stack/scripts/update.sh
+   ```
+
+   Useful flags:
+   - `--threshold N` — staleness threshold in days (default `90`)
+   - `--force` — refresh even fresh docs (override the threshold)
+
+3. **What `update` does:**
+   - For each agent whose `.bsg/<DOC>` exists and is older than the
+     threshold, re-runs its `--init` script and writes the refreshed
+     draft to `.bsg/.update-pending/<doc>.draft.md`
+   - Skips docs that are still fresh, and docs not yet bootstrapped
+     (those need `/bsg-stack init` first)
+
+4. **Hand the drafts back for human merge.** Tell the user to:
+   - Diff each `.bsg/.update-pending/*.draft.md` against its committed
+     sibling
+   - Merge or discard each draft based on what changed in the repo
+   - Remove `.bsg/.update-pending/` once merged
+
+## When to use `update` vs `init`
+
+- `init` — the doc does **not exist yet**. First-time bootstrap.
+- `update` — the doc **exists but is stale**. Refresh against the
+  current repo state without clobbering human edits.
+
+## What NOT to do
+
+- Do NOT run `update` without a `--dry-run` preview and user consent.
+- Do NOT overwrite the committed doc with the draft automatically —
+  the diff-and-merge step is a human decision by design.
+- Do NOT use `update` to bootstrap a missing doc — it skips
+  non-existent docs. Use `init` for that.
+- Do NOT leave `.bsg/.update-pending/` committed; it is a scratch
+  area, not tracked content.


### PR DESCRIPTION
Closes #624

## Context

The `/bsg-stack` umbrella skill (doctor, init, update, status) was
already implemented across #580 and #595 and is green in
`test_skills.py` + `test_bsg_stack_orchestrator.sh`. The one remaining
gap against the skill's own documented contract: `SKILL.md`'s
**Intent routing** table points to `references/doctor.md`,
`references/status.md`, `references/init.md`, and
`references/update.md` — none of which existed. The `po` skill ships
exactly this `references/` playbook pattern; `bsg-stack` declared it
but never delivered the files.

## Changes

- Add `claude-skills/skills/bsg-stack/references/doctor.md` — read-only
  scorecard workflow, exit-code contract, what to highlight / avoid.
- Add `claude-skills/skills/bsg-stack/references/status.md` — one-line
  view workflow, when to use vs `doctor`.
- Add `claude-skills/skills/bsg-stack/references/init.md` — first-time
  bootstrap workflow, dry-run-first, idempotency, hand-back-for-review.
- Add `claude-skills/skills/bsg-stack/references/update.md` — stale-doc
  refresh workflow, `.update-pending/` merge step, init-vs-update.

All four are consistent with ADR-002's read-only/write split and the
actual behaviour of the existing scripts. No script or SKILL.md change
needed — the intent-routing links now resolve.

## Test

- `python3 claude-skills/tests/test_skills.py` → 17 passed
- `bash claude-skills/tests/test_bsg_stack_orchestrator.sh` → 18 passed
- Reference files require no footer (`all_footer_bearing_files` covers
  only commands + SKILL.md + agents), matching `po/references/`.