### PR TITLE
feat(onboard-laptop): Ghostty + Oh My Zsh + Google 2FA prompt

### DIFF
--- a/claude-skills/skills/onboard-laptop/SKILL.md
+++ b/claude-skills/skills/onboard-laptop/SKILL.md
@@ -168,10 +168,13 @@ pip_global:
 mas:
   - { id: "497799835", name: "Xcode" }
 
-# Post-install commands to run verbatim (idempotent only — last-resort hatch)
+# Post-install commands to run verbatim (idempotent only — last-resort hatch).
+# $ONBOARD_SCRIPT_DIR and $ONBOARD_SKILL_DIR are exported by apply-profile.sh
+# so a profile can call bundled helpers without hard-coding the install path.
 post_install:
   - 'git config --global init.defaultBranch main'
   - 'git config --global pull.rebase true'
+  - 'bash "$ONBOARD_SCRIPT_DIR/install-oh-my-zsh.sh"'
 
 # Account checklist items — printed, never executed
 accounts:
@@ -293,6 +296,62 @@ no implicit "BSG stack" or hidden default.
   not signed in.
 - **Linux** is not supported in this version. The detection script
   reports `linux` and exits with a clear message. PRs welcome.
+
+## Shell setup — Oh My Zsh and a starter `.zshrc`
+
+The `developer` profile installs **Oh My Zsh** via a bundled
+`scripts/install-oh-my-zsh.sh` wrapper called from `post_install:`.
+The wrapper is intentionally conservative:
+
+- **Idempotent.** Detects `~/.oh-my-zsh` and exits early when present.
+- **Never overwrites your `.zshrc`.** Runs the official installer with
+  `KEEP_ZSHRC=yes`, so an existing dotfile is left untouched.
+- **Never calls `chsh`.** Runs with `CHSH=no`, so your login shell is
+  not changed. Switch with `chsh -s "$(which zsh)"` when you're ready.
+- **Optional starter `.zshrc`.** Pass `--with-starter-zshrc` to drop
+  the bundled `references/dotfiles/zshrc-starter` at `~/.zshrc` —
+  only when no `~/.zshrc` exists. The starter sources Homebrew, OMZ,
+  `zsh-syntax-highlighting`, and `zsh-autosuggestions` (declared in
+  the profile's `brew:` list) and exposes a `~/.zshrc.local` hook for
+  machine-specific tweaks.
+
+The `developer` profile pulls `zsh-syntax-highlighting` and
+`zsh-autosuggestions` via `brew:`, then runs the wrapper. To opt
+into the starter `.zshrc` too, change the `post_install:` line to:
+
+```yaml
+- 'bash "$ONBOARD_SCRIPT_DIR/install-oh-my-zsh.sh" --with-starter-zshrc'
+```
+
+`$ONBOARD_SCRIPT_DIR` (and `$ONBOARD_SKILL_DIR`) are exported by
+`apply-profile.sh` so `post_install:` commands can reference bundled
+helpers without hard-coding the install path.
+
+## Default terminal — Ghostty
+
+The `developer` profile ships **Ghostty** ([ghostty.org](https://ghostty.org/))
+as the default GPU-accelerated terminal (Mac and Linux only — Windows
+is not yet supported upstream; the profile keeps Windows Terminal /
+Warp / Cursor as alternates). `iterm2` stays in the cask list as a
+fallback for muscle-memory users. The `interview.sh` Q&A offers
+`ghostty | iterm2 | warp | wt | none` and defaults to Ghostty.
+
+## Mandatory 2-step verification on the Google account
+
+Every profile that touches a Google Workspace email ships an explicit
+checklist row for **2-step verification**:
+
+```yaml
+- { name: "Google Account — enable 2-step verification",
+    url: "https://myaccount.google.com/signinoptions/two-step-verification",
+    notes: "MANDATORY. Use an authenticator app (not SMS).
+            Save backup codes in your password manager." }
+```
+
+The URL goes straight to the 2FA settings page — no clicking through
+account settings to find it. The `security:` block also carries the
+opaque `mfa_on_email` token; the step-by-step lives in
+`references/CHECKLIST-SECURITY.md`.
 
 ## When something fails
 

--- a/claude-skills/skills/onboard-laptop/references/dotfiles/zshrc-starter
+++ b/claude-skills/skills/onboard-laptop/references/dotfiles/zshrc-starter
@@ -1,0 +1,81 @@
+# ~/.zshrc — starter shipped by claude-skills/skills/onboard-laptop.
+#
+# This file is a STARTER. Copy it, then own it — the skill never
+# overwrites an existing ~/.zshrc. Customize freely.
+
+# ----------------------------------------------------------------------
+# Homebrew on Apple Silicon — must come before anything that calls brew
+# ----------------------------------------------------------------------
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# ----------------------------------------------------------------------
+# Oh My Zsh
+# ----------------------------------------------------------------------
+export ZSH="$HOME/.oh-my-zsh"
+
+# Theme — `robbyrussell` is the OMZ default; `agnoster` needs a powerline font.
+ZSH_THEME="robbyrussell"
+
+# Plugins. Keep this list short — every plugin adds shell startup time.
+# `git` is the headline plugin; `zsh-syntax-highlighting` and
+# `zsh-autosuggestions` come from Homebrew (declare them in the profile's
+# `brew:` list).
+plugins=(
+  git
+  docker
+  npm
+)
+
+# Load Oh My Zsh — guarded so this file stays sourceable even if OMZ is
+# not yet installed (fresh machine, mid-onboarding).
+[ -f "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"
+
+# ----------------------------------------------------------------------
+# Brew-installed zsh enhancements (optional — guarded)
+# ----------------------------------------------------------------------
+SYNTAX_HL="$(brew --prefix 2>/dev/null)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+AUTOSUGG="$(brew --prefix 2>/dev/null)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
+[ -f "$SYNTAX_HL" ] && source "$SYNTAX_HL"
+[ -f "$AUTOSUGG" ] && source "$AUTOSUGG"
+
+# ----------------------------------------------------------------------
+# History — keep it generous and shared across sessions
+# ----------------------------------------------------------------------
+HISTSIZE=100000
+SAVEHIST=100000
+setopt SHARE_HISTORY HIST_IGNORE_DUPS HIST_IGNORE_SPACE
+
+# ----------------------------------------------------------------------
+# Editor
+# ----------------------------------------------------------------------
+if command -v code >/dev/null 2>&1; then
+  export EDITOR="code --wait"
+  export VISUAL="$EDITOR"
+elif command -v nvim >/dev/null 2>&1; then
+  export EDITOR="nvim"
+  export VISUAL="$EDITOR"
+fi
+
+# ----------------------------------------------------------------------
+# PATH additions — language toolchains
+# ----------------------------------------------------------------------
+# Volta / nvm / pyenv go here if you use them.
+# Example (commented — opt in only if relevant):
+# export PATH="$HOME/.volta/bin:$PATH"
+# eval "$(pyenv init -)"
+
+# ----------------------------------------------------------------------
+# Aliases
+# ----------------------------------------------------------------------
+alias ll='ls -lah'
+alias g='git'
+alias gst='git status --short'
+alias gco='git checkout'
+alias gp='git pull'
+
+# ----------------------------------------------------------------------
+# Local overrides — keep machine-specific tweaks here, NOT in this file
+# ----------------------------------------------------------------------
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"

--- a/claude-skills/skills/onboard-laptop/references/profiles/designer.yml
+++ b/claude-skills/skills/onboard-laptop/references/profiles/designer.yml
@@ -31,7 +31,8 @@ winget_apps:
 accounts:
   - { name: "Figma team", url: "https://figma.com/login", notes: "Ask design lead for team invite." }
   - { name: "Adobe Creative Cloud", url: "https://account.adobe.com", notes: "IT provisions the license." }
-  - { name: "Work email", url: "https://accounts.google.com", notes: "Enable MFA first." }
+  - { name: "Work email", url: "https://accounts.google.com", notes: "Sign in first." }
+  - { name: "Google Account — enable 2-step verification", url: "https://myaccount.google.com/signinoptions/two-step-verification", notes: "MANDATORY. Use an authenticator app (not SMS)." }
   - { name: "Slack workspace", url: "https://YOUR-WORKSPACE.slack.com", notes: "" }
   - { name: "Password manager", url: "https://1password.com/signin", notes: "Ask IT for the invite." }
 

--- a/claude-skills/skills/onboard-laptop/references/profiles/developer.yml
+++ b/claude-skills/skills/onboard-laptop/references/profiles/developer.yml
@@ -16,9 +16,12 @@ brew:
   - openjdk@21
   - docker
   - docker-compose
+  - zsh-syntax-highlighting
+  - zsh-autosuggestions
 brew_cask:
   - visual-studio-code
   - cursor
+  - ghostty                  # https://ghostty.org — GPU-accelerated terminal
   - iterm2
   - google-chrome
   - slack
@@ -60,16 +63,21 @@ pip_global:
   - ruff
   - virtualenv
 
-# --- post_install: idempotent git defaults ---
+# --- post_install: idempotent git defaults + shell setup ---
 post_install:
   - 'git config --global init.defaultBranch main'
   - 'git config --global pull.rebase true'
   - 'git config --global core.editor "code --wait"'
+  # Oh My Zsh — the wrapper is idempotent; it skips when ~/.oh-my-zsh
+  # exists, runs --unattended otherwise (KEEP_ZSHRC=yes, CHSH=no).
+  # $ONBOARD_SCRIPT_DIR is exported by apply-profile.sh.
+  - 'bash "$ONBOARD_SCRIPT_DIR/install-oh-my-zsh.sh"'
 
 # --- Accounts ---
 accounts:
   - { name: "GitHub", url: "https://github.com/join", notes: "Ask your manager for the org invitation. Enable MFA + add SSH key." }
-  - { name: "Work email (Google Workspace)", url: "https://accounts.google.com", notes: "Enable MFA — required before any other access." }
+  - { name: "Work email (Google Workspace)", url: "https://accounts.google.com", notes: "Sign in with your work address provisioned by IT." }
+  - { name: "Google Account — enable 2-step verification", url: "https://myaccount.google.com/signinoptions/two-step-verification", notes: "MANDATORY. Use an authenticator app (Authy / 1Password / Google Authenticator), not SMS. Save backup codes in your password manager." }
   - { name: "Slack workspace", url: "https://YOUR-WORKSPACE.slack.com", notes: "Use your work email." }
   - { name: "Password manager vault", url: "https://1password.com/signin", notes: "Ask IT for the team invite link." }
   - { name: "VPN (if any)", url: "https://your-vpn-portal.example", notes: "IT will hand you the config file." }

--- a/claude-skills/skills/onboard-laptop/references/profiles/minimal.yml
+++ b/claude-skills/skills/onboard-laptop/references/profiles/minimal.yml
@@ -19,7 +19,8 @@ winget_apps:
 
 # --- Accounts (printed checklist) ---
 accounts:
-  - { name: "Work email (Google Workspace / Microsoft 365)", url: "https://accounts.google.com", notes: "Sign in with the address provisioned by IT and enable MFA." }
+  - { name: "Work email (Google Workspace / Microsoft 365)", url: "https://accounts.google.com", notes: "Sign in with the address provisioned by IT." }
+  - { name: "Google Account — enable 2-step verification", url: "https://myaccount.google.com/signinoptions/two-step-verification", notes: "MANDATORY. Use an authenticator app (not SMS). Save backup codes in your password manager." }
   - { name: "Slack workspace", url: "https://YOUR-WORKSPACE.slack.com", notes: "Use your work email." }
   - { name: "Password manager vault", url: "https://1password.com/signin", notes: "Ask IT for the team invite link." }
 

--- a/claude-skills/skills/onboard-laptop/references/profiles/sales.yml
+++ b/claude-skills/skills/onboard-laptop/references/profiles/sales.yml
@@ -25,7 +25,8 @@ winget_apps:
 
 # --- Accounts ---
 accounts:
-  - { name: "Work email", url: "https://accounts.google.com", notes: "Enable MFA first — gates everything else." }
+  - { name: "Work email", url: "https://accounts.google.com", notes: "Sign in first — gates everything else." }
+  - { name: "Google Account — enable 2-step verification", url: "https://myaccount.google.com/signinoptions/two-step-verification", notes: "MANDATORY. Use an authenticator app (not SMS). Save backup codes in your password manager." }
   - { name: "CRM (HubSpot / Salesforce / Pipedrive)", url: "https://app.hubspot.com/login", notes: "Sales ops provisions the seat." }
   - { name: "LinkedIn Sales Navigator", url: "https://www.linkedin.com/sales", notes: "IT will hand you the seat." }
   - { name: "Calendar booking (Calendly / Cal.com)", url: "https://calendly.com", notes: "Connect to your work calendar." }

--- a/claude-skills/skills/onboard-laptop/scripts/apply-profile.sh
+++ b/claude-skills/skills/onboard-laptop/scripts/apply-profile.sh
@@ -16,6 +16,14 @@ PARSER="$SCRIPT_DIR/_parse-profile.py"
 FAIL_LOG="${TMPDIR:-/tmp}/onboard-laptop-failures.log"
 : > "$FAIL_LOG"
 
+# Exported so `post_install:` commands in a profile can reference
+# bundled helpers without hard-coding the install path. Example:
+#   post_install:
+#     - 'bash "$ONBOARD_SCRIPT_DIR/install-oh-my-zsh.sh"'
+export ONBOARD_SCRIPT_DIR="$SCRIPT_DIR"
+export ONBOARD_SKILL_DIR
+ONBOARD_SKILL_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
 DRY=0
 ONLY=""
 PROFILE=""

--- a/claude-skills/skills/onboard-laptop/scripts/install-oh-my-zsh.sh
+++ b/claude-skills/skills/onboard-laptop/scripts/install-oh-my-zsh.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# install-oh-my-zsh.sh — idempotent Oh My Zsh installer.
+#
+# Behavior:
+#   - If $HOME/.oh-my-zsh already exists → no-op, exit 0.
+#   - Else run the official installer in --unattended mode, which
+#       * does NOT overwrite an existing $HOME/.zshrc
+#       * does NOT call chsh (the user keeps their current login shell)
+#   - Then, if --with-starter-zshrc is passed AND no .zshrc exists,
+#     install the bundled starter from references/dotfiles/zshrc-starter.
+#     (We never touch an existing .zshrc.)
+#
+# Usage:
+#   bash install-oh-my-zsh.sh
+#   bash install-oh-my-zsh.sh --with-starter-zshrc
+#
+# Designed to be invoked from a profile's post_install: block, so the
+# orchestrator's idempotency guarantee holds end-to-end.
+
+set -uo pipefail
+
+WITH_STARTER=0
+for arg in "$@"; do
+  case "$arg" in
+    --with-starter-zshrc) WITH_STARTER=1 ;;
+    -h|--help) sed -n '1,18p' "$0"; exit 0 ;;
+  esac
+done
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+STARTER="$SCRIPT_DIR/../references/dotfiles/zshrc-starter"
+
+# Step 1: Oh My Zsh itself.
+if [ -d "$HOME/.oh-my-zsh" ]; then
+  echo "✓ Oh My Zsh already installed at $HOME/.oh-my-zsh"
+else
+  if ! command -v zsh >/dev/null 2>&1; then
+    echo "✗ zsh not on PATH — install it first (brew install zsh, or system zsh on macOS)" >&2
+    exit 2
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "✗ curl not on PATH" >&2
+    exit 2
+  fi
+  echo "→ Installing Oh My Zsh (--unattended: no .zshrc overwrite, no chsh)"
+  # RUNZSH=no    → don't drop into a zsh sub-shell at the end
+  # KEEP_ZSHRC=yes → never overwrite a pre-existing .zshrc
+  # CHSH=no      → never call chsh; user controls their login shell
+  RUNZSH=no KEEP_ZSHRC=yes CHSH=no \
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
+    "" --unattended
+  if [ -d "$HOME/.oh-my-zsh" ]; then
+    echo "✓ Oh My Zsh installed"
+  else
+    echo "✗ Oh My Zsh install did not create $HOME/.oh-my-zsh" >&2
+    exit 2
+  fi
+fi
+
+# Step 2: starter .zshrc — only when explicitly requested AND no .zshrc.
+if [ "$WITH_STARTER" -eq 1 ]; then
+  if [ -e "$HOME/.zshrc" ]; then
+    echo "↻ $HOME/.zshrc already exists — leaving it alone."
+    echo "  → diff against the starter at: $STARTER"
+  elif [ ! -f "$STARTER" ]; then
+    echo "✗ starter not found at $STARTER" >&2
+    exit 2
+  else
+    cp "$STARTER" "$HOME/.zshrc"
+    echo "✓ Installed starter .zshrc → $HOME/.zshrc"
+    echo "  Tweak it freely — it is yours from now on."
+  fi
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Open a new terminal (or run: exec zsh -l)"
+echo "  2. If zsh is not your login shell yet: chsh -s \"\$(which zsh)\""
+echo "  3. Customize \$HOME/.zshrc — Oh My Zsh themes live in ~/.oh-my-zsh/themes/"

--- a/claude-skills/skills/onboard-laptop/scripts/interview.sh
+++ b/claude-skills/skills/onboard-laptop/scripts/interview.sh
@@ -89,12 +89,22 @@ case "$IDE" in
 esac
 
 # Terminal
-TERM_EMU=$(prompt "Terminal emulator (iterm2|warp|wt|none)" "iterm2")
+TERM_EMU=$(prompt "Terminal emulator (ghostty|iterm2|warp|wt|none)" "ghostty")
 case "$TERM_EMU" in
-  iterm2) CASK+=("iterm2") ;;
-  warp)   CASK+=("warp"); WAPPS+=("Warp.Warp") ;;
-  wt)     WAPPS+=("Microsoft.WindowsTerminal") ;;
+  ghostty) CASK+=("ghostty") ;;  # mac/linux only — Windows unsupported
+  iterm2)  CASK+=("iterm2") ;;
+  warp)    CASK+=("warp"); WAPPS+=("Warp.Warp") ;;
+  wt)      WAPPS+=("Microsoft.WindowsTerminal") ;;
 esac
+
+# Shell — Oh My Zsh post_install
+INSTALL_OMZ=0
+if yesno "Install Oh My Zsh (idempotent, never overwrites your .zshrc)?" "y"; then
+  INSTALL_OMZ=1
+  # Add the syntax-highlight + autosuggest plugins to brew too — the
+  # starter .zshrc sources them when present.
+  BREW+=("zsh-syntax-highlighting" "zsh-autosuggestions")
+fi
 
 # Browsers
 if yesno "Add Google Chrome?" "y"; then
@@ -137,8 +147,8 @@ if yesno "Add a Slack workspace checklist item?" "y"; then
   WS=$(prompt "Slack workspace URL" "https://YOUR-WORKSPACE.slack.com")
   ACCOUNTS+=("Slack|${WS}|Use your work email.")
 fi
-if yesno "Add a Google Workspace checklist item?" "y"; then
-  ACCOUNTS+=("Google Workspace|https://workspace.google.com|Your work email + MFA.")
+if yesno "Add a Google account 2FA checklist item?" "y"; then
+  ACCOUNTS+=("Google Account — enable 2-step verification|https://myaccount.google.com/signinoptions/two-step-verification|MANDATORY. Use an authenticator app (not SMS). Save backup codes in your password manager.")
 fi
 
 # Security baseline
@@ -163,6 +173,15 @@ emit_list brew_cask "${CASK[@]:-}"
 emit_list winget "${WINGET[@]:-}"
 emit_list winget_apps "${WAPPS[@]:-}"
 emit_list npm_global "${NPMG[@]:-}"
+
+if [ "$INSTALL_OMZ" -eq 1 ]; then
+  cat <<'EOF'
+post_install:
+  # Oh My Zsh — idempotent wrapper. Skips when ~/.oh-my-zsh exists;
+  # otherwise runs --unattended (KEEP_ZSHRC=yes, CHSH=no).
+  - 'bash "$ONBOARD_SCRIPT_DIR/install-oh-my-zsh.sh"'
+EOF
+fi
 
 if [ "${#ACCOUNTS[@]}" -gt 0 ]; then
   echo "accounts:"


### PR DESCRIPTION
## Summary

Three additions on top of #639/#640:

- **Ghostty** ([ghostty.org](https://ghostty.org)) as the default terminal in the
  `developer` profile and the `interview.sh` Q&A (Mac/Linux only — Windows alternates
  Windows Terminal / Warp remain).
- **Oh My Zsh** via a new `scripts/install-oh-my-zsh.sh` wrapper called from
  `post_install:`. Idempotent (skips when `~/.oh-my-zsh` exists). Runs `--unattended` +
  `KEEP_ZSHRC=yes` + `CHSH=no` so it **never overwrites an existing `.zshrc`** and
  **never changes the login shell**. Pass `--with-starter-zshrc` to install the bundled
  starter at `~/.zshrc` (only when no `~/.zshrc` exists).
- **Starter dotfile** at `references/dotfiles/zshrc-starter` — sources Homebrew, OMZ,
  `zsh-syntax-highlighting`, `zsh-autosuggestions` (declared in the profile's `brew:`
  list), with a `~/.zshrc.local` hook for machine-specific tweaks.

Plumbing change: `apply-profile.sh` now exports `$ONBOARD_SCRIPT_DIR` and
`$ONBOARD_SKILL_DIR` so `post_install:` commands can reference bundled helpers
without hard-coding paths.

### Google 2-step verification — explicit prompt

Every profile that mentions a Google Workspace email now ships an explicit
checklist row pointing **straight to the 2FA settings page**:

```yaml
- { name: "Google Account — enable 2-step verification",
    url: "https://myaccount.google.com/signinoptions/two-step-verification",
    notes: "MANDATORY. Use an authenticator app (not SMS).
            Save backup codes in your password manager." }
```

The `security:` block still carries the opaque `mfa_on_email` token — this row
makes the action one click from the printed checklist.

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — 17/17 pass
- [x] Cherry-picked cleanly on top of #640's developer.yml changes (wispr-flow,
      superconductor preserved)
- [x] `_parse-profile.py developer.yml` correctly emits ghostty, zsh plugins,
      wispr-flow, superconductor, the OMZ post_install hook, and the 2FA account row
- [ ] Live run of `apply-profile.sh references/profiles/developer.yml` on a fresh
      Mac — recommended manual verification before merge
- [ ] Live run of `install-oh-my-zsh.sh --with-starter-zshrc` on a Mac without an
      existing `.zshrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)