### PR TITLE
fix(ci): use actions-clever-cloud pr-227 preview to fix timeout bug

### DIFF
--- a/.github/workflows/deploy-clever-cloud.yaml
+++ b/.github/workflows/deploy-clever-cloud.yaml
@@ -107,7 +107,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy
-        uses: 47ng/actions-clever-cloud@v2.1.0
+        uses: docker://ghcr.io/47ng/actions-clever-cloud:pr-227
         with:
           appID: ${{ inputs.app_id }}
           force: true

--- a/.github/workflows/deploy-review-app.yaml
+++ b/.github/workflows/deploy-review-app.yaml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Deploy Code
         if: inputs.action == 'deploy'
-        uses: 47ng/actions-clever-cloud@v2.1.0
+        uses: docker://ghcr.io/47ng/actions-clever-cloud:pr-227
         with:
           appID: ${{ steps.app_id.outputs.id }}
           force: true


### PR DESCRIPTION
## Summary
- Switches `47ng/actions-clever-cloud@v2.1.0` → `docker://ghcr.io/47ng/actions-clever-cloud:pr-227` in both deploy workflows
- Fixes timeout bug: `timeout: 1800` was interpreted as 1.8s (ms) instead of 30min (s)
- Affects `deploy-clever-cloud.yaml` (staging/prod) and `deploy-review-app.yaml` (review apps)
- Upstream issue: https://github.com/47ng/actions-clever-cloud/issues/226
- Upstream fix: https://github.com/47ng/actions-clever-cloud/pull/227

## Test plan
- [x] Verify diff is minimal (only `uses:` line changed)
- [ ] Re-run review app deploy on expert-flow.ai PR #2033 after merging
- [ ] Revert to tagged version (e.g. `@v2.2.0`) once upstream PR is merged and released