### PR TITLE
fix(po): use parse-plan.sh to probe PLAN.md instead of checking path directly

### DIFF
--- a/claude-skills/skills/po/SKILL.md
+++ b/claude-skills/skills/po/SKILL.md
@@ -50,6 +50,10 @@ which itself orchestrates the others.
    specific ticket the user named.
 5. **Confirm before posting** anywhere external (GitHub comments, etc.). Default
    is local-only.
+6. **Never probe for PLAN.md by path** (`cat po/PLAN.md`, `ls po/`, etc.).
+   Always use `bash scripts/parse-plan.sh --typed` — it resolves `.bsg/PLAN.md`
+   first (preferred), then `po/PLAN.md` (legacy). Path-checking bypasses this
+   resolution and silently misses repos that store the plan under `.bsg/`.
 
 ## Available scripts
 
@@ -62,7 +66,7 @@ script auto-collect a fresh one.
 | Script                    | Purpose                                                                |
 | ------------------------- | ---------------------------------------------------------------------- |
 | `collect.sh`              | One paginated GraphQL fetch → full snapshot JSON (issues, PRs, milestones, releases, repo meta). Every other script consumes this. |
-| `parse-plan.sh`           | Parse `po/PLAN.md` into an array of plan items with typed bindings (`milestones`, `epics`, `labels`). Empty array if the file is missing. |
+| `parse-plan.sh`           | Parse `.bsg/PLAN.md` (preferred) or `po/PLAN.md` (legacy fallback) into an array of plan items with typed bindings (`milestones`, `epics`, `labels`). Use `--typed` for a `{status, items}` response; empty array if the file is missing in default mode. |
 | `adherence.sh`            | Join plan items with the snapshot → per-item status, evidence, and the three drift classes (`scopeCreep`, `abandonedItems`, `offCourse`). |
 | `bootstrap-plan.sh`       | Emit a draft starter `PLAN.md` from current milestones + top labels. Never writes to disk — caller saves under `po/drafts/`. |
 | `status.sh`               | Repo-wide counts + PR flow summary (review pending, failing checks, oldest open PR, avg time-to-first-review). |

--- a/claude-skills/skills/po/references/adherence.md
+++ b/claude-skills/skills/po/references/adherence.md
@@ -10,10 +10,18 @@ tickets, and milestone progress are supporting evidence below it.
 
 ## Preconditions
 
-- `po/PLAN.md` exists in the target repo and parses (see
-  `references/plan-schema.md` for the grammar).
-- If it doesn't exist, route to the **bootstrap flow** below instead —
-  don't silently create one.
+**Never check for PLAN.md by path directly.** Always use the script:
+
+```bash
+bash scripts/parse-plan.sh --typed | jq -r .status
+# "ok"      → plan found and parseable, proceed
+# "missing" → route to bootstrap flow below
+# "unparseable" → plan exists but has no binding tags; treat as missing
+```
+
+`parse-plan.sh` resolves `.bsg/PLAN.md` first (preferred), then falls
+back to `po/PLAN.md` (legacy). Checking the path manually breaks repos
+that store the plan under `.bsg/` — the script is the only correct probe.
 
 ## Steps
 
@@ -82,7 +90,7 @@ tickets, and milestone progress are supporting evidence below it.
 
 ## Bootstrap flow — when PLAN.md is missing
 
-1. Do **not** create `po/PLAN.md` directly. Instead:
+1. Do **not** create `po/PLAN.md` or `.bsg/PLAN.md` directly. Instead:
 
    ```bash
    mkdir -p po/drafts
@@ -96,7 +104,8 @@ tickets, and milestone progress are supporting evidence below it.
    Drafted a starter plan from your milestones and top labels:
      po/drafts/PLAN-suggested-2026-04-14.md
 
-   Edit it, then rename to po/PLAN.md to activate adherence tracking.
+   Edit it, then move to .bsg/PLAN.md (preferred) to activate adherence tracking.
+   po/PLAN.md also works but .bsg/PLAN.md is the canonical location.
    ```
 
 3. **Never** post to GitHub as part of bootstrap. The draft is local


### PR DESCRIPTION
## Problem

Repos storing the plan under `.bsg/PLAN.md` (the canonical location per ADR-001) were silently falling through to the bootstrap flow. The skill instructed Claude to probe `po/PLAN.md` by path (`cat`, `ls`, etc.), bypassing the `_bsg-paths.sh` resolution logic already baked into `parse-plan.sh`.

Repro: run `/po` on `expert-flow.ai` — the skill reported "no PLAN.md found" even though `.bsg/PLAN.md` exists and is well-maintained with 37 bound plan items.

## Fix

- **`SKILL.md`**: add hard rule #6 (`Never probe for PLAN.md by path — always use parse-plan.sh --typed`); update `parse-plan.sh` table entry to document `.bsg/PLAN.md` as the preferred location.
- **`adherence.md`**: replace the `po/PLAN.md exists` precondition with the correct `parse-plan.sh --typed | jq -r .status` invocation; update bootstrap guidance to name `.bsg/PLAN.md` as the canonical target.

## Test

```bash
bash scripts/parse-plan.sh --typed | jq -r .status
# "ok" on expert-flow.ai (was "missing" before)
```