### PR TITLE
feat(security): scan CI config in init-securityignore

### DIFF
--- a/claude-skills/skills/security-report/scripts/init-securityignore.sh
+++ b/claude-skills/skills/security-report/scripts/init-securityignore.sh
@@ -2,10 +2,11 @@
 # init-securityignore.sh — generate a draft SECURITYIGNORE from repo scan.
 #
 # Part of #237 (per-agent --init contract): scans the repo for paths
-# that typically contain test fixtures, sample credentials, or example
-# data — i.e. the most common sources of secret-scanner false positives.
-# Emits a draft `.bsg/SECURITYIGNORE` to stdout. The security agent
-# reads this file every tick to suppress known false-positive paths.
+# that typically contain test fixtures, sample credentials, example
+# data, or CI configuration — i.e. the most common sources of
+# secret-scanner false positives. Emits a draft `.bsg/SECURITYIGNORE`
+# to stdout. The security agent reads this file every tick to suppress
+# known false-positive paths.
 #
 # The orchestrator (`/bsg-stack init`) captures stdout and opens a PR
 # for human review — this script never writes to disk.
@@ -79,6 +80,21 @@ done < <(find . -maxdepth 3 -type f \
     -name '*.example' -o -name '*.sample' \
     -o -name '.env.example' -o -name '.env.sample' -o -name '.env.template' \
   \) 2>/dev/null | head -20)
+
+# 4. CI config files / directories. CI workflows often inline placeholder
+# tokens, sample webhook URLs, or comment-out real secrets behind
+# `${{ secrets.* }}` references that some naive scanners mis-flag.
+# Listed so reviewers can keep what triggers FPs and drop the rest.
+for d in .github/workflows .circleci .gitlab .buildkite; do
+  if [[ -d "$d" ]]; then
+    add_suggestion "$d/"
+  fi
+done
+for f in .gitlab-ci.yml .travis.yml azure-pipelines.yml bitbucket-pipelines.yml Jenkinsfile; do
+  if [[ -f "$f" ]]; then
+    add_suggestion "$f"
+  fi
+done
 
 # ----------------------------------------------- emit
 


### PR DESCRIPTION
Closes #621

## Changements

Extend `claude-skills/skills/security-report/scripts/init-securityignore.sh` to also surface CI configuration files and directories — the issue asked the bootstrapper to scan *fixtures de test, données d'exemple, **config CI***, and CI config was the missing leg.

CI workflows commonly inline placeholder tokens, sample webhook URLs, or commented-out reference secrets that naive scanners mis-flag. Surfacing them in the draft `SECURITYIGNORE` lets the reviewer keep what actually triggers false positives and drop the rest (same pattern as the existing test/fixture suggestions).

New detection:
- Dirs: `.github/workflows/`, `.circleci/`, `.gitlab/`, `.buildkite/`
- Files: `.gitlab-ci.yml`, `.travis.yml`, `azure-pipelines.yml`, `bitbucket-pipelines.yml`, `Jenkinsfile`

The header comment is unchanged — reviewers are already told to delete what they don't recognise.

## Test

- `bash -n` clean.
- `bash claude-skills/tests/test_init_scripts.sh` → `PASS: 40, FAIL: 0` (contract still satisfied: stdout-only, non-empty in empty repo, --help exits 0).
- Manual: ran in a fresh `git init` tmpdir seeded with `.github/workflows/ci.yml`, `.circleci/config.yml`, `.gitlab-ci.yml`, `Jenkinsfile`, `.env.example`, `tests/fixtures/` — all six now appear in the draft.
- Manual on this repo: previously emitted only `tests/`; now also emits `.github/workflows/`.