### PR TITLE
feat(test-scala): add pre_test_script input for DB seeding

### DIFF
--- a/.github/workflows/test-scala.yaml
+++ b/.github/workflows/test-scala.yaml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: "temurin"
+      pre_test_script:
+        description: "Script to run before sbt (e.g. DB seed). Runs from working_directory."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -81,6 +86,12 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
+      - name: Pre-test setup
+        if: ${{ inputs.pre_test_script != '' }}
+        run: ${{ inputs.pre_test_script }}
+        env:
+          TEST_DB_URL: postgresql://jarvis:jarvis@localhost:5432/jarvis
 
       - name: Run tests
         if: ${{ !inputs.coverage }}


### PR DESCRIPTION
## Summary

Adds an optional `pre_test_script` input to the `test-scala.yaml` reusable workflow. When provided, the script runs after checkout + JDK/sbt setup but before `sbt test`, with `TEST_DB_URL` pointing to the CI Postgres service.

Use case: repos with Flyway migrations that can't replay cleanly from scratch (e.g. expert-flow.ai's V070 drops `flyway_schema_history` mid-migration). The calling repo provides a script that applies migrations via `psql` instead of Flyway.

## Changes

- New input `pre_test_script` (string, default empty)
- New step "Pre-test setup" that runs the script if non-empty
- Backward-compatible: empty default means no change for existing callers

## Test plan

- [x] Existing callers (no `pre_test_script`) unchanged — step is skipped
- [ ] expert-flow.ai PR will use `pre_test_script: bash scripts/ci-seed-db.sh` to validate