### PR TITLE
fix(tick-all): waves must fire synchronous Agent calls

### DIFF
--- a/claude-skills/commands/tick-all.md
+++ b/claude-skills/commands/tick-all.md
@@ -39,6 +39,13 @@ parallel sweep (all agents at once, cheapest wall-clock).
    - `prompt: "tick"`
    - `subagent_type: "<name>"`
    - `isolation: "worktree"`
+   - `run_in_background: false` — **synchronous, always.** Waves are
+     ordered by awaiting the previous wave's receipts; backgrounded
+     ticks break that ordering, and in headless runs (`claude -p
+     "/tick-all"`) the session terminates at the background-wait
+     ceiling (~600 s) before the sweep finishes, orphaning the agents
+     mid-wave. Parallelism within a wave comes from batching the
+     synchronous calls in one tool-use block, not from backgrounding.
 
    **Wave 1 — routing.** Fire `po-manager` alone and wait for its
    receipt. Its routing phases (label normalization, orphan triage,


### PR DESCRIPTION
Headless `claude -p "/tick-all"` runs died at the 600s background-wait ceiling with wave 1 still running: the dispatcher backgrounded the ticks, the print session terminated, and waves 2–3 never fired (observed tonight on the-shift.ai, the-sentinel.ai, and prizoners during the multi-repo loop). The wave cascade is a barrier structure — ordering only exists if Agent calls are synchronous (`run_in_background: false`); in-wave parallelism comes from batching the calls in one tool-use block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)