### PR TITLE
fix(po): scope tick short-circuit to the report; cascade tick-all in waves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,19 @@ Semantics every `tick` must follow:
      — that detail belongs in the report file.
   3. Contradictory receipts like `PR #94 opened. Nothing to report` — if a PR
      was opened, state what it says; if nothing to report, don't open a PR.
-- **Short-circuit on same-day idempotency.** When today's report for the
-  same agent is already merged and inputs haven't changed, the tick must
-  skip its full aggregation and return `Tick: unchanged — see PR #NN`.
-  Re-running the entire audit pipeline to produce a byte-identical PR is a
-  pure token leak on recurring sweeps. `security` and `pr-comms` already
-  implement this check — other agents should follow.
+- **Short-circuit on same-day idempotency — audit phase only.** When
+  today's report for the same agent is already merged and inputs haven't
+  changed, the tick must skip its audit/report aggregation and return
+  `Tick: unchanged — see PR #NN`. Re-running the entire audit pipeline to
+  produce a byte-identical PR is a pure token leak on recurring sweeps.
+  The short-circuit gates **only** the report: phases with independent
+  triggers — implementation (B), peer review (C), and the PO's routing
+  phases (1.4/1.5/A.5) — must still run. The fingerprint can't see
+  "work exists but was never routed": an unrouted backlog keeps the
+  fingerprint stable precisely because nothing routes it, so a
+  whole-tick stop deadlocks the delegation pipeline. `tech-lead`, `qa`,
+  `seo`, and `po-manager` implement the scoped version — other agents
+  should follow.
 - **Never pause for consent.** A `tick` on an `output: pr` agent must open
   the report PR without asking. If a silence-breaker requires a human
   decision, the report documents it and the PR *is* the consent surface —

--- a/claude-skills/agents/po-manager.md
+++ b/claude-skills/agents/po-manager.md
@@ -19,9 +19,19 @@ output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim po` to fetch any inbox items — today this returns empty because no `needs:po` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
   (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh po-manager po)"`.
-  If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
-  Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
-  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh po-manager po po)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to po/idle-ticks.log.
+  If TICK_SHORT_CIRCUIT=1, set TICK_AUDIT_RECEIPT="unchanged — see PR #$TICK_LAST_PR"
+  and skip phase (2) only — the status report is gated by input freshness, but
+  the routing phases (1, 1.4, 1.5, 1.6, A.5, A.6) and peer review (C) have
+  triggers the fingerprint does not capture (unrouted backlog, orphans, stuck
+  candidates, unreviewed PRs) and must always run. Stopping the whole tick on
+  short-circuit deadlocks delegation: an unrouted backlog keeps the fingerprint
+  stable precisely because nothing routes it. Receipt: "Tick: unchanged — see
+  PR #$TICK_LAST_PR" when routing changed nothing, "Tick: routed <N> — see PR
+  #$TICK_LAST_PR" when it did (details land in the next report, not in chat).
+  When TICK_SHORT_CIRCUIT=0, export TICK_FINGERPRINT so generate-report.sh
+  embeds it and run all phases. There is no (0.6) adaptive back-off for the
+  PO — the orchestrator's routing duty is exactly what an idle-stop would
+  skip, and the routing scripts are themselves cheap no-ops when idle.
   (1) Run `reconcile-milestones.sh` to assign GitHub milestones from po/PLAN.md
   bindings — each bound issue/PR gets the milestone matching its epic slug,
   scope-creep label for unbound ones (idempotent; skip silently if the plan
@@ -168,6 +178,15 @@ that nothing gets posted in chat when the project is healthy.
 
 ### Steps
 
+0.5. **Fingerprint short-circuit — gates the report only.** Source
+   `tick-fingerprint.sh`; when `TICK_SHORT_CIRCUIT=1`, skip steps 2–4
+   (today's status report is already merged for identical inputs) but
+   still run every routing step (1, 1.4, 1.5, 1.6, 5) and peer review.
+   Their triggers — unrouted backlog, orphan issues, stuck candidates,
+   unreviewed PRs — are not captured by the fingerprint: an unrouted
+   backlog keeps the fingerprint stable precisely because nothing routes
+   it, so stopping here deadlocks the delegation pipeline.
+
 1. **Reconcile plan bindings to GitHub milestones** (idempotent; silent on
    plan drift so it doesn't add noise between plan edits):
 
@@ -299,6 +318,10 @@ that nothing gets posted in chat when the project is healthy.
    line — e.g. `Tick: all green, report at $PR_URL` — is the whole reply.
    If breakers fired or issues were filed, send the 3-bullet executive
    summary plus `$PR_URL` and a count of delegated issues.
+   On a short-circuited tick (step 0.5), the line is
+   `Tick: unchanged — see PR #$TICK_LAST_PR` when routing changed nothing,
+   or `Tick: routed <N> — see PR #$TICK_LAST_PR` when labels were applied
+   or issues filed; routing details go into the next report, never chat.
 
 ### Silence-breakers (what counts as "needs human attention")
 

--- a/claude-skills/commands/tick-all.md
+++ b/claude-skills/commands/tick-all.md
@@ -7,36 +7,59 @@ model: haiku
 Run a full tick sweep across all registered BSG agents for this repository.
 
 You are the **tick-all dispatcher**. Your job is to fire every registered
-BSG agent's `tick` action in parallel, collect their one-line results, and
-print a brief sweep summary. Nothing more — routing, work, and handoffs are
-each agent's own responsibility.
+BSG agent's `tick` action in three cascading waves, collect their one-line
+results, and print a brief sweep summary. Nothing more — routing, work, and
+handoffs are each agent's own responsibility.
+
+Why waves and not one flat parallel batch: in a flat sweep the PO routes
+labels and files issues *while* the implementers are already checking for
+candidates — anything the PO routes is only picked up on the **next**
+sweep, so tickets take two sweeps to travel from routing to implementation.
+The cascade lets a ticket flow PO → implementer → peer review inside a
+single `/tick-all` run. Pass `--flat` to force the legacy single-wave
+parallel sweep (all agents at once, cheapest wall-clock).
 
 ## Steps
 
-1. **Load the registry.**
+1. **Load the registry and partition the waves.**
 
    ```bash
    REGISTRY=$(cat claude-skills/agents/registry.json 2>/dev/null || echo '{"agents":[]}')
-   AGENTS=$(echo "$REGISTRY" | jq -r '.agents[].name')
+   ROUTERS=$(echo "$REGISTRY" | jq -r '.agents[] | select(.name == "po-manager") | .name')
+   IMPLEMENTERS=$(echo "$REGISTRY" | jq -r '.agents[] | select(.output == "commit") | .name')
+   AUDITORS=$(echo "$REGISTRY" | jq -r '.agents[] | select(.output != "commit" and .name != "po-manager") | .name')
    ```
 
    If `claude-skills/agents/registry.json` is absent, fall back to the
-   hardcoded default list at the bottom of this file.
+   hardcoded default list at the bottom of this file (po-manager is the
+   router; `output: commit` rows are implementers; the rest are auditors).
 
-2. **Fire each agent's tick in parallel — each in its own git worktree.**
-
-   Spawn one Agent tool call per entry with:
+2. **Fire the waves.** Every Agent tool call in every wave uses:
 
    - `prompt: "tick"`
    - `subagent_type: "<name>"`
    - `isolation: "worktree"`
 
-   Do **not** wait for one to finish before starting the next — send
-   all calls in the same tool-use block.
+   **Wave 1 — routing.** Fire `po-manager` alone and wait for its
+   receipt. Its routing phases (label normalization, orphan triage,
+   delegation) are what put candidates in the implementers' inboxes.
+
+   **Wave 2 — implementation.** Fire all `output: commit` agents
+   (tech-lead, qa, seo, docs-keeper) in parallel — one tool-use block,
+   do not wait between them. They consume the candidates wave 1 just
+   routed.
+
+   **Wave 3 — audit + peer review.** Fire the remaining `output: pr`
+   agents (security, marketing, storytelling, pr-comms, cleaner) in
+   parallel. Running them last means their peer-review phase sees the
+   implementation PRs wave 2 just opened, not last sweep's.
+
+   With `--flat`: fire all registered agents in a single parallel
+   tool-use block instead (the pre-cascade behavior).
 
    The `isolation: "worktree"` flag is essential: it gives each agent
    its own git worktree branched off the current HEAD. Without it,
-   eight parallel agents writing `po/`, `security/`, `qa/`,
+   parallel agents writing `po/`, `security/`, `qa/`,
    `tech/`, `seo/`, `marketing/`, `brand/`, and `comms/` into the
    same working tree produce cross-contamination — a sibling's
    untracked output dir can block another agent's
@@ -60,16 +83,23 @@ each agent's own responsibility.
    ```
    ## tick-all — 2026-04-22T14:00:00Z
 
-   ✅ po-manager   Tick: all green, report at https://github.com/…/pull/123
-   ✅ security     Tick: all green, report at https://github.com/…/pull/124
+   wave 1 — routing
+   ✅ po-manager   Tick: routed 3 — see PR #123
+
+   wave 2 — implementation
+   ✅ tech-lead    Tick: implemented #616 — https://github.com/…/pull/126
+   ✅ qa           Tick: unchanged — see PR #124 · pilot: no candidates
+
+   wave 3 — audit + peer review
    ⚠️ seo         Tick: 3 pages missing canonical — report at …/pull/125
    ❌ marketing    ERROR: registry entry missing bus_label
 
-   4 agents swept in 18 s
+   6 agents swept in 3 waves, 74 s
    ```
 
    Prefix: ✅ green (no silence-breaker), ⚠️ silence-breaker fired, ❌ error.
-   Total elapsed time on the last line.
+   Total elapsed time on the last line. With `--flat`, drop the wave
+   headers and keep the flat list.
 
 5. **Prune stale agent worktrees.**
 
@@ -115,6 +145,9 @@ See `docs/label-taxonomy.md` for the full label schema and
   that repo.
 - **Worktree-isolated.** Every agent gets `isolation: "worktree"`.
   Parallel ticks must never share a working tree.
+- **Waves are barriers, not dependencies.** A wave-1 error (or a
+  `Tick: unchanged` receipt) never cancels waves 2–3 — record the
+  receipt and keep going. The cascade only orders the start times.
 - **Human-initiated.** For recurring sweeps, use `/loop 30m /tick-all` or
   `/schedule` — never a GitHub Actions cron.
 - **Idempotent.** Re-running is safe: `open-report-pr.sh` reuses existing
@@ -126,16 +159,18 @@ See `docs/label-taxonomy.md` for the full label schema and
 
 Used when `claude-skills/agents/registry.json` is absent:
 
-| Agent name     | bus_label     | output |
-|----------------|---------------|--------|
-| `po-manager`   | `po`          | pr     |
-| `security`     | `security`    | pr     |
-| `qa`           | `qa`          | pr     |
-| `tech-lead`    | `tech`        | pr     |
-| `seo`          | `seo`         | pr     |
-| `marketing`    | `marketing`   | pr     |
-| `storytelling` | `storytelling`| pr     |
-| `pr-comms`     | `pr-comms`    | pr     |
+| Agent name     | bus_label     | output | wave |
+|----------------|---------------|--------|------|
+| `po-manager`   | `po`          | pr     | 1    |
+| `tech-lead`    | `tech`        | commit | 2    |
+| `qa`           | `qa`          | commit | 2    |
+| `seo`          | `seo`         | commit | 2    |
+| `docs-keeper`  | `docs-keeper` | commit | 2    |
+| `security`     | `security`    | pr     | 3    |
+| `marketing`    | `marketing`   | pr     | 3    |
+| `storytelling` | `storytelling`| pr     | 3    |
+| `pr-comms`     | `pr-comms`    | pr     | 3    |
+| `cleaner`      | `cleaner`     | pr     | 3    |
 
 ---
 

--- a/claude-skills/tests/test_agent_frontmatter.py
+++ b/claude-skills/tests/test_agent_frontmatter.py
@@ -350,11 +350,15 @@ class TestAgentFrontmatter(unittest.TestCase):
     # --------------------------------- tick short-circuit scope (#261)
 
     def test_commit_agents_tick_does_not_short_circuit_phase_b(self) -> None:
-        """output: commit agents must not skip phase (B) on audit short-circuit.
+        """output: commit agents and routers must not full-stop on short-circuit.
 
         The tick-fingerprint short-circuit only means the audit (A) is
         unchanged. Phases (B) implementation pilot and (C) peer review have
-        independent triggers and must always run. See #261.
+        independent triggers and must always run. See #261. The same holds
+        for routing agents (frontmatter carries `delegates-to`): their
+        routing phases (1.4/1.5/A.5) are what change the fingerprint, so a
+        full stop deadlocks the delegation pipeline — an unrouted backlog
+        keeps the fingerprint stable precisely because nothing routes it.
         """
         for path in list_agents():
             with self.subTest(agent=path.stem):
@@ -363,7 +367,8 @@ class TestAgentFrontmatter(unittest.TestCase):
                 self.assertIsNotNone(fm_match)
                 frontmatter = fm_match.group(1)
                 scalars = dict(FRONTMATTER_SCALAR_RE.findall(frontmatter))
-                if scalars.get("output") != "commit":
+                is_router = re.search(r"^delegates-to:", frontmatter, re.M)
+                if scalars.get("output") != "commit" and not is_router:
                     continue
                 tick_body = extract_tick_body(frontmatter)
                 self.assertNotRegex(
@@ -371,8 +376,9 @@ class TestAgentFrontmatter(unittest.TestCase):
                     r"SHORT_CIRCUIT.*and stop",
                     f"{path.relative_to(REPO_ROOT)}: tick field instructs a "
                     f"full stop on audit short-circuit, which blocks phase "
-                    f"(B) implementation pilot from running. The short-circuit "
-                    f"should only skip phases (A) and (A.5). See #261.",
+                    f"(B) implementation pilot / routing from running. The "
+                    f"short-circuit should only skip phases (A) and (A.5) — "
+                    f"for routers, only the status report. See #261.",
                 )
 
     # --------------------------------- adaptive back-off (#363)
@@ -385,8 +391,15 @@ class TestAgentFrontmatter(unittest.TestCase):
         Without it, a no-change tick-all sweep reruns the full audit
         pipeline for every agent on every loop — the primary token-burn
         source identified in E1-tick-hygiene. See #363 and #393.
+
+        po-manager is exempt: the router's routing phases must run on
+        every tick (an idle-stop would deadlock delegation — see the
+        short-circuit-scope test above), and its routing scripts are
+        already cheap no-ops when there is nothing to route.
         """
         for path in list_agents():
+            if path.stem == "po-manager":
+                continue
             with self.subTest(agent=path.stem):
                 text = path.read_text()
                 fm_match = FRONTMATTER_RE.match(text)


### PR DESCRIPTION
## Problem

`/po tick` never distributes work once today's report is merged: step (0.5) short-circuits the **entire** tick on an unchanged fingerprint, skipping label normalization (1.4), orphan triage (1.5), stuck detection (1.6), delegation (A.5), blocker escalation (A.6), and peer review (C).

This is a deadlock by construction: the fingerprint (issues + PRs + HEAD) cannot see "work exists but was never routed" — an unrouted backlog keeps the fingerprint stable *precisely because nothing routes it*. Observed live: 6 open issues with no bus label (#618–#621, #636, #645) invisible to the pipeline while every tick returned `Tick: unchanged`.

On top of that, `/tick-all` fires all agents in one flat parallel batch, so anything the PO routes during a sweep is only consumed on the *next* sweep — tickets take two sweeps to travel from routing to implementation.

## Changes

- **po-manager (0.5)** now gates only phase (2), the status report. Routing phases and peer review always run — the exact pattern tech-lead/qa/seo already use for phases (B)/(C) per #261. Receipt stays one line: `Tick: unchanged — see PR #NN` or `Tick: routed <N> — see PR #NN`.
- **Drop (0.6) adaptive back-off for the PO**: an idle-stop is the same deadlock, and the routing scripts are cheap no-ops when there is nothing to route.
- **`/tick-all` cascades in 3 waves**: wave 1 po-manager (routing) → wave 2 `output: commit` agents (implementation) → wave 3 remaining `output: pr` agents (audit + peer review of the fresh PRs). Tickets now flow agent-to-agent inside a single sweep. `--flat` keeps the legacy flat batch. Waves are barriers, not dependencies — a wave-1 error never cancels waves 2–3.
- **Tests**: extend the #261 no-full-stop test to routers (`delegates-to` frontmatter); exempt po-manager from the #363 back-off requirement with rationale.
- **CLAUDE.md**: the same-day short-circuit convention now explicitly gates the audit phase only.

## Verification

`python3 -m pytest claude-skills/tests/` — 254 passed, 420 subtests passed. The 5 failures (`test_updater_stale_cache.py`, `test_updater_resilience.py`) pre-exist on a clean `origin/main` checkout and are untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)