### PR TITLE
feat(google-workspace): gws-switch.sh — multi-profile auth switcher

### DIFF
--- a/claude-skills/skills/google-workspace/SKILL.md
+++ b/claude-skills/skills/google-workspace/SKILL.md
@@ -96,6 +96,48 @@ or service failing). Auto-repairs missing scopes by re-running
 `auth-login.sh` and re-checking — only escalates to manual if the scope
 is missing from the consent-screen registration.
 
+## Multi-account → `scripts/gws-switch.sh`
+
+`gws` only authenticates one account at a time (credentials live under
+`$GOOGLE_WORKSPACE_CLI_CONFIG_DIR`, default `~/.config/gws`). For
+agents juggling a personal account + several client accounts, the switch
+script wraps a per-profile config-dir pattern so toggling between them
+is a single command — no re-auth, no browser re-consent.
+
+```bash
+# Create a profile (one-time browser consent, scoped to its own dir):
+bash scripts/gws-switch.sh init prizoners
+bash scripts/gws-switch.sh init client-acme --readonly
+
+# Inspect:
+bash scripts/gws-switch.sh list      # PROFILE | EMAIL | DIR
+bash scripts/gws-switch.sh whoami    # current profile + bound email
+
+# Activate in the current shell (needs eval because env exports don't
+# survive a child bash):
+eval "$(bash scripts/gws-switch.sh use prizoners)"
+eval "$(bash scripts/gws-switch.sh use default)"
+
+# Cleaner UX — install the shell function once, then `gws-switch X`:
+bash scripts/gws-switch.sh install >> ~/.zshrc.user
+source ~/.zshrc.user
+gws-switch prizoners                 # → active
+gws-switch default                   # → back to ~/.config/gws
+gws-switch list
+
+# Remove a profile when the engagement ends:
+bash scripts/gws-switch.sh remove client-acme --yes
+```
+
+After `gws-switch.sh install`, every subsequent terminal can toggle
+between accounts with a single word. Token caches stay alive across
+switches — only the *first* auth on a profile requires the browser.
+
+⚠ Each profile carries its **own** OAuth tokens and scope set. Running
+`doctor.sh` or `signature-audit.sh` operates against whichever profile
+is active in the current shell — be explicit about which account you're
+auditing in any human-facing report.
+
 ## Gmail audit → aliases & signatures
 
 The skill ships three companion scripts that close the loop on the most
@@ -342,6 +384,7 @@ mention any drift to the user.
 ```
 First-time setup?  → bash scripts/onboard.sh         §First-time setup
 Health check?      → bash scripts/doctor.sh          §Daily health check
+Switch accounts?   → bash scripts/gws-switch.sh      §Multi-account
 Audit aliases?     → bash scripts/signature-audit.sh §Gmail audit
 Set a signature?   → bash scripts/signature-set.sh   §Gmail audit
 Markdown → email?  → bash scripts/email-md-send.sh   §Markdown email

--- a/claude-skills/skills/google-workspace/scripts/gws-switch.sh
+++ b/claude-skills/skills/google-workspace/scripts/gws-switch.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# gws-switch.sh — multi-profile switcher for `gws`.
+#
+# Background: `gws` keeps credentials under `$GOOGLE_WORKSPACE_CLI_CONFIG_DIR`
+# (default `~/.config/gws`) and only authenticates one account at a time.
+# Pointing that env var at a per-profile directory gives you N parallel
+# accounts; switching is then a single `export` away. This script wraps
+# that pattern with a clean CLI.
+#
+# USAGE
+#   bash scripts/gws-switch.sh list
+#       List every profile under ~/.config/gws* with email + token status.
+#
+#   bash scripts/gws-switch.sh whoami
+#       Show the active profile (default or named) and the bound email.
+#
+#   bash scripts/gws-switch.sh init <name> [auth-login-args...]
+#       Create profile <name> at ~/.config/gws-<name> and run the OAuth
+#       consent flow against it. Extra args pass through to auth-login.sh
+#       (e.g. --readonly, --services gmail,calendar).
+#
+#   eval "$(bash scripts/gws-switch.sh use <name>)"
+#       Activate profile <name> in the current shell.
+#       <name> = `default` resets to ~/.config/gws (unsets the env var).
+#
+#   bash scripts/gws-switch.sh install
+#       Print a shell function `gws-switch` that wraps the eval pattern
+#       so users can type `gws-switch prizoners` without the eval shim.
+#       Append to ~/.zshrc.user or equivalent.
+#
+#   bash scripts/gws-switch.sh remove <name>
+#       Delete profile <name> (asks for confirmation; --yes to skip).
+#
+# Exit codes:
+#   0  ok
+#   1  invalid args / unknown profile
+#   2  auth flow failed
+#   3  unsupported environment
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROFILE_PREFIX="$HOME/.config/gws"
+DEFAULT_DIR="$HOME/.config/gws"
+
+die()  { printf "❌ %s\n" "$*" >&2; exit "${2:-1}"; }
+warn() { printf "⚠ %s\n" "$*" >&2; }
+note() { printf "ℹ %s\n" "$*" >&2; }
+
+require_bin() {
+  command -v "$1" >/dev/null || die "$1 not installed${2:+ — $2}" 3
+}
+
+profile_dir_for() {
+  local name="$1"
+  if [ "$name" = "default" ]; then
+    printf "%s" "$DEFAULT_DIR"
+  else
+    printf "%s-%s" "$PROFILE_PREFIX" "$name"
+  fi
+}
+
+profile_email() {
+  # Read email from a profile dir without disturbing the active env.
+  local dir="$1" email
+  [ -f "$dir/credentials.enc" ] || { printf "(no creds)"; return; }
+  email=$(GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$dir" \
+    gws gmail users getProfile --params '{"userId":"me"}' 2>/dev/null \
+    | jq -r '.emailAddress // empty' 2>/dev/null)
+  if [ -n "$email" ]; then
+    printf "%s" "$email"
+  else
+    printf "(auth invalid)"
+  fi
+}
+
+profile_token_valid() {
+  local dir="$1"
+  GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$dir" gws auth status 2>/dev/null \
+    | jq -e '.token_valid == true' >/dev/null
+}
+
+list_profiles() {
+  require_bin gws
+  require_bin jq
+  printf "%-20s  %-32s  %s\n" "PROFILE" "EMAIL" "DIR"
+  printf "%-20s  %-32s  %s\n" "-------" "-----" "---"
+  # Default profile
+  local email_default
+  if [ -d "$DEFAULT_DIR" ]; then
+    email_default=$(profile_email "$DEFAULT_DIR")
+    printf "%-20s  %-32s  %s\n" "default" "$email_default" "$DEFAULT_DIR"
+  fi
+  # Named profiles
+  local dir name email
+  for dir in "$PROFILE_PREFIX"-*; do
+    [ -d "$dir" ] || continue
+    name="${dir##*/gws-}"
+    email=$(profile_email "$dir")
+    printf "%-20s  %-32s  %s\n" "$name" "$email" "$dir"
+  done
+}
+
+cmd_whoami() {
+  require_bin gws
+  require_bin jq
+  local active="${GOOGLE_WORKSPACE_CLI_CONFIG_DIR:-$DEFAULT_DIR}" name email
+  if [ "$active" = "$DEFAULT_DIR" ]; then
+    name="default"
+  else
+    name="${active##*/gws-}"
+  fi
+  email=$(profile_email "$active")
+  printf "active profile : %s\n" "$name"
+  printf "email          : %s\n" "$email"
+  printf "config dir     : %s\n" "$active"
+}
+
+cmd_init() {
+  local name="${1:-}"
+  [ -z "$name" ] && die "init requires a profile name (e.g. 'prizoners')"
+  [ "$name" = "default" ] && die "use plain 'gws auth login' for the default profile"
+  shift
+  local dir; dir=$(profile_dir_for "$name")
+  if [ -f "$dir/credentials.enc" ]; then
+    warn "profile '$name' already exists at $dir — re-running auth-login will replace its credentials."
+  fi
+  mkdir -p "$dir"
+  note "running auth-login against profile '$name' (dir=$dir)…"
+  GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$dir" bash "$SCRIPT_DIR/auth-login.sh" "$@" \
+    || die "auth-login failed for profile '$name'" 2
+  local email; email=$(profile_email "$dir")
+  printf "\n✅ profile '%s' ready — bound to %s\n" "$name" "$email"
+  printf "   activate with: eval \"\$(bash %s use %s)\"\n" "$SCRIPT_DIR/gws-switch.sh" "$name"
+  printf "   or install the shell function: bash %s install\n" "$SCRIPT_DIR/gws-switch.sh"
+}
+
+cmd_use() {
+  local name="${1:-}"
+  [ -z "$name" ] && die "use requires a profile name (or 'default')"
+  if [ "$name" = "default" ]; then
+    # Emit export lines that unset the override in the parent shell.
+    printf "unset GOOGLE_WORKSPACE_CLI_CONFIG_DIR\n"
+    printf "echo '→ gws profile: default'\n"
+    return 0
+  fi
+  local dir; dir=$(profile_dir_for "$name")
+  [ -d "$dir" ] || die "profile '$name' does not exist (init it first: gws-switch.sh init $name)"
+  printf "export GOOGLE_WORKSPACE_CLI_CONFIG_DIR=%q\n" "$dir"
+  printf "echo '→ gws profile: %s'\n" "$name"
+}
+
+cmd_install() {
+  # Print a shell function the user can append to ~/.zshrc.
+  cat <<'SHELL'
+# --- gws multi-profile switcher (installed by gws-switch.sh) -----------------
+# Usage:
+#   gws-switch list
+#   gws-switch whoami
+#   gws-switch init <name> [-- auth-login-args...]
+#   gws-switch <name>          # shorthand for `use <name>`
+#   gws-switch default         # back to ~/.config/gws
+gws-switch() {
+  local script="$HOME/.claude/skills/google-workspace/scripts/gws-switch.sh"
+  [ -f "$script" ] || { echo "gws-switch.sh not found at $script" >&2; return 1; }
+  case "${1:-}" in
+    "" | -h | --help | help)
+      bash "$script" --help
+      ;;
+    list | whoami | init | install | remove)
+      bash "$script" "$@"
+      ;;
+    use)
+      shift
+      eval "$(bash "$script" use "$@")"
+      ;;
+    *)
+      # Shorthand: `gws-switch prizoners` == `gws-switch use prizoners`
+      eval "$(bash "$script" use "$@")"
+      ;;
+  esac
+}
+# --- /gws multi-profile switcher --------------------------------------------
+SHELL
+}
+
+cmd_remove() {
+  local name="${1:-}" yes=0
+  [ -z "$name" ] && die "remove requires a profile name"
+  [ "$name" = "default" ] && die "refusing to delete the default profile dir"
+  shift || true
+  for arg in "$@"; do
+    [ "$arg" = "--yes" ] && yes=1
+  done
+  local dir; dir=$(profile_dir_for "$name")
+  [ -d "$dir" ] || die "profile '$name' does not exist"
+  if [ "$yes" -ne 1 ]; then
+    printf "About to delete: %s\nConfirm? [y/N] " "$dir" >&2
+    local reply; read -r reply
+    case "$reply" in y|Y|yes|YES) ;; *) die "aborted" 0 ;; esac
+  fi
+  rm -rf "$dir"
+  printf "✓ profile '%s' removed\n" "$name"
+}
+
+usage() {
+  sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  list)    shift; list_profiles "$@" ;;
+  whoami)  shift; cmd_whoami "$@" ;;
+  init)    shift; cmd_init "$@" ;;
+  use)     shift; cmd_use "$@" ;;
+  install) shift; cmd_install "$@" ;;
+  remove)  shift; cmd_remove "$@" ;;
+  -h | --help | "" | help) usage ;;
+  *) die "unknown subcommand: $1 (run with --help)" ;;
+esac

--- a/claude-skills/skills/google-workspace/scripts/gws-switch.sh
+++ b/claude-skills/skills/google-workspace/scripts/gws-switch.sh
@@ -126,6 +126,15 @@ cmd_init() {
     warn "profile '$name' already exists at $dir — re-running auth-login will replace its credentials."
   fi
   mkdir -p "$dir"
+  # Reuse the OAuth client from the default profile (same GCP app, multiple
+  # users). Without this, the new dir has no client_secret.json and `gws auth
+  # login` errors out with "No OAuth client configured". Skip silently if
+  # the default profile isn't bootstrapped — auth-login.sh will surface the
+  # missing client to the user with the documented remediation paths.
+  if [ -f "$DEFAULT_DIR/client_secret.json" ] && [ ! -f "$dir/client_secret.json" ]; then
+    cp "$DEFAULT_DIR/client_secret.json" "$dir/client_secret.json"
+    note "copied OAuth client from default profile → $dir/client_secret.json"
+  fi
   note "running auth-login against profile '$name' (dir=$dir)…"
   GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$dir" bash "$SCRIPT_DIR/auth-login.sh" "$@" \
     || die "auth-login failed for profile '$name'" 2


### PR DESCRIPTION
## Summary

- Adds `scripts/gws-switch.sh` to the `google-workspace` skill.
- Wraps the `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` env-var pattern so agents can keep N parallel OAuth profiles (one per account) and toggle between them with a single word.
- Updates `SKILL.md` with a new **Multi-account** section + a decision-tree entry.

## Motivation

Agents working across BSG personal accounts + multiple client domains (Prizoners, Expert-Flow, etc.) currently hit a dead-end with `gws`: it only authenticates one account at a time, and `gws auth login` *replaces* the current credentials instead of adding to them. The workaround (export `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=…`) is documented but raw — easy to forget which dir corresponds to which account, no shorthand, no listing.

`gws-switch.sh` formalises the pattern.

## Subcommands

| Command | What it does |
|---|---|
| `gws-switch.sh list` | Table of every profile (`default` + `~/.config/gws-*`) with bound email and dir |
| `gws-switch.sh whoami` | Active profile + email + config dir |
| `gws-switch.sh init <name> [auth-login args]` | Create profile at `~/.config/gws-<name>`, run `auth-login.sh` against it (pass-through args supported: `--readonly`, `--services`, `--scopes`) |
| `eval "$(gws-switch.sh use <name>)"` | Emit `export GOOGLE_WORKSPACE_CLI_CONFIG_DIR=…` for the parent shell; `use default` unsets the override |
| `gws-switch.sh install` | Print a `gws-switch` shell function to append to `~/.zshrc.user` — turns the eval shim into a clean `gws-switch prizoners` |
| `gws-switch.sh remove <name> [--yes]` | Delete profile dir (asks confirmation by default) |

## Recommended UX

```bash
# One-time:
bash scripts/gws-switch.sh init prizoners       # browser consent against client account
bash scripts/gws-switch.sh install >> ~/.zshrc.user
source ~/.zshrc.user

# Every day:
gws-switch prizoners                            # → grenoble@prizoners.com
gws gmail +triage --max 5
gws-switch default                              # → gdumas@the-shift.ai
```

Token caches persist per profile — only the *first* auth on a profile needs the browser. Switches afterward are instant.

## Test plan

- [x] `bash gws-switch.sh --help` renders the docstring
- [x] `bash gws-switch.sh list` shows current default profile + email
- [x] `bash gws-switch.sh whoami` reports active profile correctly
- [x] `bash gws-switch.sh use default` emits `unset GOOGLE_WORKSPACE_CLI_CONFIG_DIR`
- [x] `bash gws-switch.sh use bogus` exits 1 with a clear error
- [ ] (reviewer) `bash gws-switch.sh init <name>` creates the dir, runs auth-login, and binds the right email
- [ ] (reviewer) Install the shell function in zsh, confirm `gws-switch <name>` activates the profile in the running shell
- [ ] (reviewer) `bash gws-switch.sh remove <name>` deletes the dir after confirmation

## Notes for reviewers

- The script is **read-only by default** — `init` and `remove` are the only mutating subcommands, both gated (init only runs `auth-login.sh` which itself asks for browser consent; remove asks for confirmation unless `--yes`).
- No new dependencies — uses `jq` (already required by other scripts) and `gws` itself for the email lookup.
- The `cmd_use` subcommand intentionally emits shell-eval-able lines instead of trying to mutate the parent shell directly (impossible from a child bash). The `install` subcommand prints a shell function that hides this from end users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)