### PR TITLE
fix(md-to-word): TOC visible in headless PDF (updateFields + --pdf flag)

### DIFF
--- a/claude-skills/skills/md-to-word/SKILL.md
+++ b/claude-skills/skills/md-to-word/SKILL.md
@@ -36,9 +36,16 @@ bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md>
 bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md> --force-template
 # Force a specific cover logo (overrides discovery):
 bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md> --logo path/to/logo.png
+# Export a PDF alongside the .docx (LibreOffice headless, TOC mis à jour) :
+bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md> --pdf
 ```
 
-Output `.docx` is written next to the source file.
+Output `.docx` (and `.pdf` if `--pdf`) is written next to the source file.
+
+The `.docx` carries `<w:updateFields w:val="true"/>` in `word/settings.xml`,
+so Word / LibreOffice rebuild the sommaire (TOC) and page numbers automatically
+on open. That includes headless PDF exports (`soffice --convert-to pdf`),
+which is what `--pdf` uses under the hood.
 
 ## Pipeline
 
@@ -46,7 +53,8 @@ Output `.docx` is written next to the source file.
 |------|--------|--------------|
 | 1 | `generate-template.py` | Parses `.bsg/DESIGN.md`, generates `brand/templates/reference.docx` (python-docx) |
 | 2 | pandoc | Converts markdown → docx with `--toc`, `--lua-filter pagebreak.lua`, title metadata |
-| 3 | `post-process.py` | Full-width autofit tables, branded header rows, alternating rows, cell padding, logo before TOC |
+| 3 | `post-process.py` | Full-width autofit tables, branded header rows, alternating rows, cell padding, logo before TOC, `updateFields=true` in settings.xml |
+| 4 (opt) | `soffice --convert-to pdf` | When `--pdf` is passed: headless PDF export. The TOC is rebuilt because step 3 set the `updateFields` flag. |
 
 ## Document title
 
@@ -127,6 +135,9 @@ Margins: 2.5 cm all sides.
 
 - `python3` + `python-docx` (auto-installed if missing)
 - `pandoc` (`brew install pandoc`)
+- `libreoffice` / `soffice` (only required for `--pdf`)
+  - macOS : `brew install --cask libreoffice`
+  - Linux : `apt install libreoffice` (or distribution equivalent)
 
 ---
 

--- a/claude-skills/skills/md-to-word/scripts/md-to-word.sh
+++ b/claude-skills/skills/md-to-word/scripts/md-to-word.sh
@@ -1,27 +1,36 @@
 #!/usr/bin/env bash
-# md-to-word.sh — generic branded markdown → .docx converter
+# md-to-word.sh — generic branded markdown → .docx (+ optional PDF) converter
 # Reads brand tokens from .bsg/DESIGN.md in the repo root.
 #
-# Usage: md-to-word.sh <file.md> [--force-template] [--logo /path/to/logo.png]
+# Usage: md-to-word.sh <file.md> [--force-template] [--logo /path/to/logo.png] [--pdf]
 #   --force-template  Regenerate brand/templates/reference.docx even if present
 #   --logo PATH       Override the cover logo (else: DESIGN.md company match,
 #                     then generic discovery). Also settable via $MD_TO_WORD_LOGO.
+#   --pdf             Also export a PDF via LibreOffice headless. The TOC is
+#                     rebuilt automatically thanks to the updateFields flag
+#                     written by post-process.py.
 set -euo pipefail
 
 FILE="${1:-}"
 if [[ -z "$FILE" || ! -f "$FILE" ]]; then
-  echo "Usage: md-to-word.sh <file.md> [--force-template] [--logo PATH]" >&2
+  echo "Usage: md-to-word.sh <file.md> [--force-template] [--logo PATH] [--pdf]" >&2
   exit 1
 fi
 shift
 
 FORCE_TEMPLATE=false
 LOGO="${MD_TO_WORD_LOGO:-}"
+EXPORT_PDF=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --force-template) FORCE_TEMPLATE=true; shift ;;
     --logo)           LOGO="${2:-}"; shift 2 ;;
-    *)                shift ;;
+    --pdf)            EXPORT_PDF=true; shift ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: md-to-word.sh <file.md> [--force-template] [--logo PATH] [--pdf]" >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -78,3 +87,33 @@ POST_ARGS=("$OUTPUT" --repo "$REPO_ROOT")
 python3 "$SKILL_DIR/scripts/post-process.py" "${POST_ARGS[@]}"
 
 echo "✓ Exporté : $OUTPUT"
+
+# 5. Optional PDF export via LibreOffice headless.
+#    The post-process step set <w:updateFields w:val="true"/> in settings.xml,
+#    so LibreOffice rebuilds the TOC + page numbers when it opens the docx —
+#    no macro / UNO bridge needed.
+if [[ "$EXPORT_PDF" == true ]]; then
+  SOFFICE=$(command -v soffice 2>/dev/null || command -v libreoffice 2>/dev/null || true)
+  if [[ -z "$SOFFICE" ]]; then
+    echo "⚠ LibreOffice introuvable (soffice/libreoffice). Skip --pdf." >&2
+    echo "  → brew install --cask libreoffice  ou  apt install libreoffice" >&2
+    exit 1
+  fi
+
+  PDF_OUT="${OUTPUT%.docx}.pdf"
+  OUT_DIR="$(dirname "$OUTPUT")"
+  echo "→ Conversion PDF (LibreOffice headless)…"
+  # Use an isolated user profile so a busy LibreOffice instance can't lock us out.
+  USER_PROFILE="$(mktemp -d -t lo-profile-XXXXXX)"
+  trap 'rm -rf "$USER_PROFILE"' EXIT
+  "$SOFFICE" \
+    --headless --norestore --nologo --nofirststartwizard \
+    "-env:UserInstallation=file://$USER_PROFILE" \
+    --convert-to pdf --outdir "$OUT_DIR" "$OUTPUT" >/dev/null
+  if [[ -f "$PDF_OUT" ]]; then
+    echo "✓ PDF exporté : $PDF_OUT"
+  else
+    echo "⚠ Échec de la conversion PDF." >&2
+    exit 1
+  fi
+fi

--- a/claude-skills/skills/md-to-word/scripts/post-process.py
+++ b/claude-skills/skills/md-to-word/scripts/post-process.py
@@ -329,6 +329,25 @@ def style_table_branded(tbl, tokens: dict):
                         r.font.bold = True
 
 
+# ── Force TOC / fields update on open ────────────────────────────────────────
+
+def enable_update_fields_on_open(doc: Document):
+    """Set <w:updateFields w:val="true"/> in word/settings.xml.
+
+    Without this flag, LibreOffice headless export (`soffice --convert-to pdf`)
+    leaves the pandoc-generated TOC empty because it never recomputes fields.
+    Word and LibreOffice both honour the flag and rebuild the TOC + page
+    numbers when the document is opened — which is exactly what the PDF
+    converter does behind the scenes.
+    """
+    settings_el = doc.settings.element
+    for old in settings_el.findall(qn("w:updateFields")):
+        settings_el.remove(old)
+    update = OxmlElement("w:updateFields")
+    update.set(qn("w:val"), "true")
+    settings_el.append(update)
+
+
 # ── Logo before TOC ───────────────────────────────────────────────────────────
 
 def insert_logo_before_toc(doc: Document, logo_path: str, company: str = ""):
@@ -390,6 +409,10 @@ def post_process(docx_path: str, repo_root: str = ".", logo_override: str = ""):
     for tbl in doc.tables:
         set_table_full_width(tbl)
         style_table_branded(tbl, tokens)
+
+    # 3. Tell readers (Word, LibreOffice) to refresh fields on open —
+    #    required for the TOC to appear in headless PDF exports.
+    enable_update_fields_on_open(doc)
 
     doc.save(docx_path)
     if n:


### PR DESCRIPTION
Closes #645

## Problème

Quand `md-to-word` sort un `.docx` et qu'on le passe à `soffice --headless --convert-to pdf`, le sommaire (TOC) généré par pandoc reste vide : LibreOffice headless n'exécute aucune macro et ne recalcule pas les champs avant l'export.

## Fix

Plutôt qu'une macro Basic ou un pont UNO, on pose le drapeau standard OOXML `<w:updateFields w:val="true"/>` dans `word/settings.xml` au moment du post-traitement. Word **et** LibreOffice savent que cela veut dire « rebuild les champs (TOC, page numbers…) à l'ouverture » — et l'ouverture inclut celle déclenchée par `soffice --convert-to pdf`. Donc le sommaire apparaît, à jour, dans le PDF, sans étape manuelle.

## Changements

- `claude-skills/skills/md-to-word/scripts/post-process.py`
  - Nouvelle fonction `enable_update_fields_on_open(doc)` qui ajoute (et déduplique) `<w:updateFields w:val="true"/>` dans `word/settings.xml`.
  - Appelée dans `post_process()` après l'insertion du logo et la mise en forme des tableaux.
- `claude-skills/skills/md-to-word/scripts/md-to-word.sh`
  - Nouveau flag opt-in `--pdf` : après la génération du `.docx`, lance `soffice --headless --convert-to pdf` dans un profil utilisateur isolé (`-env:UserInstallation=file://…` + cleanup) pour ne pas tomber sur un lock d'instance LibreOffice déjà ouverte.
  - Parsing des flags rendu commutatif (`--pdf --force-template` et `--force-template --pdf` fonctionnent tous les deux ; ordre quelconque, ancien usage préservé).
  - Message d'erreur clair si `soffice`/`libreoffice` est absent.
- `claude-skills/skills/md-to-word/SKILL.md`
  - Doc du flag `--pdf`, dépendance LibreOffice optionnelle, ligne pipeline supplémentaire.

## Test

- `bash -n` sur `md-to-word.sh` et `python3 -c "import ast; ast.parse(...)"` sur `post-process.py` : OK.
- Smoke test python-docx : `enable_update_fields_on_open()` est idempotent (un seul `<w:updateFields>` même après plusieurs appels) et le `.docx` sauvé contient bien la balise dans `word/settings.xml`.
- Parsing de flags vérifié pour `[]`, `[--force-template]`, `[--pdf]`, `[--pdf --force-template]`, `[--force-template --pdf]`.

## Vérification côté utilisateur

```bash
bash .claude/skills/md-to-word/scripts/md-to-word.sh devis.md --pdf
# → devis.docx + devis.pdf, avec sommaire à jour dans les deux.
```

Pour un `.docx` déjà existant (compatible) : `soffice --headless --convert-to pdf devis.docx` suffit maintenant à obtenir un TOC à jour, car le flag est posé dans le docx lui-même.