### PR TITLE
feat(po): generate weekly task plan + Google Calendar daily blocks

### DIFF
--- a/claude-skills/skills/po/SKILL.md
+++ b/claude-skills/skills/po/SKILL.md
@@ -34,6 +34,7 @@ Read the user's request and pick the matching reference document:
 | Stale issues, no recent activity, abandoned work               | `references/stale.md`       |
 | PR review latency, merge queue, throughput                     | `references/pr-flow.md`     |
 | Velocity, burndown, trends, "are we speeding up/slowing down?" | `references/trends.md`      |
+| Wire the weekly plan into Google Calendar / assign issues      | `references/weekly-plan.md` |
 
 For multi-topic requests (e.g. "give me a full report"), follow `references/status.md`
 which itself orchestrates the others.
@@ -71,6 +72,7 @@ script auto-collect a fresh one.
 | `trends.sh`               | Reads `po/history/*.json` → velocity (issues closed / PRs merged per week), scope delta, timeseries. Git history is the trend store — no extra state. |
 | `generate-report.sh`      | Collects once, runs adherence, composes a full markdown report with the adherence matrix as headline. |
 | `render-adherence.jq`     | Standalone jq program that turns `adherence.sh` output into the "Plan adherence" markdown section (used by `generate-report.sh`). |
+| `weekly-plan.sh`          | Emits a Mon→Fri JSON breakdown of open issues; with `--calendar` creates/patches one `gws calendar +insert` event per working day (repo prefix mandatory); with `--assign --user X` batch-assigns the cited issues (dry-run by default, `--yes` to mutate). See `references/weekly-plan.md`. |
 
 **Invocation patterns:**
 

--- a/claude-skills/skills/po/references/weekly-plan.md
+++ b/claude-skills/skills/po/references/weekly-plan.md
@@ -1,0 +1,171 @@
+# Weekly task plan + Google Calendar daily blocks
+
+Use this when the user has a `po/reports/<date>-weekly-plan-s<NN>.md` ready and
+wants to **wire it into the week**: 5 calendar blocks (one per working day)
+and/or batch-assign GitHub issues. Driven by `scripts/weekly-plan.sh`.
+
+## Why it exists
+
+`/po` is great at producing the markdown weekly plan, but every Monday the
+PO still has to:
+
+1. Decide manually which day = which task
+2. Create 5 Google Calendar events by hand
+3. Remember to put the repo name in every event title (this was forgotten
+   on the first real run on `bsg-lbo` — all 5 events had to be patched)
+4. Re-assign GitHub issues to the right milestone / owner
+
+`weekly-plan.sh` collapses all four into one command.
+
+## What it does
+
+1. **Reads the snapshot** (`collect.sh` or `--snapshot`) and emits a JSON
+   per-day breakdown for Mon→Fri.
+2. **With `--calendar`**: creates (or patches, if same-prefix event exists)
+   one Google Calendar event per working day via `gws calendar +insert`.
+3. **With `--assign --user <login>`**: dry-runs the `gh issue edit
+   --add-assignee` calls; `--yes` actually mutates.
+
+## Invocation
+
+```bash
+# Just inspect the plan:
+bash claude-skills/skills/po/scripts/weekly-plan.sh
+
+# Pin the start day and slot, push to calendar:
+bash claude-skills/skills/po/scripts/weekly-plan.sh \
+  --calendar --start MON --slot 08:30-08:45
+
+# Reuse a snapshot collected earlier:
+bash claude-skills/skills/po/scripts/weekly-plan.sh \
+  --snapshot /tmp/snap.json --start 2026-06-01
+
+# Assign all cited issues to g-dumas (dry-run first!):
+bash claude-skills/skills/po/scripts/weekly-plan.sh --assign --user g-dumas
+bash claude-skills/skills/po/scripts/weekly-plan.sh --assign --user g-dumas --yes
+```
+
+## Flags
+
+| Flag             | Default                                  | Notes                                          |
+| ---------------- | ---------------------------------------- | ---------------------------------------------- |
+| `--snapshot`     | _auto_ (`collect.sh`)                    | Path to a pre-collected snapshot.              |
+| `--start`        | next Monday                              | `YYYY-MM-DD` or `MON`/`TUE`/...                |
+| `--slot`         | `08:30-08:45`                            | `HH:MM-HH:MM`. Same slot every day.            |
+| `--timezone`     | `Europe/Paris`                           | IANA tz.                                       |
+| `--report`       | `po/reports/<today>-weekly-plan-s<NN>.md`| Cited inside the event description.            |
+| `--calendar`     | off                                      | Push events.                                   |
+| `--calendar-id`  | `primary`                                | Target calendar id.                            |
+| `--assign`       | off                                      | Dry-run by default; add `--yes` to mutate.     |
+| `--user`         | _required with --assign_                 | GitHub login to add as assignee.               |
+| `--yes`          | off                                      | Required to actually mutate with `--assign`.   |
+
+## Per-day heuristic
+
+Issues are bucketed from their labels + state, then round-robin-assigned to a
+narrow set of target days:
+
+| Bucket             | Detected when…                                            | Target days |
+| ------------------ | --------------------------------------------------------- | ----------- |
+| `A_blocker`        | label in `{P0, blocker, urgent, go}`                      | Mon, Tue    |
+| `B_in_progress`    | has assignee OR label in `{in-progress, wip}`             | Tue, Wed    |
+| `C_outreach`       | label in `{outreach, cedant, cédant}`                     | Wed, Thu    |
+| `D_sprint`         | label in `{P1, epic, sprint}`                             | Wed, Thu    |
+| `Z_other`          | none of the above                                         | Mon→Thu     |
+| PR review batch    | OPEN, non-draft, `reviewDecision != APPROVED`             | Fri         |
+
+The day's `theme` is derived from the dominant bucket. Friday is reserved
+for PR reviews regardless.
+
+If your team uses different label conventions, edit the constant tables at
+the top of the python block in `scripts/weekly-plan.sh`. No external
+configuration file by design — labels rarely change.
+
+## Output shape
+
+```json
+{
+  "weekIso": "2026-W23",
+  "repo": "beyond-scale-group/bsg-lbo",
+  "repoShort": "bsg-lbo",
+  "repoUrl": "https://github.com/beyond-scale-group/bsg-lbo",
+  "reportPath": "po/reports/2026-06-01-weekly-plan-s23.md",
+  "days": [
+    {
+      "date": "2026-06-01",
+      "label": "Lun 1/6",
+      "priority": "P0",
+      "theme": "Débloquer P0 / urgences",
+      "tasks": [
+        {
+          "issue": 181,
+          "title": "Avocat LOI bloqué",
+          "url": "https://github.com/.../issues/181",
+          "action": "débloquer",
+          "kind": "issue"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Event format (mandatory)
+
+Calendar events created by `--calendar` **always** include:
+
+- **Title**: `[<repo-short>] PO Daily — <day> : <theme>` (e.g.
+  `[bsg-lbo] PO Daily — Lun 1/6 : Débloquer P0 / urgences`)
+- **Description** starts with the repo URL and the report reference:
+
+  ```
+  Repo: https://github.com/<owner>/<repo>
+  Réf: po/reports/<today>-weekly-plan-s<NN>.md
+
+  Tâches:
+  - #181 — Avocat LOI bloqué (débloquer)
+  - #132 — Envoyer LOI DIPOLE (débloquer)
+  ```
+
+The `[<repo-short>]` prefix is **non-negotiable** — multi-repo POs need to
+see the project context at a glance in their calendar. This was the
+real-world friction that motivated this script: the first manual run forgot
+the repo prefix and all 5 events had to be patched the next morning.
+
+## Idempotency
+
+Before inserting, the script asks `gws calendar events list` for events
+between `00:00` and `23:59` on the target date, filters by
+`summary | startswith("[<repo-short>] PO Daily — <day>")`, and:
+
+- **Match found** → `gws calendar events patch` (updates summary +
+  description + start + end).
+- **No match** → `gws calendar +insert`.
+
+So re-running the same command on the same week is safe.
+
+## `--assign` semantics
+
+- Iterates over unique `issue` numbers in the plan.
+- Skips an issue if `--user` is already in its assignees (no churn).
+- **Dry-run by default**: prints the `gh issue edit` command it _would_ run
+  to stderr.
+- Add `--yes` to actually call `gh issue edit --add-assignee`.
+
+> ⚠️ Milestone assignment is not yet implemented — `weekly-plan.sh` adds
+> assignees only. The per-task milestone is preserved in the JSON output
+> for callers that want to handle it themselves. If you need a one-shot
+> milestone fix, drive it from the JSON:
+>
+> ```bash
+> bash scripts/weekly-plan.sh | jq -r '.days[].tasks[].issue' \
+>   | xargs -I{} gh issue edit {} --milestone 'Sprint 23'
+> ```
+
+## When to fall back to manual
+
+- The plan calls for tasks that aren't open issues yet (just bullets in the
+  markdown) — the script can't see them. Open issues first, then re-run.
+- You want a custom slot per day (e.g. 08h30 Monday, 14h00 Friday). The
+  script uses a single slot. Patch the events manually after.
+- Cross-repo plans — out of scope, one repo per invocation.

--- a/claude-skills/skills/po/scripts/tests/weekly-plan-smoke.sh
+++ b/claude-skills/skills/po/scripts/tests/weekly-plan-smoke.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# weekly-plan-smoke.sh — smoke test for scripts/weekly-plan.sh.
+#
+# Feeds a fake snapshot into the script (no `gh`, no `gws`) and asserts
+# the JSON shape. Run from anywhere:
+#
+#   bash claude-skills/skills/po/scripts/tests/weekly-plan-smoke.sh
+#
+# Exit 0 = all pass, exit 1 = failure.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/../weekly-plan.sh"
+
+if [[ ! -x "$SUT" ]]; then
+  echo "FAIL: $SUT not executable" >&2
+  exit 1
+fi
+
+for bin in jq python3; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "SKIP: $bin missing" >&2
+    exit 0
+  fi
+done
+
+PASS=0
+FAIL=0
+
+assert() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+snap=$(mktemp)
+trap 'rm -f "$snap"' EXIT
+
+cat > "$snap" <<'JSON'
+{
+  "repo": "beyond-scale-group/bsg-lbo",
+  "generatedAt": "2026-06-01T08:00:00Z",
+  "issues": [
+    {"number": 181, "title": "Avocat LOI bloqué",
+     "url": "https://github.com/beyond-scale-group/bsg-lbo/issues/181",
+     "state": "OPEN", "labels": ["P0", "blocker"], "assignees": []},
+    {"number": 132, "title": "Envoyer LOI DIPOLE",
+     "url": "https://github.com/beyond-scale-group/bsg-lbo/issues/132",
+     "state": "OPEN", "labels": ["urgent"], "assignees": ["g-dumas"]},
+    {"number": 99, "title": "Refacto modèle valuation",
+     "url": "https://github.com/beyond-scale-group/bsg-lbo/issues/99",
+     "state": "OPEN", "labels": ["P1", "epic"], "assignees": []},
+    {"number": 88, "title": "Relance cédant ALPHA",
+     "url": "https://github.com/beyond-scale-group/bsg-lbo/issues/88",
+     "state": "OPEN", "labels": ["outreach"], "assignees": []},
+    {"number": 44, "title": "Already closed",
+     "url": "https://github.com/beyond-scale-group/bsg-lbo/issues/44",
+     "state": "CLOSED", "labels": [], "assignees": []}
+  ],
+  "pullRequests": [
+    {"number": 200, "title": "Fix typo",
+     "url": "https://github.com/beyond-scale-group/bsg-lbo/pull/200",
+     "state": "OPEN", "isDraft": false, "labels": [],
+     "reviewDecision": "REVIEW_REQUIRED"}
+  ],
+  "milestones": []
+}
+JSON
+
+# Pin a known Monday so the assertions are stable.
+out=$(bash "$SUT" --snapshot "$snap" --start 2026-06-01)
+
+# --- shape -----------------------------------------------------------------
+assert "top-level repo"      "beyond-scale-group/bsg-lbo" "$(jq -r '.repo' <<<"$out")"
+assert "top-level repoShort" "bsg-lbo"                    "$(jq -r '.repoShort' <<<"$out")"
+assert "top-level repoUrl"   "https://github.com/beyond-scale-group/bsg-lbo" "$(jq -r '.repoUrl' <<<"$out")"
+assert "weekIso"             "2026-W23"                   "$(jq -r '.weekIso' <<<"$out")"
+assert "exactly 5 days"      "5"                          "$(jq '.days | length' <<<"$out")"
+
+# --- per-day basics --------------------------------------------------------
+assert "Monday date"   "2026-06-01" "$(jq -r '.days[0].date'  <<<"$out")"
+assert "Friday date"   "2026-06-05" "$(jq -r '.days[4].date'  <<<"$out")"
+assert "Monday label"  "Lun 1/6"    "$(jq -r '.days[0].label' <<<"$out")"
+assert "Monday priority" "P0"       "$(jq -r '.days[0].priority' <<<"$out")"
+assert "Friday priority" "PR-REVIEW" "$(jq -r '.days[4].priority' <<<"$out")"
+
+# --- heuristics ------------------------------------------------------------
+# P0/blocker #181 lands Monday/Tuesday (first slot is Monday).
+assert "P0 issue routed to Mon" \
+  "181" \
+  "$(jq -r '.days[0].tasks[] | select(.kind == "issue") | .issue' <<<"$out" | head -n1)"
+
+# Closed issues should NOT appear anywhere.
+assert "closed issue absent" \
+  "0" \
+  "$(jq '[.days[].tasks[].issue] | map(select(. == 44)) | length' <<<"$out")"
+
+# PR review batch -> Friday only.
+assert "PR review on Friday" \
+  "200" \
+  "$(jq -r '.days[4].tasks[] | select(.kind == "pr-review") | .issue' <<<"$out")"
+
+assert "no PR review before Friday" \
+  "0" \
+  "$(jq '[.days[0:4][].tasks[] | select(.kind == "pr-review")] | length' <<<"$out")"
+
+# Every task must carry the four documented keys.
+missing_keys=$(jq '[.days[].tasks[]
+  | select((has("issue") and has("title") and has("url") and has("action") and has("kind")) | not)
+] | length' <<<"$out")
+assert "all tasks have required keys" "0" "$missing_keys"
+
+# Report path defaulting: must look like po/reports/YYYY-MM-DD-weekly-plan-sNN.md
+report=$(jq -r '.reportPath' <<<"$out")
+if [[ "$report" =~ ^po/reports/[0-9]{4}-[0-9]{2}-[0-9]{2}-weekly-plan-s[0-9]{2}\.md$ ]]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: reportPath shape"
+  echo "  got: $report"
+fi
+
+# --- weekday name resolution: --start FRI from a Monday should give that Friday
+out2=$(bash "$SUT" --snapshot "$snap" --start FRI 2>/dev/null) || true
+# Just check it produced 5 days and starts on a Friday-formatted label.
+n=$(jq '.days | length' <<<"$out2")
+assert "FRI start: 5 days" "5" "$n"
+fri_label=$(jq -r '.days[0].label' <<<"$out2")
+case "$fri_label" in
+  Ven\ *) PASS=$((PASS + 1)) ;;
+  *)
+    FAIL=$((FAIL + 1))
+    echo "FAIL: --start FRI: expected first day label to start with 'Ven '"
+    echo "  got: $fri_label"
+    ;;
+esac
+
+echo ""
+echo "PASS: $PASS, FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/claude-skills/skills/po/scripts/weekly-plan.sh
+++ b/claude-skills/skills/po/scripts/weekly-plan.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# weekly-plan.sh — turn the current snapshot into a Mon→Fri task plan,
+# optionally write it into Google Calendar and re-assign GitHub issues.
+#
+# By default emits JSON on stdout (see references/weekly-plan.md for the
+# shape). Flags:
+#
+#   --snapshot <path>       Reuse a collect.sh snapshot.
+#   --start <YYYY-MM-DD|MON> First day. Default: next Monday from today.
+#                           `MON` / `TUE` / ... resolves to the next
+#                           occurrence of that weekday (today if it matches).
+#   --slot <HH:MM-HH:MM>    Time slot for the calendar block. Default 08:30-08:45.
+#   --timezone <TZ>         IANA tz, default `Europe/Paris`.
+#   --report <path>         Markdown report to reference in event description.
+#                           Default: po/reports/<today>-weekly-plan-s<isoweek>.md
+#   --calendar              Create/patch one event per working day via gws.
+#   --calendar-id <ID>      Calendar to write to. Default `primary`.
+#   --assign                For each task, set assignee + milestone (dry-run).
+#   --user <login>          Login used by --assign. Required if --assign.
+#   --yes                   Actually mutate (otherwise --assign is dry-run).
+#
+# Exit codes:
+#   0 = success
+#   2 = usage error
+#   3 = missing dependency (gh / jq / gws / python3)
+#
+# Notes:
+# - Repo is resolved like collect.sh does: $GH_REPO env or `gh repo view`.
+# - Idempotent calendar writes: existing events on the matching date whose
+#   summary starts with `[<repo-short>] PO Daily — <day>` are patched
+#   instead of duplicated.
+# - --assign without --yes prints the would-be mutations to stderr.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# --- arg parsing ----------------------------------------------------------
+
+snapshot_path=""
+start_arg=""
+slot="08:30-08:45"
+timezone="Europe/Paris"
+report_path=""
+do_calendar=0
+calendar_id="primary"
+do_assign=0
+assign_user=""
+do_apply=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --snapshot) snapshot_path="$2"; shift 2 ;;
+    --start) start_arg="$2"; shift 2 ;;
+    --slot) slot="$2"; shift 2 ;;
+    --timezone) timezone="$2"; shift 2 ;;
+    --report) report_path="$2"; shift 2 ;;
+    --calendar) do_calendar=1; shift ;;
+    --calendar-id) calendar_id="$2"; shift 2 ;;
+    --assign) do_assign=1; shift ;;
+    --user) assign_user="$2"; shift 2 ;;
+    --yes) do_apply=1; shift ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "weekly-plan.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ $do_assign -eq 1 && -z "$assign_user" ]]; then
+  echo "weekly-plan.sh: --assign requires --user <login>" >&2
+  exit 2
+fi
+
+# --- deps -----------------------------------------------------------------
+
+for bin in jq python3; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "weekly-plan.sh: $bin not found" >&2
+    exit 3
+  fi
+done
+
+# --- snapshot -------------------------------------------------------------
+
+snapshot=""
+if [[ -n "$snapshot_path" ]]; then
+  snapshot=$(cat "$snapshot_path")
+elif [[ ! -t 0 ]]; then
+  snapshot=$(cat)
+fi
+if [[ -z "$snapshot" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "weekly-plan.sh: gh not found and no snapshot provided" >&2
+    exit 3
+  fi
+  snapshot=$(bash "$HERE/collect.sh")
+fi
+
+# --- build plan in python (cleaner than nested jq) ------------------------
+
+snap_tmp=$(mktemp)
+trap 'rm -f "$snap_tmp"' EXIT
+printf '%s' "$snapshot" > "$snap_tmp"
+
+plan_json=$(
+  REPORT_PATH="$report_path" \
+  START_ARG="$start_arg" \
+  TODAY_ISO="$(date -u +%F)" \
+  SNAPSHOT_PATH="$snap_tmp" \
+  python3 - <<'PY'
+import datetime as dt
+import json
+import os
+import sys
+
+with open(os.environ["SNAPSHOT_PATH"]) as f:
+    snapshot = json.load(f)
+start_arg = os.environ.get("START_ARG", "").strip()
+report_path = os.environ.get("REPORT_PATH", "").strip()
+today_iso = os.environ["TODAY_ISO"]
+today = dt.date.fromisoformat(today_iso)
+
+WEEKDAY_MAP = {"MON":0,"TUE":1,"WED":2,"THU":3,"FRI":4,"SAT":5,"SUN":6}
+
+def next_weekday(d: dt.date, target: int) -> dt.date:
+    delta = (target - d.weekday()) % 7
+    if delta == 0:
+        return d  # today matches target
+    return d + dt.timedelta(days=delta)
+
+if not start_arg:
+    start = next_weekday(today, 0)
+elif start_arg.upper() in WEEKDAY_MAP:
+    start = next_weekday(today, WEEKDAY_MAP[start_arg.upper()])
+else:
+    try:
+        start = dt.date.fromisoformat(start_arg)
+    except ValueError:
+        print(f"weekly-plan.sh: invalid --start value: {start_arg}", file=sys.stderr)
+        sys.exit(2)
+
+iso_year, iso_week, _ = start.isocalendar()
+week_iso = f"{iso_year}-W{iso_week:02d}"
+
+# Label uses the actual weekday so `--start FRI` produces "Ven … / Sam …",
+# not "Lun …". We still emit exactly 5 days regardless of start.
+WEEKDAY_FR = ["Lun","Mar","Mer","Jeu","Ven","Sam","Dim"]
+days = []
+for i in range(5):
+    d = start + dt.timedelta(days=i)
+    days.append({
+        "date": d.isoformat(),
+        "label": f"{WEEKDAY_FR[d.weekday()]} {d.day}/{d.month}",
+        "index": i,
+    })
+
+repo = snapshot.get("repo", "")
+repo_short = repo.split("/", 1)[1] if "/" in repo else repo
+repo_url = f"https://github.com/{repo}" if repo else ""
+
+if not report_path:
+    report_path = f"po/reports/{today_iso}-weekly-plan-s{iso_week:02d}.md"
+
+# --- classify issues ------------------------------------------------------
+
+BLOCKER_LABELS = {"P0", "blocker", "urgent", "go"}
+IN_PROGRESS_LABELS = {"in-progress", "wip"}
+OUTREACH_LABELS = {"outreach", "cedant", "cédant"}
+SPRINT_LABELS = {"P1", "epic", "sprint"}
+
+def classify(issue: dict) -> str:
+    labels = set(issue.get("labels") or [])
+    if labels & BLOCKER_LABELS:
+        return "A_blocker"
+    if (issue.get("assignees") or []) or (labels & IN_PROGRESS_LABELS):
+        return "B_in_progress"
+    if labels & OUTREACH_LABELS:
+        return "C_outreach"
+    if labels & SPRINT_LABELS:
+        return "D_sprint"
+    return "Z_other"
+
+# Target day indices per bucket (round-robin within those days).
+TARGETS = {
+    "A_blocker":     [0, 1],
+    "B_in_progress": [1, 2],
+    "C_outreach":    [2, 3],
+    "D_sprint":      [2, 3],
+    "Z_other":       [0, 1, 2, 3],
+}
+
+ACTIONS = {
+    "A_blocker":     "débloquer",
+    "B_in_progress": "avancer",
+    "C_outreach":    "relancer",
+    "D_sprint":      "avancer sprint",
+    "Z_other":       "traiter",
+}
+
+THEMES = {
+    "A_blocker":     "Débloquer P0 / urgences",
+    "B_in_progress": "Push work in-progress",
+    "C_outreach":    "Outreach cédants",
+    "D_sprint":      "Avancer le sprint",
+    "Z_other":       "Backlog / divers",
+}
+
+by_day: dict[int, list[dict]] = {i: [] for i in range(5)}
+counters: dict[str, int] = {}
+
+open_issues = [i for i in (snapshot.get("issues") or []) if i.get("state") == "OPEN"]
+
+for issue in open_issues:
+    bucket = classify(issue)
+    targets = TARGETS[bucket]
+    n = counters.get(bucket, 0)
+    day_idx = targets[n % len(targets)]
+    counters[bucket] = n + 1
+    by_day[day_idx].append({
+        "number": issue.get("number"),
+        "title": issue.get("title", ""),
+        "url": issue.get("url", ""),
+        "labels": issue.get("labels") or [],
+        "milestone": (issue.get("milestone") or {}).get("title") if issue.get("milestone") else None,
+        "bucket": bucket,
+        "kind": "issue",
+    })
+
+# PR review batch -> Friday (index 4).
+prs = []
+for pr in (snapshot.get("pullRequests") or []):
+    if pr.get("state") != "OPEN":
+        continue
+    if pr.get("isDraft"):
+        continue
+    if pr.get("reviewDecision") == "APPROVED":
+        continue
+    prs.append({
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "url": pr.get("url", ""),
+        "labels": pr.get("labels") or [],
+        "bucket": "E_pr_review",
+        "kind": "pr-review",
+    })
+
+by_day[4].extend(prs)
+
+def theme_for(idx: int, tasks: list[dict]) -> str:
+    if idx == 4 and any(t["kind"] == "pr-review" for t in tasks):
+        return "PR review batch"
+    if not tasks:
+        return "Buffer / overflow"
+    counts: dict[str, int] = {}
+    for t in tasks:
+        counts[t["bucket"]] = counts.get(t["bucket"], 0) + 1
+    top = max(counts.items(), key=lambda kv: kv[1])[0]
+    return THEMES.get(top, "Backlog / divers")
+
+def priority_for(idx: int) -> str:
+    if idx <= 1:
+        return "P0"
+    if idx == 4:
+        return "PR-REVIEW"
+    return "P1"
+
+def task_action(t: dict) -> str:
+    if t["kind"] == "pr-review":
+        return f"review PR #{t['number']}"
+    return ACTIONS.get(t["bucket"], "traiter")
+
+plan = {
+    "weekIso": week_iso,
+    "repo": repo,
+    "repoShort": repo_short,
+    "repoUrl": repo_url,
+    "reportPath": report_path,
+    "days": [
+        {
+            "date": d["date"],
+            "label": d["label"],
+            "priority": priority_for(d["index"]),
+            "theme": theme_for(d["index"], by_day[d["index"]]),
+            "tasks": [
+                {
+                    "issue": t.get("number"),
+                    "title": t.get("title", ""),
+                    "url": t.get("url", ""),
+                    "action": task_action(t),
+                    "kind": t.get("kind", "issue"),
+                }
+                for t in by_day[d["index"]]
+            ],
+        }
+        for d in days
+    ],
+}
+
+json.dump(plan, sys.stdout, ensure_ascii=False, indent=2)
+sys.stdout.write("\n")
+PY
+)
+
+# --- emit JSON ------------------------------------------------------------
+
+printf '%s\n' "$plan_json"
+
+if [[ $do_calendar -eq 0 && $do_assign -eq 0 ]]; then
+  exit 0
+fi
+
+# Pull a few values back out of the plan for side effects.
+repo=$(jq -r '.repo' <<<"$plan_json")
+repo_short=$(jq -r '.repoShort' <<<"$plan_json")
+repo_url=$(jq -r '.repoUrl' <<<"$plan_json")
+plan_report_path=$(jq -r '.reportPath' <<<"$plan_json")
+
+# --- calendar -------------------------------------------------------------
+
+if [[ $do_calendar -eq 1 ]]; then
+  if ! command -v gws >/dev/null 2>&1; then
+    echo "weekly-plan.sh: gws CLI not found — skipping --calendar" >&2
+    exit 3
+  fi
+
+  start_hm="${slot%-*}"
+  end_hm="${slot#*-}"
+  if [[ ! "$start_hm" =~ ^[0-9]{2}:[0-9]{2}$ ]] || [[ ! "$end_hm" =~ ^[0-9]{2}:[0-9]{2}$ ]]; then
+    echo "weekly-plan.sh: invalid --slot '$slot' (expected HH:MM-HH:MM)" >&2
+    exit 2
+  fi
+
+  ndays=$(jq '.days | length' <<<"$plan_json")
+  for i in $(seq 0 $((ndays - 1))); do
+    day_json=$(jq -c ".days[$i]" <<<"$plan_json")
+    date=$(jq -r '.date' <<<"$day_json")
+    label=$(jq -r '.label' <<<"$day_json")
+    theme=$(jq -r '.theme' <<<"$day_json")
+    tasks_md=$(jq -r '.tasks
+      | if length == 0 then "_(aucune tâche assignée)_"
+        else map("- " + (
+             if .issue then "#" + (.issue|tostring) + " — " + .title + " (" + .action + ")"
+             else .title + " (" + .action + ")"
+             end
+           )) | join("\n")
+      end' <<<"$day_json")
+
+    # MANDATORY repo prefix in title + description (fix from issue #636).
+    summary="[${repo_short}] PO Daily — ${label} : ${theme}"
+    description=$(printf 'Repo: %s\nRéf: %s\n\nTâches:\n%s' \
+      "$repo_url" "$plan_report_path" "$tasks_md")
+
+    # Compute offset for the timezone via python (portable across mac/linux).
+    offset=$(TZ_NAME="$timezone" DATE_STR="$date" HM="$start_hm" python3 - <<'PY'
+import datetime as dt
+import os
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    print("+00:00"); raise SystemExit(0)
+tz_name = os.environ["TZ_NAME"]
+date_str = os.environ["DATE_STR"]
+h, m = (int(x) for x in os.environ["HM"].split(":"))
+d = dt.date.fromisoformat(date_str)
+local = dt.datetime(d.year, d.month, d.day, h, m, tzinfo=ZoneInfo(tz_name))
+off = local.utcoffset() or dt.timedelta(0)
+total = int(off.total_seconds())
+sign = "+" if total >= 0 else "-"
+total = abs(total)
+print(f"{sign}{total//3600:02d}:{(total%3600)//60:02d}")
+PY
+)
+
+    start_rfc="${date}T${start_hm}:00${offset}"
+    end_rfc="${date}T${end_hm}:00${offset}"
+
+    # Idempotency: look for an existing event the same day whose summary
+    # starts with the repo-tagged prefix.
+    time_min="${date}T00:00:00${offset}"
+    time_max="${date}T23:59:59${offset}"
+    existing_id=""
+    existing_id=$(gws calendar events list --params "$(jq -nc \
+        --arg cid "$calendar_id" --arg tmin "$time_min" --arg tmax "$time_max" \
+        '{calendarId:$cid,timeMin:$tmin,timeMax:$tmax,singleEvents:true,orderBy:"startTime"}')" 2>/dev/null \
+      | jq -r --arg prefix "[${repo_short}] PO Daily — ${label}" \
+            '.items // [] | map(select(.summary | startswith($prefix))) | (.[0].id // "")' \
+      2>/dev/null || true)
+
+    if [[ -n "$existing_id" ]]; then
+      echo "weekly-plan.sh: patch existing event ${existing_id} for ${date}" >&2
+      gws calendar events patch \
+        --params "$(jq -nc --arg cid "$calendar_id" --arg eid "$existing_id" \
+                       '{calendarId:$cid,eventId:$eid}')" \
+        --json "$(jq -nc \
+                   --arg s "$summary" --arg d "$description" \
+                   --arg start "$start_rfc" --arg end "$end_rfc" \
+                   --arg tz "$timezone" \
+                   '{summary:$s,description:$d,
+                     start:{dateTime:$start,timeZone:$tz},
+                     end:{dateTime:$end,timeZone:$tz}}')" >/dev/null
+    else
+      echo "weekly-plan.sh: insert new event for ${date}" >&2
+      gws calendar +insert \
+        --summary "$summary" \
+        --start   "$start_rfc" \
+        --end     "$end_rfc" \
+        --description "$description" \
+        --calendar "$calendar_id" >/dev/null
+    fi
+  done
+fi
+
+# --- assign ---------------------------------------------------------------
+
+if [[ $do_assign -eq 1 ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "weekly-plan.sh: gh CLI not found — skipping --assign" >&2
+    exit 3
+  fi
+
+  issues=$(jq -r '.days[].tasks[] | select(.kind == "issue" and .issue != null) | (.issue|tostring)' \
+    <<<"$plan_json" | sort -u)
+
+  for n in $issues; do
+    current=$(printf '%s' "$snapshot" | jq -c --argjson n "$n" \
+      '.issues[] | select(.number == $n)
+       | {assignees: (.assignees // []),
+          milestone: (.milestone.title // null)}')
+    cur_assignees=$(jq -r '.assignees | join(",")' <<<"$current")
+
+    needs_assignee=1
+    if [[ -n "$cur_assignees" ]]; then
+      case ",${cur_assignees}," in *",${assign_user},"*) needs_assignee=0 ;; esac
+    fi
+
+    if [[ $needs_assignee -eq 1 ]]; then
+      if [[ $do_apply -eq 1 ]]; then
+        echo "weekly-plan.sh: gh issue edit #${n} --add-assignee ${assign_user}" >&2
+        gh issue edit "$n" --repo "$repo" --add-assignee "$assign_user" >/dev/null \
+          || echo "weekly-plan.sh: failed to assign #${n}" >&2
+      else
+        echo "[dry-run] gh issue edit #${n} --add-assignee ${assign_user} (repo=${repo})" >&2
+      fi
+    fi
+  done
+fi


### PR DESCRIPTION
Closes #636

## Changements

- **`claude-skills/skills/po/scripts/weekly-plan.sh`** (new)
  - Emits Mon→Fri JSON breakdown of open issues, classified by bucket (P0/blocker, in-progress, outreach, sprint, PR review).
  - `--calendar` → creates/patches 1 event per working day via `gws calendar +insert`.
  - Event title always: `[<repo-short>] PO Daily — <day> : <theme>`.
  - Event description always contains repo URL + reference to the markdown weekly-plan report.
  - Idempotent: existing same-day events whose summary starts with the repo-tagged prefix are patched, not duplicated.
  - `--assign --user <login>` → dry-runs `gh issue edit --add-assignee` for every cited issue; `--yes` to apply (skips no-ops where user is already assigned).
  - Flags for `--start` (date or `MON`/`TUE`/...), `--slot HH:MM-HH:MM` (default `08:30-08:45`), `--timezone`, `--report`, `--calendar-id`, `--snapshot`.
- **`claude-skills/skills/po/references/weekly-plan.md`** (new) — full doc: heuristic table, output shape, idempotency contract, dry-run semantics, known limitations.
- **`claude-skills/skills/po/SKILL.md`** — adds the routing row + scripts table entry.
- **`claude-skills/skills/po/scripts/tests/weekly-plan-smoke.sh`** (new) — smoke test feeding a fake snapshot; asserts JSON shape, per-day heuristics, closed-issue exclusion, PR-review batching on Friday, weekday label resolution.

## Test

- [x] `bash -n claude-skills/skills/po/scripts/weekly-plan.sh` — syntax OK.
- [x] `bash claude-skills/skills/po/scripts/tests/weekly-plan-smoke.sh` — 18 assertions pass.
- [ ] Live calendar check on `bsg-lbo` next Monday: `bash scripts/weekly-plan.sh --calendar --start MON --slot 08:30-08:45`, then re-run same command and confirm events are patched (no duplicates).
- [ ] `--assign --user g-dumas` dry-run on a real snapshot to confirm the list of `gh issue edit` invocations.

## Out of scope (per issue)

- Cross-repo plans (one repo per run).
- Recurring weekly cron — use `/loop` / `/schedule` skills.
- Non-Google calendars.
- Milestone assignment via `--assign` — documented as a follow-up in `references/weekly-plan.md` (assignee-only for v1; milestone info is preserved in the JSON for downstream callers).