### PR TITLE
feat(onboard-laptop): add Wispr Flow + Superconductor to developer profiles

### DIFF
--- a/claude-skills/skills/onboard-laptop/references/profiles/developer.yml
+++ b/claude-skills/skills/onboard-laptop/references/profiles/developer.yml
@@ -26,6 +26,8 @@ brew_cask:
   - 1password
   - docker
   - rectangle
+  - wispr-flow            # system-wide voice dictation
+  - superconductor        # git worktree + Claude Code session manager
 
 # --- Windows ---
 winget:

--- a/claude-skills/skills/onboard-laptop/references/profiles/linux-developer.yml
+++ b/claude-skills/skills/onboard-laptop/references/profiles/linux-developer.yml
@@ -13,6 +13,7 @@ apt:
   - jq
   - ripgrep
   - fzf
+  - tmux                   # worktree-per-pane workflow (Superconductor alternative)
   - python3
   - python3-pip
   - python3-venv
@@ -24,6 +25,7 @@ apt:
   - apt-transport-https
   - unzip
   - zip
+  - xdotool                # X11 keystroke injection for nerd-dictation
 
 # --- Linux (snap — GUI apps + sandboxed CLIs) ---
 snap:
@@ -49,6 +51,7 @@ pip_global:
   - black
   - ruff
   - virtualenv
+  - vosk                   # offline speech engine for nerd-dictation (Wispr Flow alternative)
 
 # --- post_install: idempotent setup commands ---
 post_install:
@@ -56,6 +59,22 @@ post_install:
   - 'git config --global pull.rebase true'
   - 'git config --global core.editor "code --wait"'
   - 'sudo usermod -aG docker $USER'
+
+# --- Wispr Flow alternative: nerd-dictation (system-wide voice-to-text) ---
+# Wispr Flow is macOS/Windows only. nerd-dictation is offline, open source,
+# and uses the VOSK engine installed via pip above.
+# Clone and symlink — no package manager needed:
+#   git clone https://github.com/ideasman42/nerd-dictation.git ~/nerd-dictation
+#   ln -s ~/nerd-dictation/nerd-dictation ~/.local/bin/nerd-dictation
+#   nerd-dictation begin  # start dictating (uses xdotool to type)
+# On Wayland, replace xdotool with wtype: sudo apt install wtype
+
+# --- Superconductor alternative: git worktree + tmux ---
+# Superconductor (git worktree + Claude Code session manager) is macOS only.
+# On Linux, use git worktrees + tmux panes for the same parallel workflow:
+#   git worktree add ../feature-branch feature-branch
+#   tmux new-session -s feature-branch -c ../feature-branch
+# The BSG sync-worktree skill automates worktree lifecycle management.
 
 # --- Node.js via nvm (apt ships an old version) ---
 # Uncomment and run manually — nvm is installed via a curl script:


### PR DESCRIPTION
## Summary

- **macOS developer profile**: add `wispr-flow` and `superconductor` as brew casks
- **Linux developer profile**: add Linux-native alternatives since neither app supports Linux:
  - **Wispr Flow** → `nerd-dictation` (offline, VOSK-powered via `pip install vosk`, uses `xdotool` for X11 / `wtype` for Wayland)
  - **Superconductor** → `tmux` + `git worktree` workflow (+ BSG `sync-worktree` skill for lifecycle management)

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — 17/17 pass
- [x] `_parse-profile.py developer.yml` → emits `wispr-flow` and `superconductor` cask records
- [x] `_parse-profile.py linux-developer.yml` → emits `vosk`, `xdotool`, `tmux` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)