### PR TITLE
chore(skills): right-size model assignments across agents, commands, and skills

### DIFF
--- a/claude-skills/agents/cleaner.md
+++ b/claude-skills/agents/cleaner.md
@@ -9,7 +9,7 @@ description: >
   dry-run mode (lists what it would do, touches nothing) — recommended for
   first invocation on any repo.
 tools: Read, Glob, Grep, Bash, Write
-model: sonnet
+model: haiku
 skills: []
 color: gray
 output: pr

--- a/claude-skills/agents/docs-keeper.md
+++ b/claude-skills/agents/docs-keeper.md
@@ -13,7 +13,7 @@ description: >
   or "docs-keeper tick". ADRs under `.bsg/adr/` are read-only — owned
   by `tech-lead`.
 tools: Read, Glob, Grep, Bash, Write
-model: sonnet
+model: haiku
 skills: [docs-report]
 color: cyan
 output: commit

--- a/claude-skills/agents/marketing.md
+++ b/claude-skills/agents/marketing.md
@@ -9,7 +9,7 @@ description: >
   page check", "calendrier marketing", "brief de campagne", or
   "alignement produit-marketing".
 tools: Read, Glob, Grep, Bash, Write
-model: sonnet
+model: haiku
 skills: [marketing-report]
 color: pink
 output: pr

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -9,7 +9,7 @@ description: >
   "structured data", "audit SEO", "référencement", or "optimisation
   moteurs de recherche".
 tools: Read, Glob, Grep, Bash, Write
-model: sonnet
+model: haiku
 skills: [seo-report]
 color: orange
 output: commit

--- a/claude-skills/commands/babysit.md
+++ b/claude-skills/commands/babysit.md
@@ -1,3 +1,9 @@
+---
+name: babysit
+description: >-
+  Babysit the following process: monitor failures, diagnose root causes, fix them, and retry.
+model: sonnet
+---
 Babysit the following process: $ARGUMENTS
 
 You are a babysitter agent. Your job is to monitor a long-running or flaky process, detect failures, diagnose root causes, fix them, and retry — looping until success or until you've exhausted reasonable attempts.

--- a/claude-skills/commands/ocr.md
+++ b/claude-skills/commands/ocr.md
@@ -1,3 +1,9 @@
+---
+name: ocr
+description: >-
+  Extract text from an image or PDF without uploading it into Claude's context.
+model: haiku
+---
 Extract text from an image or PDF **without** uploading it into Claude's context: $ARGUMENTS
 
 You are invoking the `ocr` skill. The goal is to save Anthropic tokens by

--- a/claude-skills/commands/ship.md
+++ b/claude-skills/commands/ship.md
@@ -1,3 +1,9 @@
+---
+name: ship
+description: >-
+  Ship the current branch: run preflight checks, commit, push, and open a PR.
+model: haiku
+---
 Ship the current branch: run preflight checks, commit, push, and open a PR. $ARGUMENTS
 
 You are the **ship** command. Your job is to take the current branch from

--- a/claude-skills/commands/ship_and_merge.md
+++ b/claude-skills/commands/ship_and_merge.md
@@ -1,3 +1,9 @@
+---
+name: ship_and_merge
+description: >-
+  Ship and merge the current branch: preflight checks, fix failures, commit, push, open a PR, wait for CI green, and merge.
+model: haiku
+---
 Ship and merge the current branch: run preflight checks, fix failures, commit, push, open a PR, wait for CI green, and merge. $ARGUMENTS
 
 You are the **ship_and_merge** command. You do everything `/ship` does, plus

--- a/claude-skills/commands/sync-worktree.md
+++ b/claude-skills/commands/sync-worktree.md
@@ -1,3 +1,9 @@
+---
+name: sync-worktree
+description: >-
+  Synchronize git worktrees with their PRs and prune obsolete ones.
+model: haiku
+---
 Synchronize git worktrees with their PRs and prune obsolete ones: $ARGUMENTS
 
 You are invoking the `sync-worktree` command. Its job is to reconcile the

--- a/claude-skills/commands/tick-all.md
+++ b/claude-skills/commands/tick-all.md
@@ -1,3 +1,9 @@
+---
+name: tick-all
+description: >-
+  Run a full tick sweep across all registered BSG agents for this repository.
+model: haiku
+---
 Run a full tick sweep across all registered BSG agents for this repository.
 
 You are the **tick-all dispatcher**. Your job is to fire every registered

--- a/claude-skills/skills/browser/SKILL.md
+++ b/claude-skills/skills/browser/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   persistent profile management, a curated Google login helper, and
   headed-first-then-headless defaults.
 version: 0.1.0
+model: sonnet
 ---
 
 # Browser Skill

--- a/claude-skills/skills/bsg-stack/SKILL.md
+++ b/claude-skills/skills/bsg-stack/SKILL.md
@@ -15,6 +15,7 @@ init: >
   init scripts are responsible for their own scan + draft logic;
   this skill routes the call.
 version: 0.1.0
+model: haiku
 ---
 
 # /bsg-stack — BSG infrastructure umbrella

--- a/claude-skills/skills/docs-report/SKILL.md
+++ b/claude-skills/skills/docs-report/SKILL.md
@@ -8,6 +8,7 @@ description: >
   `Makefile`, and tagged releases missing from CHANGELOG. Scripts do
   the aggregation; the LLM narrates. ADRs under `.bsg/adr/` are read-only
   in this skill — they belong to `tech-report`.
+model: haiku
 ---
 
 # Docs Report

--- a/claude-skills/skills/email-imap/SKILL.md
+++ b/claude-skills/skills/email-imap/SKILL.md
@@ -19,6 +19,7 @@ description: >-
   Not for sending — pair with SMTP or the `google-workspace` skill for
   send flows. Not for OAuth-friendly accounts where you control the
   GCP project — `google-workspace` gives you a richer surface there.
+model: haiku
 ---
 
 # email-imap

--- a/claude-skills/skills/gamma-presentation/SKILL.md
+++ b/claude-skills/skills/gamma-presentation/SKILL.md
@@ -12,6 +12,7 @@ version: 0.1.0
 output: chat
 auto-implements: []
 never-auto-implements: []
+model: haiku
 ---
 
 # Gamma Presentation Skill

--- a/claude-skills/skills/github-compliance/SKILL.md
+++ b/claude-skills/skills/github-compliance/SKILL.md
@@ -8,6 +8,7 @@ description: >
   "check team assignments", "fix repo permissions", "run compliance check", or
   "github-compliance tick". Works with the `beyond-scale-group` org and the
   `board` team by default.
+model: haiku
 ---
 
 # GitHub Compliance

--- a/claude-skills/skills/google-apps-script/SKILL.md
+++ b/claude-skills/skills/google-apps-script/SKILL.md
@@ -8,6 +8,7 @@ description: >-
   Triggers include "google apps script", "clasp", "debug apps script",
   "run apps script", "push apps script", "deploy apps script",
   "pull apps script", "apps script logs".
+model: sonnet
 ---
 
 # Google Apps Script (`clasp`)

--- a/claude-skills/skills/google-workspace/SKILL.md
+++ b/claude-skills/skills/google-workspace/SKILL.md
@@ -19,6 +19,7 @@ description: >-
   "prochaine réunion", "Google Workspace", "créer un brouillon",
   "draft an email", "brouillon gmail", "envoie un mail". Not for Admin
   SDK / user provisioning — use the `workspace-admin` skill instead.
+model: sonnet
 ---
 
 # Google Workspace (`gws`)

--- a/claude-skills/skills/learn/SKILL.md
+++ b/claude-skills/skills/learn/SKILL.md
@@ -8,6 +8,7 @@ description: >
   entries, file reorganization, workflow improvements. Presents a numbered menu and
   applies whichever items the user selects. Short-circuits with a one-line receipt when
   no new signal is detected vs. recent prior iterations (dedup check, #104).
+model: sonnet
 ---
 
 # Learn

--- a/claude-skills/skills/marketing-report/SKILL.md
+++ b/claude-skills/skills/marketing-report/SKILL.md
@@ -8,6 +8,7 @@ description: >
   when the user asks to "check marketing alignment", "audit content
   calendar", "generate campaign brief from milestone", or "find
   unmarketed releases". Scripts do the aggregation; the LLM narrates.
+model: haiku
 ---
 
 # Marketing Report

--- a/claude-skills/skills/md-to-office/SKILL.md
+++ b/claude-skills/skills/md-to-office/SKILL.md
@@ -17,6 +17,7 @@ init: >
   Scans CSS custom properties, Tailwind config, design tokens, and logo
   files to generate DESIGN.md following the Google Stitch spec, and
   derives branded Office templates. Opens as PR for human review.
+model: haiku
 ---
 
 # md-to-office Skill

--- a/claude-skills/skills/md-to-word/SKILL.md
+++ b/claude-skills/skills/md-to-word/SKILL.md
@@ -21,6 +21,7 @@ init: >
   Scans CSS custom properties, Tailwind config, design tokens, and logo
   files to generate DESIGN.md following the Google Stitch spec, then
   derives branded Word templates. Opens as PR for human review.
+model: haiku
 ---
 
 # md-to-word

--- a/claude-skills/skills/ocr/SKILL.md
+++ b/claude-skills/skills/ocr/SKILL.md
@@ -11,6 +11,7 @@ description: >
   document screenshot or scanned PDF into the model context. The point is to
   save Anthropic tokens — never use multimodal transcription as the default.
 version: 0.1.0
+model: haiku
 ---
 
 # OCR Skill

--- a/claude-skills/skills/onboard-laptop/SKILL.md
+++ b/claude-skills/skills/onboard-laptop/SKILL.md
@@ -12,6 +12,7 @@ description: >-
   setup", "setup mac for new hire", "setup windows for new hire",
   "install dev environment for new employee", "onboarding ordinateur",
   "setup poste nouvel employé", "configure laptop for onboarding".
+model: haiku
 ---
 
 # onboard-laptop

--- a/claude-skills/skills/po/SKILL.md
+++ b/claude-skills/skills/po/SKILL.md
@@ -10,6 +10,7 @@ description: >
   "generate a PO report", or any product-ownership question. Reporting
   is one capability among many — not the primary purpose.
 version: 0.2.0
+model: sonnet
 ---
 
 # Product Owner

--- a/claude-skills/skills/pr-comms-report/SKILL.md
+++ b/claude-skills/skills/pr-comms-report/SKILL.md
@@ -8,6 +8,7 @@ description: >
   to avoid re-drafting. Use when the user asks to "find newsworthy
   events", "draft a press release", "check press-kit freshness", or
   "plan the announcement schedule". No external API calls.
+model: haiku
 ---
 
 # PR / Comms Report

--- a/claude-skills/skills/qa-report/SKILL.md
+++ b/claude-skills/skills/qa-report/SKILL.md
@@ -8,6 +8,7 @@ description: >
   report. Use when the user asks to "check test coverage", "score
   regression risk", "detect flaky tests", "run a QA audit", or "show
   coverage trends". Scripts do the aggregation; the LLM narrates.
+model: haiku
 ---
 
 # QA Report

--- a/claude-skills/skills/security-report/SKILL.md
+++ b/claude-skills/skills/security-report/SKILL.md
@@ -8,6 +8,7 @@ description: >
   vulnerabilities", "check for leaked secrets", "run a security audit",
   "OWASP check", "CVE scan", or "are there known vulns". Heavy lifting
   happens in bash + jq scripts; the LLM narrates the findings.
+model: sonnet
 ---
 
 # Security Report

--- a/claude-skills/skills/seo-report/SKILL.md
+++ b/claude-skills/skills/seo-report/SKILL.md
@@ -9,6 +9,7 @@ description: >
   Use when the user asks to "audit SEO", "check meta tags", "find
   orphan pages", "verify sitemap", or "check keyword coverage". No
   external API calls — everything is source-at-rest.
+model: haiku
 ---
 
 # SEO Report

--- a/claude-skills/skills/storytelling-report/SKILL.md
+++ b/claude-skills/skills/storytelling-report/SKILL.md
@@ -10,6 +10,7 @@ description: >
   drafts for unnarrated releases. Use when the user asks to "check
   brand voice", "audit narrative consistency", "draft talking points",
   or "find key messages missing from README". No external NLP APIs.
+model: haiku
 ---
 
 # Storytelling Report

--- a/claude-skills/skills/tech-report/SKILL.md
+++ b/claude-skills/skills/tech-report/SKILL.md
@@ -9,6 +9,7 @@ description: >
   the user asks for "tech health", "architecture review",
   "dependency lag", "tech debt", "ADR gaps", "code complexity", or
   "biggest files". Scripts do the counting; the LLM narrates.
+model: sonnet
 ---
 
 # Tech Report


### PR DESCRIPTION
## Summary

- **4 agents downgraded to haiku**: `cleaner`, `docs-keeper`, `seo`, `marketing` — scripts do the aggregation, the LLM only narrates
- **6 agents kept on sonnet**: `po-manager`, `security`, `tech-lead`, `storytelling`, `pr-comms`, `qa` — where strategic reasoning or writing quality matters
- **6 command files**: added full YAML frontmatter (`name`, `description`, `model`) — all mechanical commands get haiku; `babysit` stays sonnet (diagnoses/fixes failures)
- **21 SKILL.md files**: added `model:` field — 14 → haiku, 7 → sonnet

## Test plan

- [x] `python3 claude-skills/tests/test_skills.py` — 17/17 tests pass
- [x] Verify frontmatter format is valid YAML in all touched files
- [ ] Spot-check that Claude Code picks up the new `model:` field on next install

🤖 Generated with [Claude Code](https://claude.com/claude-code)