### PR TITLE
fix(security-report): initialize SUGGESTIONS array for bash 3.2

### DIFF
--- a/claude-skills/skills/security-report/scripts/init-securityignore.sh
+++ b/claude-skills/skills/security-report/scripts/init-securityignore.sh
@@ -32,7 +32,7 @@ today=$(date -u +%F)
 
 # Track suggestions so we only emit each once, and report whether
 # anything was found.
-declare -a SUGGESTIONS
+SUGGESTIONS=()
 seen=""
 add_suggestion() {
   local path="$1"


### PR DESCRIPTION
## Summary

- `init-securityignore.sh` aborted with `EXIT=1` and \"SUGGESTIONS: unbound variable\" on any repo with no top-level `tests/`, `fixtures/`, `examples/`, or `*.sample` files.
- Root cause: on macOS bash 3.2 with `set -u`, `declare -a SUGGESTIONS` does **not** initialize the array — `${#SUGGESTIONS[@]}` later in the script then trips the unbound-variable check.
- Fix: replace `declare -a SUGGESTIONS` with `SUGGESTIONS=()`. One-line change, portable to bash 3.2 and bash 4+.

## How it surfaced

Running `/bsg-stack init` on a docs-only repo (no `tests/`, no `fixtures/`) reported:

```
create:  .bsg/SECURITYIGNORE  ← bash skills/security-report/scripts/init-securityignore.sh
  └─ ✗ script produced no output; nothing written
```

…and `/bsg-stack doctor` then flagged `.bsg/SECURITYIGNORE` as missing.

## Test plan

- [x] Re-ran `bash claude-skills/skills/security-report/scripts/init-securityignore.sh` on a repo with no fixture dirs → exit 0, fallback comment block emitted as designed
- [ ] Maintainer: re-run `/bsg-stack init` end-to-end on a docs-only repo and confirm `.bsg/SECURITYIGNORE` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)