### PR TITLE
fix(md-to-word): cover logo follows DESIGN.md brand + add --logo override

### DIFF
--- a/claude-skills/skills/md-to-word/SKILL.md
+++ b/claude-skills/skills/md-to-word/SKILL.md
@@ -34,6 +34,8 @@ Converts markdown → branded `.docx` driven by `.bsg/DESIGN.md`.
 bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md>
 # Regenerate brand/templates/reference.docx from current .bsg/DESIGN.md:
 bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md> --force-template
+# Force a specific cover logo (overrides discovery):
+bash .claude/skills/md-to-word/scripts/md-to-word.sh <file.md> --logo path/to/logo.png
 ```
 
 Output `.docx` is written next to the source file.
@@ -93,12 +95,21 @@ Police principale : **Calibri** (Inter non embarquée dans Word ; Calibri est la
 
 ## Logo discovery order
 
-1. `vitrine/public/the-shift_dot_ai_petit.png`
-2. `vitrine/public/logo-*.png` / `vitrine/public/*logo*.png`
-3. `public/logo*.png` / `public/*logo*.png`
-4. `brand/assets/logo.png`
-5. `assets/logo.png`
-6. **No logo found** → company name shown at 18pt bold (placeholder)
+1. **`--logo PATH`** flag (or **`$MD_TO_WORD_LOGO`** env var) — explicit override.
+2. **Company-matched logo** — a `*logo*.png` whose filename contains every token
+   of the DESIGN.md company name (e.g. company `BSG Holding` →
+   `logo-bsg-holding.png`), searched in common brand dirs (repo root,
+   `brand/assets`, `brand`, `public`, `vitrine/public`, `assets`,
+   `content/images`, `content/strategy/images`,
+   `tools/document-generation/assets`). Shortest filename wins. This keeps the
+   cover logo aligned with `.bsg/DESIGN.md` instead of defaulting to whatever
+   generic `logo.png` happens to exist.
+3. Generic discovery globs:
+   `vitrine/public/the-shift_dot_ai_petit.png` →
+   `vitrine/public/logo-*.png` / `*logo*.png` →
+   `public/logo*.png` / `*logo*.png` →
+   `brand/assets/logo.png` → `assets/logo.png`.
+4. **No logo found** → company name shown at 18pt bold (placeholder).
 
 ## Tabula-inspired spacing (applied to all documents)
 

--- a/claude-skills/skills/md-to-word/scripts/md-to-word.sh
+++ b/claude-skills/skills/md-to-word/scripts/md-to-word.sh
@@ -2,18 +2,28 @@
 # md-to-word.sh — generic branded markdown → .docx converter
 # Reads brand tokens from .bsg/DESIGN.md in the repo root.
 #
-# Usage: md-to-word.sh <file.md> [--force-template]
+# Usage: md-to-word.sh <file.md> [--force-template] [--logo /path/to/logo.png]
 #   --force-template  Regenerate brand/templates/reference.docx even if present
+#   --logo PATH       Override the cover logo (else: DESIGN.md company match,
+#                     then generic discovery). Also settable via $MD_TO_WORD_LOGO.
 set -euo pipefail
 
 FILE="${1:-}"
 if [[ -z "$FILE" || ! -f "$FILE" ]]; then
-  echo "Usage: md-to-word.sh <file.md> [--force-template]" >&2
+  echo "Usage: md-to-word.sh <file.md> [--force-template] [--logo PATH]" >&2
   exit 1
 fi
+shift
 
 FORCE_TEMPLATE=false
-[[ "${2:-}" == "--force-template" ]] && FORCE_TEMPLATE=true
+LOGO="${MD_TO_WORD_LOGO:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force-template) FORCE_TEMPLATE=true; shift ;;
+    --logo)           LOGO="${2:-}"; shift 2 ;;
+    *)                shift ;;
+  esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -63,6 +73,8 @@ echo "→ Conversion pandoc…"
 
 # 4. Post-process: logo + full-width branded tables
 echo "→ Post-traitement…"
-python3 "$SKILL_DIR/scripts/post-process.py" "$OUTPUT" --repo "$REPO_ROOT"
+POST_ARGS=("$OUTPUT" --repo "$REPO_ROOT")
+[[ -n "$LOGO" ]] && POST_ARGS+=(--logo "$LOGO")
+python3 "$SKILL_DIR/scripts/post-process.py" "${POST_ARGS[@]}"
 
 echo "✓ Exporté : $OUTPUT"

--- a/claude-skills/skills/md-to-word/scripts/post-process.py
+++ b/claude-skills/skills/md-to-word/scripts/post-process.py
@@ -5,8 +5,16 @@ Post-process a pandoc-generated .docx: full-width tables + brand colours.
 Reads brand tokens from .bsg/DESIGN.md in the repo root (falls back to
 neutral defaults if absent).  Project-agnostic — works with any BSG repo.
 
-Usage: python3 post-process.py <file.docx> [--repo /path/to/repo/root]
+Usage: python3 post-process.py <file.docx> [--repo /path/to/repo/root] [--logo /path/to/logo.png]
+
+Logo selection order:
+  1. --logo PATH (or $MD_TO_WORD_LOGO env var)
+  2. a logo whose filename matches the DESIGN.md company (e.g. "BSG Holding"
+     → logo-bsg-holding.png), searched in common brand directories
+  3. the generic discovery globs (_LOGO_GLOBS)
+  4. company name rendered as text (placeholder)
 """
+import os
 import re
 import sys
 from pathlib import Path
@@ -86,7 +94,62 @@ _LOGO_GLOBS = [
 ]
 
 
-def find_logo(repo_root: Path):
+# Directories scanned when matching a logo to the DESIGN.md brand name.
+_BRAND_DIRS = ["", "brand/assets", "brand", "public", "vitrine/public",
+               "assets", "content/images", "content/strategy/images",
+               "tools/document-generation/assets"]
+
+# Generic words dropped before matching a logo filename, so the brand tokens
+# drive the match regardless of the "Design System — Brand" / "Brand — …"
+# heading convention.
+_BRAND_STOPWORDS = {"design", "system", "the", "brand", "guide", "guidelines"}
+
+
+def _brand_tokens(text: str):
+    """"Design System — BSG Holding" -> ["bsg", "holding"]."""
+    return [t for t in re.split(r"[^a-z0-9]+", text.lower())
+            if t and t not in _BRAND_STOPWORDS]
+
+
+def _design_h1(repo_root: Path) -> str:
+    path = repo_root / ".bsg" / "DESIGN.md"
+    if not path.exists():
+        return ""
+    m = re.search(r"^#\s+(.+?)\s*$", path.read_text(encoding="utf-8"),
+                  re.MULTILINE)
+    return m.group(1) if m else ""
+
+
+def _brand_logo(repo_root: Path, company: str):
+    """Find a *logo* whose filename contains every brand token."""
+    tokens = _brand_tokens(_design_h1(repo_root) or company)
+    if not tokens:
+        return None
+    candidates = []
+    for d in _BRAND_DIRS:
+        base = repo_root / d if d else repo_root
+        if not base.is_dir():
+            continue
+        for p in base.glob("*.png"):
+            name = p.name.lower()
+            if "logo" in name and all(t in name for t in tokens):
+                candidates.append(p)
+    if candidates:
+        # shortest filename = most specific brand logo; then alphabetical
+        return str(sorted(candidates, key=lambda p: (len(p.name), p.name))[0])
+    return None
+
+
+def find_logo(repo_root: Path, override: str = "", company: str = ""):
+    # 1. explicit override (CLI flag or env var)
+    override = override or os.environ.get("MD_TO_WORD_LOGO", "")
+    if override and Path(override).exists():
+        return str(override)
+    # 2. logo matching the DESIGN.md brand name
+    by_brand = _brand_logo(repo_root, company)
+    if by_brand:
+        return by_brand
+    # 3. generic discovery globs
     for pattern in _LOGO_GLOBS:
         matches = sorted(repo_root.glob(pattern))
         if matches:
@@ -311,10 +374,11 @@ def insert_logo_before_toc(doc: Document, logo_path: str, company: str = ""):
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-def post_process(docx_path: str, repo_root: str = "."):
+def post_process(docx_path: str, repo_root: str = ".", logo_override: str = ""):
     root   = Path(repo_root)
     tokens = parse_design_md(root)
-    logo   = find_logo(root)
+    logo   = find_logo(root, override=logo_override,
+                       company=tokens.get("company", ""))
 
     doc = Document(docx_path)
 
@@ -335,12 +399,16 @@ def post_process(docx_path: str, repo_root: str = "."):
 if __name__ == "__main__":
     args = sys.argv[1:]
     if not args:
-        print("Usage: post-process.py <file.docx> [--repo /path/to/root]",
-              file=sys.stderr)
+        print("Usage: post-process.py <file.docx> [--repo /path/to/root] "
+              "[--logo /path/to/logo.png]", file=sys.stderr)
         sys.exit(1)
     docx  = args[0]
     root  = "."
+    logo  = ""
     if "--repo" in args:
         i    = args.index("--repo")
         root = args[i + 1]
-    post_process(docx, root)
+    if "--logo" in args:
+        i    = args.index("--logo")
+        logo = args[i + 1]
+    post_process(docx, root, logo_override=logo)


### PR DESCRIPTION
## Problème

Le logo de couverture était choisi par une liste de découverte **codée en dur** qui privilégie les logos *the-shift*. Conséquence : tout repo contenant `brand/assets/logo.png` (souvent le logo the-shift) reçoit ce branding **même si son `.bsg/DESIGN.md` indique une autre société** (ex. BSG Holding). Le message `✓ Logo The Shift AI inséré` était d'ailleurs codé en dur.

Constaté en générant des documents Word dans un repo dont le `DESIGN.md` = *BSG Holding* : les docx sortaient avec le logo the-shift.

## Correctif

`find_logo()` applique désormais cet ordre :
1. **`--logo PATH`** (ou variable d'env **`$MD_TO_WORD_LOGO`**) — override explicite.
2. **Logo correspondant au brand du `DESIGN.md`** — un `*logo*.png` dont le nom contient tous les tokens du brand (ex. `BSG Holding` → `logo-bsg-holding.png`), recherché dans les dossiers de marque courants.
3. **Globs génériques** existants — dernier recours.
4. Nom de société en texte — placeholder.

Le matching lit le **H1 complet** du `DESIGN.md` et ignore les mots génériques (`design`, `system`, …), donc il fonctionne pour les deux conventions de titre : `Design System — Brand` **et** `Brand — sous-titre`.

## Fichiers
- `scripts/post-process.py` — `find_logo(override, company)`, matching par brand, lecture `--logo`.
- `scripts/md-to-word.sh` — parsing robuste des flags, passe `--logo` au post-process.
- `SKILL.md` — documente le nouvel ordre de sélection.

## Tests
- `py_compile` + `bash -n` OK.
- Repo `DESIGN.md` = *BSG Holding* : logo auto-résolu → `content/images/logo-bsg-holding.png` (au lieu du logo the-shift). ✅
- `--logo PATH` et `$MD_TO_WORD_LOGO` respectés. ✅
- Convention inverse `Acme Corp — Design System` → tokens `[acme, corp]`. ✅