### PR TITLE
fix(reports): commit with the developer's git identity, not <agent>@bsg-agents.bot

### DIFF
--- a/claude-skills/scripts/open-report-pr.sh
+++ b/claude-skills/scripts/open-report-pr.sh
@@ -145,9 +145,13 @@ if git diff --cached --quiet; then
   git checkout "$original" >/dev/null 2>&1 || true
   exit 0
 fi
-git -c "user.name=${AGENT}" \
-    -c "user.email=${AGENT}@bsg-agents.bot" \
-    commit -m "$title" >/dev/null
+# Commit with the developer's configured git identity. Overriding the
+# author to <agent>@bsg-agents.bot breaks required checks that validate
+# the author email against a GitHub account (e.g. Vercel's commit-author
+# check), leaving report PRs permanently BLOCKED on integrated repos —
+# observed on the-shift.ai (#180–#185) and prizoners (#121–#125).
+# Agent attribution lives in the commit message and PR body instead.
+git commit -m "$title" >/dev/null
 git push -u origin "$branch" >/dev/null 2>&1
 
 # Reuse an existing PR targeting this branch, otherwise open a new one.


### PR DESCRIPTION
Required checks that validate the commit author against a GitHub
account (e.g. Vercel's commit-author check) fail on the synthetic
bot email, leaving every report PR permanently BLOCKED on integrated
repos — observed tonight on the-shift.ai (#180-#185) and prizoners
(#121-#125), all requiring admin-merge to unblock. Agents already act
under the developer's gh credentials; attribution stays in the commit
message and PR body.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
