### PR TITLE
report(pr-comms): 2026-07-02-events

### DIFF
--- a/comms/reports/2026-07-02-events.md
+++ b/comms/reports/2026-07-02-events.md
@@ -1,0 +1,53 @@
+<!-- fingerprint: none -->
+# PR / Comms Events — 2026-07-02
+
+**Repository:** `agent-adde1bf69675b7269` (visibility: public)
+**Generated:** 2026-07-02T19:28:09Z
+**Releases tracked:** 0
+**Milestones tracked:** 11
+**Contributors:** 4 — **PRs merged (total):** 556
+
+---
+
+## Newsworthy Events
+
+**Summary:** 0 events — 0 unannounced major/minor, 0 unannounced milestone, 0 security advisories, 2 community milestones (0 patches skipped)
+
+
+
+
+
+
+
+
+
+### Community milestones
+
+- prsMerged crossed 100 (current: 556)
+- prsMerged crossed 500 (current: 556)
+
+---
+
+## Press Kit Health
+
+**Directory:** `comms/press-kit`; **assets:** 2, **stale:** 0, **missing recommended:** 4
+
+
+
+| File | Last updated | Age (days) | Stale? |
+|------|--------------|-----------:|--------|
+| contact.md | 2026-04-24 | 69 | no |
+| boilerplate.md | 2026-04-24 | 69 | no |
+
+
+
+**Missing recommended files:** `fact-sheet.md`, `leadership.md`, `milestones.md`, `faq.md`
+
+---
+
+## Draft Press Releases
+
+_No unannounced releases require drafting._
+
+
+


### PR DESCRIPTION
Automated report generated by @pr-comms.

File: `comms/reports/2026-07-02-events.md`

This PR is opened by `open-report-pr.sh` and auto-merges when the repo allows it.