### PR TITLE
fix(open-report-pr): don't abort cleanup after successful API merge

### DIFF
--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -160,9 +160,26 @@ fi
 # no required checks / reviews configured (common for young repos).
 # The `--delete-branch` flag cleans up the remote head ref so it
 # doesn't accumulate in `gh pr list --state all` output (#363).
+#
+# `gh pr merge` performs local git operations (checking out / pulling
+# the base branch) after the remote API call succeeds. In worktree-
+# isolated sweeps (/tick-all), `main` is already checked out by a
+# sibling worktree, so that local step fails with `fatal: 'main' is
+# already used by worktree at ...` — but only *after* the remote
+# merge already landed. Under `set -euo pipefail` that would abort
+# the script and skip every cleanup step below, including printing
+# the PR URL to stdout. Re-check PR state on non-zero exit and only
+# treat it as a real failure if the PR is not actually MERGED. See #660.
 if ! gh pr merge --auto --squash --delete-branch "$pr_url" >/dev/null 2>&1; then
   echo "open-report-pr.sh: auto-merge not available, merging directly" >&2
-  gh pr merge --squash --delete-branch "$pr_url" >/dev/null
+  if ! gh pr merge --squash --delete-branch "$pr_url" >/dev/null 2>&1; then
+    merged_state=$(gh pr view "$pr_url" --json state --jq .state 2>/dev/null || true)
+    if [[ "$merged_state" != "MERGED" ]]; then
+      echo "open-report-pr.sh: gh pr merge failed and PR is not merged (state=${merged_state:-unknown})" >&2
+      exit 1
+    fi
+    echo "open-report-pr.sh: gh pr merge reported failure but PR is MERGED — continuing cleanup" >&2
+  fi
 fi
 
 # Return to the original branch. Fast-forward pull to bring in the


### PR DESCRIPTION
Closes #660

## Changements

- `claude-skills/scripts/open-report-pr.sh` — guard the fallback `gh pr merge --squash --delete-branch` call so a non-zero exit from `gh` doesn't abort the script when the PR is already merged on the remote.
- On non-zero exit, re-verify PR state with `gh pr view --json state --jq .state`. If state is `MERGED`, log a warning to stderr and continue with cleanup (`git checkout`, `git branch -D`, `git worktree unlock`, `echo \"\$pr_url\"`). Otherwise exit 1 as before.
- Expanded the comment above the block to document the worktree-isolated failure mode (sibling worktree holds `main`, `gh pr merge` API succeeds but local git ops fail).

## Test

- `bash -n claude-skills/scripts/open-report-pr.sh` passes.
- Manual review of the diff against the exact failure trace from #659 / issue #660: the specific `fatal: 'main' is already used by worktree` case now falls through to the cleanup steps and emits the PR URL to stdout.
- Bare fallback `gh pr merge --squash` (line ~165 in the original) is now guarded with `if ! ...; then ... fi` so `set -euo pipefail` no longer aborts on it.