### PR TITLE
test(bsg-stack): lock in init bootstraps the 4 agent custom docs (#622)

### DIFF
--- a/claude-skills/tests/test_bsg_stack_orchestrator.sh
+++ b/claude-skills/tests/test_bsg_stack_orchestrator.sh
@@ -67,6 +67,17 @@ assert "init creates .bsg/adr/"                 "[[ -d '$tmp/.bsg/adr' ]]"
 assert "init creates .bsg/reports/po/"          "[[ -d '$tmp/.bsg/reports/po' ]]"
 assert "init creates .bsg/AUTOPILOT.yml"        "[[ -f '$tmp/.bsg/AUTOPILOT.yml' ]]"
 
+# Per-agent custom docs that #622 (and the wider #237 batch) explicitly
+# required init.sh to bootstrap. Each row below pairs one of those four
+# agents with the .bsg/ path its init script must populate. Pin them here
+# so a future change that drops a wire from init.sh — or breaks one of
+# the per-agent init-*.sh scripts — fails the orchestrator suite
+# instead of silently producing an incomplete .bsg/ tree.
+assert "init creates .bsg/CALENDAR.md (marketing)"                "[[ -f '$tmp/.bsg/CALENDAR.md' ]]"
+assert "init creates .bsg/ANNOUNCED.md (pr-comms)"                "[[ -f '$tmp/.bsg/ANNOUNCED.md' ]]"
+assert "init creates .bsg/adr/0000-architecture-baseline.md"      "[[ -f '$tmp/.bsg/adr/0000-architecture-baseline.md' ]]"
+assert "init creates .bsg/reports/qa/0000-baseline.md"            "[[ -f '$tmp/.bsg/reports/qa/0000-baseline.md' ]]"
+
 # Capture pre-state, re-run, compare.
 pre="$(find "$tmp/.bsg" -type f | sort | xargs -I{} stat -f '%N %m' {} 2>/dev/null \
        || find "$tmp/.bsg" -type f | sort | xargs -I{} stat -c '%n %Y' {})"


### PR DESCRIPTION
Closes #622.

## Context

The 4 agents called out by #622 — **marketing**, **pr-comms**,
**tech-lead**, **qa** — all already have their `--init` infrastructure
landed:

| Agent | Custom doc | Init script | Shipped in |
|---|---|---|---|
| marketing | `.bsg/CALENDAR.md` | `marketing-report/scripts/init-calendar.sh` | #594 |
| pr-comms | `.bsg/ANNOUNCED.md` | `pr-comms-report/scripts/init-announced.sh` | #594 |
| tech-lead | `.bsg/adr/0000-architecture-baseline.md` | `tech-report/scripts/init-adr.sh` | #609 |
| qa | `.bsg/reports/qa/0000-baseline.md` | `qa-report/scripts/init-qa-baseline.sh` | #609 |

Each agent's frontmatter declares both `custom-doc:` and `init:`
(enforced by `test_agent_frontmatter.py`), each script passes the
five-point contract in `test_init_scripts.sh`, and `init.sh` already
routes the agent → script + agent → output-path maps for all four.

## What's missing

The orchestrator test only asserted the `.bsg/` skeleton (`.bsg/adr/`,
`.bsg/reports/po/`, `.bsg/AUTOPILOT.yml`) — not that the four custom
docs #622 explicitly names actually get bootstrapped by an `init.sh`
run. A future change that drops a row from `init.sh`'s case statement,
or that breaks one of the per-agent init-*.sh scripts, would silently
produce an incomplete `.bsg/` tree.

## Changes

Adds four file-exists assertions to
`claude-skills/tests/test_bsg_stack_orchestrator.sh` — one per agent
listed in #622 — pinned to the exact `.bsg/` paths the issue calls out.

## Test

- [x] `bash claude-skills/tests/test_bsg_stack_orchestrator.sh` →
  `PASS: 22, FAIL: 0` (previously 18 pass — 4 new guards).
- [x] Sanity-check that the guards bite: temporarily pointed
  `init.sh` at a nonexistent script for marketing and confirmed the
  suite drops to `PASS: 21, FAIL: 1` with the expected `init creates
  .bsg/CALENDAR.md (marketing)` failure, then recovered on restore.
- [x] `bash claude-skills/tests/test_init_scripts.sh` still
  `PASS: 40, FAIL: 0` (no contract change).