### PR TITLE
feat(md-to-office): extend brand scan for Stitch DESIGN.md signals

### DIFF
--- a/claude-skills/skills/md-to-office/SKILL.md
+++ b/claude-skills/skills/md-to-office/SKILL.md
@@ -94,11 +94,17 @@ branded Office templates. Signals detected:
 
 | Signal | Where it looks |
 |---|---|
-| **Colors** | CSS custom properties, `tailwind.config.*`, design-token JSON |
+| **Colors** | CSS custom properties, `tailwind.config.*`, Tailwind v4 `@theme` blocks, design-token JSON, Style Dictionary trees (`tokens/**/*.json`, `*.tokens.json`), Figma Tokens exports (`tokens.figma.json`, `$themes.json`) |
 | **Typography** | CSS `--font-*` variables, `@font-face`, Google Fonts imports |
 | **Logo** | `public/`, `brand/`, `images/`, `assets/` — files with "logo" in name |
-| **Voice & identity** | `brand/NARRATIVE.md`, `DESIGN.md`, `*identity*.md` |
+| **Favicon** | `favicon.{ico,svg,png}`, `apple-touch-icon.*`, `icon-*.*` (root, `public/`, `app/`, `static/`) |
+| **OG / social** | `og-image.*`, `opengraph-image.*`, `twitter-image.*`, `social-card.*` |
+| **Voice & identity** | `.bsg/NARRATIVE.md`, `.bsg/DESIGN.md`, `brand/NARRATIVE.md`, `*identity*.md` |
 | **Existing templates** | `.docx`, `.pptx`, `.xlsx` already in the repo |
+
+The scan emits `.bsg/DESIGN.md` (Google Stitch design-system spec — the
+[canonical brand source](https://blog.google/innovation-and-ai/models-and-research/google-labs/stitch-design-md/))
+alongside `brand/tokens.json` (derived shape used by the template renderers).
 
 ```bash
 md-to-office.sh --init                    # scan repo, generate templates
@@ -110,7 +116,8 @@ md-to-office.sh --init --tokens-only      # scan only, skip template gen
 Output:
 
 ```
-brand/tokens.json                   ← extracted tokens (name, colors, fonts, logos, …)
+.bsg/DESIGN.md                      ← Google Stitch design-system spec (canonical)
+brand/tokens.json                   ← derived tokens (name, colors, fonts, logos, favicons, og_images, …)
 brand/templates/brand-audit.md      ← what was found and what was chosen
 brand/templates/reference.docx      ← pandoc reference-doc with brand styles
 brand/templates/template.pptx       ← PowerPoint with brand theme

--- a/claude-skills/skills/md-to-office/scripts/scan-brand.py
+++ b/claude-skills/skills/md-to-office/scripts/scan-brand.py
@@ -280,8 +280,68 @@ def _scan_primary() -> str:
             except Exception:
                 continue
 
+    # --- Step 3: Style Dictionary / Figma Tokens nested format ---------------
+    # Style Dictionary wraps every leaf in { "value": "<hex>" } and nests under
+    # categories like color/colors/brand. Figma Tokens (Studio plugin) adds a
+    # "type": "color" sibling and groups under "global" / theme names.
+    # Both can ship as tokens/**/*.json, *.tokens.json, $themes.json, etc.
+    sd_globs = (
+        "tokens/**/*.json",
+        "design-tokens/**/*.json",
+        "tokens.figma.json",
+        "figma-tokens.json",
+        "*.tokens.json",
+        "$themes.json",
+    )
+    sd_candidates: list[Path] = []
+    for pattern in sd_globs:
+        for f in ROOT.glob(pattern):
+            if any(d in f.parts for d in _SKIP_DIRS):
+                continue
+            if f.is_file() and f not in sd_candidates:
+                sd_candidates.append(f)
+
+    primary_keys = ("primary", "brand", "accent", "main")
+    for f in sd_candidates:
+        try:
+            data = json.loads(f.read_text())
+        except Exception:
+            continue
+        found = _find_token_value(data, primary_keys)
+        if found:
+            result = _normalize_hex(found)
+            _audit("primary", f"Style Dictionary / Figma token in {_rel(f)}", result)
+            return result
+
     _default_applied("primary")
     return "#1a1a2e"
+
+
+def _find_token_value(node: object, name_hints: tuple[str, ...]) -> str | None:
+    """Walk a Style Dictionary / Figma Tokens tree, returning the first hex
+    value whose ancestor key matches one of `name_hints`. Leaves are detected
+    as dicts that carry a "value" entry (Style Dictionary / Figma convention).
+    """
+    def _walk(n: object, hint_matched: bool) -> str | None:
+        if isinstance(n, dict):
+            # Leaf: { "value": "...", "type": "color" } or just { "value": "..." }.
+            if "value" in n and isinstance(n["value"], str):
+                if hint_matched:
+                    raw = n["value"].strip()
+                    if re.match(r"#?[0-9a-fA-F]{3,6}$", raw):
+                        return raw
+                    return None
+                # Unmatched leaf — skip.
+                return None
+            for key, child in n.items():
+                key_lc = str(key).lower()
+                hit = hint_matched or any(h in key_lc for h in name_hints)
+                result = _walk(child, hit)
+                if result:
+                    return result
+        return None
+
+    return _walk(node, hint_matched=False)
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +418,115 @@ def _scan_logos() -> list[str]:
     results.sort()
     for r in results:
         _audit("logo", r, "found")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Favicon detection
+# ---------------------------------------------------------------------------
+
+_FAVICON_DIRS = ("public", "static", "app", "src/app", "brand", "assets", "img")
+_FAVICON_EXTS = (".ico", ".svg", ".png", ".webp")
+_FAVICON_STEMS = ("favicon", "apple-touch-icon", "apple-icon", "icon")
+
+
+def _scan_favicons() -> list[str]:
+    results: list[str] = []
+
+    def _maybe_add(f: Path) -> None:
+        if not f.is_file() or any(skip in f.parts for skip in _SKIP_DIRS):
+            return
+        if f.suffix.lower() not in _FAVICON_EXTS:
+            return
+        stem = f.stem.lower()
+        # Match canonical names exactly or as a prefix (e.g. icon-192.png),
+        # but never "logo-icon" or random "icon"-containing words.
+        if stem in _FAVICON_STEMS:
+            rel = _rel(f)
+            if rel not in results:
+                results.append(rel)
+            return
+        for canonical in _FAVICON_STEMS:
+            if stem == canonical or stem.startswith(canonical + "-"):
+                rel = _rel(f)
+                if rel not in results:
+                    results.append(rel)
+                return
+
+    for d in _FAVICON_DIRS:
+        dir_path = ROOT / d
+        if not dir_path.is_dir():
+            continue
+        for f in dir_path.rglob("*"):
+            _maybe_add(f)
+
+    # Top-level favicon.ico / favicon.svg (common in Next.js / Astro repos).
+    for ext in _FAVICON_EXTS:
+        for stem in _FAVICON_STEMS:
+            f = ROOT / f"{stem}{ext}"
+            if f.exists():
+                _maybe_add(f)
+
+    results.sort()
+    for r in results:
+        _audit("favicon", r, "found")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Open Graph / social share images
+# ---------------------------------------------------------------------------
+
+_OG_DIRS = ("public", "static", "app", "src/app", "brand", "assets", "img", "images")
+_OG_EXTS = (".png", ".jpg", ".jpeg", ".webp", ".svg")
+_OG_STEM_HINTS = (
+    "og-image",
+    "ogimage",
+    "opengraph-image",
+    "opengraph",
+    "og",
+    "twitter-image",
+    "twitter-card",
+    "social-card",
+    "social-share",
+)
+
+
+def _scan_og_images() -> list[str]:
+    results: list[str] = []
+
+    def _stem_matches(stem: str) -> bool:
+        s = stem.lower()
+        for hint in _OG_STEM_HINTS:
+            if s == hint or s.startswith(hint + "-") or s.startswith(hint + "."):
+                return True
+        return False
+
+    for d in _OG_DIRS:
+        dir_path = ROOT / d
+        if not dir_path.is_dir():
+            continue
+        for f in dir_path.rglob("*"):
+            if any(skip in f.parts for skip in _SKIP_DIRS):
+                continue
+            if not f.is_file() or f.suffix.lower() not in _OG_EXTS:
+                continue
+            if _stem_matches(f.stem):
+                rel = _rel(f)
+                if rel not in results:
+                    results.append(rel)
+
+    # Top-level og-image.* / opengraph-image.* (Next.js 13+ App Router convention).
+    for ext in _OG_EXTS:
+        for f in ROOT.glob(f"*{ext}"):
+            if _stem_matches(f.stem):
+                rel = _rel(f)
+                if rel not in results:
+                    results.append(rel)
+
+    results.sort()
+    for r in results:
+        _audit("og_image", r, "found")
     return results
 
 
@@ -448,11 +617,13 @@ def _generate_audit(tokens: dict, audit_path: Path) -> None:
         "primary": "Primary color",
         "font": "Typography",
         "logo": "Logo files",
+        "favicon": "Favicons",
+        "og_image": "Open Graph images",
         "identity": "Identity documents",
         "existing_template": "Existing Office templates",
     }
 
-    for key in ("name", "primary", "font", "logo", "identity", "existing_template"):
+    for key in ("name", "primary", "font", "logo", "favicon", "og_image", "identity", "existing_template"):
         label = section_labels.get(key, key)
         lines.append(f"### {label}")
         lines.append("")
@@ -530,10 +701,23 @@ def _contrast_ratio(fg: str, bg: str) -> float:
     return (lighter + 0.05) / (darker + 0.05)
 
 
+def _format_asset_rows(label: str, items: list[str]) -> list[str]:
+    if not items:
+        return [f"- **{label}** — _none detected. Add to the repo and re-run "
+                "`md-to-office.sh --init` to refresh._"]
+    rows = [f"- **{label}**"]
+    for item in items:
+        rows.append(f"  - `{item}`")
+    return rows
+
+
 def _generate_design_md(tokens: dict, design_path: Path) -> None:
     name = tokens["name"]
     primary = tokens["colors"]["primary"]
     font = tokens["fonts"]["primary"]
+    logos = tokens.get("logos", [])
+    favicons = tokens.get("favicons", [])
+    og_images = tokens.get("og_images", [])
 
     accent = _mix(primary, 255, 0.25)
     bg = "#ffffff"
@@ -614,6 +798,15 @@ def _generate_design_md(tokens: dict, design_path: Path) -> None:
         "",
         "<!-- Defaults — replace with the project's real component patterns. -->",
         "",
+        "## Brand assets",
+        "",
+        *_format_asset_rows("Logos", logos),
+        *_format_asset_rows("Favicons", favicons),
+        *_format_asset_rows("Open Graph / social images", og_images),
+        "",
+        "<!-- Detected by scan-brand.py. Replace placeholders with the team's "
+        "canonical assets and re-run `md-to-office.sh --init --force`. -->",
+        "",
         "## Accessibility",
         "",
         f"- Body text on background: contrast **{text_on_bg:.1f}:1** "
@@ -661,6 +854,8 @@ def main() -> None:
     font    = existing.get("fonts",  {}).get("primary") or _scan_font()
 
     logos = _scan_logos()
+    favicons = _scan_favicons()
+    og_images = _scan_og_images()
     identity_docs = _scan_identity_docs()
     existing_templates = _scan_existing_templates()
 
@@ -669,6 +864,8 @@ def main() -> None:
         "colors": {"primary": primary},
         "fonts":  {"primary": font},
         "logos":  logos,
+        "favicons": favicons,
+        "og_images": og_images,
         "identity_docs": identity_docs,
         "existing_templates": existing_templates,
     }

--- a/claude-skills/tests/test_md_to_office_init.py
+++ b/claude-skills/tests/test_md_to_office_init.py
@@ -216,6 +216,7 @@ class TestDesignMdGeneration(unittest.TestCase):
             "## Typography",
             "## Spacing & layout",
             "## Components",
+            "## Brand assets",
             "## Accessibility",
         ):
             self.assertIn(section, content, f"DESIGN.md missing {section!r}")
@@ -255,6 +256,37 @@ class TestDesignMdGeneration(unittest.TestCase):
         )
         content = (self.tmp / ".bsg" / "DESIGN.md").read_text()
         self.assertRegex(content, r"contrast \*\*\d+\.\d+:1\*\* \(WCAG ")
+
+    def test_design_md_lists_scanned_brand_assets(self) -> None:
+        """#623: detected favicons / OG images / logos surface in DESIGN.md."""
+        (self.tmp / "favicon.ico").write_bytes(b"\x00\x00\x01\x00")
+        (self.tmp / "og-image.png").write_bytes(b"\x89PNG")
+        pub = self.tmp / "public"
+        pub.mkdir()
+        (pub / "logo.svg").write_text("<svg/>")
+        run(
+            ["python3", str(SCAN_BRAND), "--design", ".bsg/DESIGN.md"],
+            cwd=self.tmp,
+        )
+        content = (self.tmp / ".bsg" / "DESIGN.md").read_text()
+        self.assertIn("## Brand assets", content)
+        self.assertIn("favicon.ico", content)
+        self.assertIn("og-image.png", content)
+        self.assertIn("logo.svg", content)
+
+    def test_design_md_brand_assets_section_handles_empty_repo(self) -> None:
+        """Empty repo must still emit the Brand assets section with placeholders."""
+        empty = Path(tempfile.mkdtemp(prefix="bsg-design-empty-"))
+        try:
+            run(
+                ["python3", str(SCAN_BRAND), "--design", ".bsg/DESIGN.md"],
+                cwd=empty,
+            )
+            content = (empty / ".bsg" / "DESIGN.md").read_text()
+            self.assertIn("## Brand assets", content)
+            self.assertIn("none detected", content.lower())
+        finally:
+            shutil.rmtree(empty, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/claude-skills/tests/test_md_to_office_scan.py
+++ b/claude-skills/tests/test_md_to_office_scan.py
@@ -140,6 +140,38 @@ class TestScanBrand(unittest.TestCase):
         )
         self.assertEqual(self._scan()["colors"]["primary"], "#ff6b35")
 
+    def test_primary_from_style_dictionary_tokens(self) -> None:
+        """#623: Style Dictionary nests leaves under {"value": "#hex"}."""
+        tokens_dir = self.tmp / "tokens"
+        tokens_dir.mkdir()
+        (tokens_dir / "color.json").write_text(json.dumps({
+            "color": {
+                "brand": {
+                    "primary": {"value": "#0066ff", "type": "color"},
+                    "secondary": {"value": "#999999", "type": "color"},
+                }
+            }
+        }))
+        self.assertEqual(self._scan()["colors"]["primary"], "#0066ff")
+
+    def test_primary_from_figma_tokens_export(self) -> None:
+        """#623: Figma Tokens (Studio plugin) groups under 'global'."""
+        (self.tmp / "tokens.figma.json").write_text(json.dumps({
+            "global": {
+                "colors": {
+                    "primary": {"value": "#abcdef", "type": "color"},
+                }
+            }
+        }))
+        self.assertEqual(self._scan()["colors"]["primary"], "#abcdef")
+
+    def test_primary_from_dotted_tokens_file(self) -> None:
+        """#623: any *.tokens.json file is treated as a design-token tree."""
+        (self.tmp / "brand.tokens.json").write_text(json.dumps({
+            "brand": {"primary": {"value": "112233"}}
+        }))
+        self.assertEqual(self._scan()["colors"]["primary"], "#112233")
+
     def test_primary_shorthand_hex_expanded(self) -> None:
         css = self.tmp / "main.css"
         css.write_text(":root { --primary: #f0f; }\n")
@@ -225,6 +257,65 @@ class TestScanBrand(unittest.TestCase):
     def test_logos_empty_when_none_found(self) -> None:
         tokens = self._scan()
         self.assertEqual(tokens["logos"], [])
+
+    # ---- favicon detection --------------------------------------------------
+
+    def test_favicon_found_at_root(self) -> None:
+        """#623: root-level favicon.ico / favicon.svg (Next.js / Astro convention)."""
+        (self.tmp / "favicon.ico").write_bytes(b"\x00\x00\x01\x00")
+        (self.tmp / "favicon.svg").write_text("<svg/>")
+        tokens = self._scan()
+        self.assertIn("favicons", tokens)
+        self.assertTrue(any("favicon.ico" in f for f in tokens["favicons"]))
+        self.assertTrue(any("favicon.svg" in f for f in tokens["favicons"]))
+
+    def test_favicon_found_in_public_dir(self) -> None:
+        """#623: favicon set under public/ (CRA / Vite convention)."""
+        pub = self.tmp / "public"
+        pub.mkdir()
+        (pub / "favicon.ico").write_bytes(b"\x00\x00\x01\x00")
+        (pub / "apple-touch-icon.png").write_bytes(b"\x89PNG")
+        (pub / "icon-192.png").write_bytes(b"\x89PNG")
+        favicons = self._scan()["favicons"]
+        self.assertTrue(any("favicon.ico" in f for f in favicons))
+        self.assertTrue(any("apple-touch-icon.png" in f for f in favicons))
+        self.assertTrue(any("icon-192.png" in f for f in favicons))
+
+    def test_favicon_does_not_match_logo_icon(self) -> None:
+        """`logo-icon.png` is a logo, not a favicon — must not be classified."""
+        pub = self.tmp / "public"
+        pub.mkdir()
+        (pub / "logo-icon.png").write_bytes(b"\x89PNG")
+        favicons = self._scan()["favicons"]
+        self.assertFalse(
+            any("logo-icon" in f for f in favicons),
+            f"logo-icon.png leaked into favicons: {favicons}",
+        )
+
+    def test_favicons_empty_when_none_found(self) -> None:
+        self.assertEqual(self._scan()["favicons"], [])
+
+    # ---- OG image detection -------------------------------------------------
+
+    def test_og_image_found_at_root(self) -> None:
+        """#623: Next.js 13+ App Router puts opengraph-image.* at root or in app/."""
+        (self.tmp / "og-image.png").write_bytes(b"\x89PNG")
+        (self.tmp / "opengraph-image.jpg").write_bytes(b"\xff\xd8\xff")
+        og = self._scan()["og_images"]
+        self.assertTrue(any("og-image.png" in p for p in og))
+        self.assertTrue(any("opengraph-image.jpg" in p for p in og))
+
+    def test_og_image_found_under_public(self) -> None:
+        pub = self.tmp / "public"
+        pub.mkdir()
+        (pub / "twitter-image.png").write_bytes(b"\x89PNG")
+        (pub / "social-card.png").write_bytes(b"\x89PNG")
+        og = self._scan()["og_images"]
+        self.assertTrue(any("twitter-image.png" in p for p in og))
+        self.assertTrue(any("social-card.png" in p for p in og))
+
+    def test_og_images_empty_when_none_found(self) -> None:
+        self.assertEqual(self._scan()["og_images"], [])
 
     # ---- identity doc detection ----------------------------------------------
 


### PR DESCRIPTION
Closes #623

## Changements

`scan-brand.py` (and the `.bsg/DESIGN.md` it emits per the Google Stitch
spec) now picks up the signal sources called out in the issue:

- **Style Dictionary token trees** (`tokens/**/*.json`, `*.tokens.json`)
  and **Figma Tokens** exports (`tokens.figma.json`, `$themes.json`).
  Both wrap leaves as `{ "value": "#hex" }`, which the previous flat-key
  walker did not handle.
- **Favicons** — `favicon.{ico,svg,png}`, `apple-touch-icon.*`, `icon-*`
  at the repo root and under `public/`, `static/`, `app/`.
- **OG / social images** — `og-image.*`, `opengraph-image.*`,
  `twitter-image.*`, `social-card.*`.

`DESIGN.md` gets a new `## Brand assets` section that lists every
detected logo, favicon and Open Graph image (or shows a placeholder
prompt when the repo carries none yet). `tokens.json` now exposes
matching `favicons` / `og_images` arrays, and the audit report + the
`md-to-office` SKILL.md table are updated in lockstep so the documented
catalogue stays consistent.

## Test

```bash
python3 claude-skills/tests/test_md_to_office_scan.py    # 40 tests (10 new)
python3 claude-skills/tests/test_md_to_office_init.py    # 16 tests (2 new for DESIGN.md)
```

End-to-end smoke (root favicon + OG image + Style Dictionary token +
CSS variables) verified manually — DESIGN.md renders the expected
Stitch sections (`Colors`, `Typography`, `Spacing & layout`,
`Components`, `Brand assets`, `Accessibility`) with the scanned values
substituted in.