### PR TITLE
fix(po): guard AUTOPILOT.yml grep reads against pipefail crash

### DIFF
--- a/claude-skills/scripts/auto-merge-or-flag.sh
+++ b/claude-skills/scripts/auto-merge-or-flag.sh
@@ -45,8 +45,8 @@ AUTOPILOT_FILE=""$BSG_AUTOPILOT_FILE""
 AUTO_MERGE=false
 
 if [[ -f "$AUTOPILOT_FILE" ]]; then
-  enabled=$(grep -E '^\s*enabled\s*:' "$AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
-  auto_merge=$(grep -E '^\s*auto_merge\s*:' "$AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  enabled=$(grep -E '^\s*enabled\s*:' "$AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]' || true)
+  auto_merge=$(grep -E '^\s*auto_merge\s*:' "$AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]' || true)
   if [[ "$enabled" == "true" ]] && [[ "$auto_merge" == "true" ]]; then
     if grep -qE "^\s*-\s+$AGENT\s*$" "$AUTOPILOT_FILE" 2>/dev/null; then
       AUTO_MERGE=true

--- a/claude-skills/scripts/detect-stuck-issues.sh
+++ b/claude-skills/scripts/detect-stuck-issues.sh
@@ -61,8 +61,12 @@ done
 # escalation falls back to the issue creator (next best human).
 HUMAN_REVIEWER=""
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then
+  # `|| true` swallows grep's exit 1 when the key is absent — otherwise
+  # `set -o pipefail` + `set -e` aborts the script before any stuck
+  # detection runs. `default_human_reviewer` isn't in the documented
+  # scaffold, so most repos hit the no-match path every tick.
   HUMAN_REVIEWER=$(grep -E '^\s*default_human_reviewer\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \
-    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'")
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'" || true)
 fi
 
 # Bootstrap the labels we may apply (idempotent).

--- a/claude-skills/scripts/file-issue.sh
+++ b/claude-skills/scripts/file-issue.sh
@@ -151,7 +151,7 @@ fi
 # human-gated and gets the label regardless of autopilot mode.
 APPLY_REVIEW_LABEL=true
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then
-  enabled=$(grep -E '^\s*enabled\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+  enabled=$(grep -E '^\s*enabled\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]' || true)
   if [[ "$enabled" == "true" ]]; then
     APPLY_REVIEW_LABEL=false
   fi
@@ -164,7 +164,7 @@ fi
 # wins; otherwise read default_human_reviewer from $BSG_AUTOPILOT_FILE.
 if [[ -n "$HUMAN_REASON" && -z "$ASSIGN_TO" && -f "$BSG_AUTOPILOT_FILE" ]]; then
   ASSIGN_TO=$(grep -E '^\s*default_human_reviewer\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \
-    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'")
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]"' | tr -d "'" || true)
 fi
 
 # Idempotently ensure the review label exists on the target repo when

--- a/claude-skills/scripts/normalize-issue-labels.sh
+++ b/claude-skills/scripts/normalize-issue-labels.sh
@@ -75,8 +75,12 @@ done
 # Cap per tick — read from $BSG_AUTOPILOT_FILE.
 MAX_ISSUES=10
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then
+  # `|| true` swallows grep's exit 1 when the key is absent — otherwise
+  # `set -o pipefail` + `set -e` aborts the whole script before any
+  # label routing runs. `max_issues_per_tick` isn't in the documented
+  # scaffold under `budget:`, so most repos hit the no-match path.
   configured=$(grep -E '^\s*max_issues_per_tick\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \
-    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]' || true)
   if [[ -n "$configured" ]]; then
     MAX_ISSUES="$configured"
   fi

--- a/claude-skills/scripts/po-decompose-oversized.sh
+++ b/claude-skills/scripts/po-decompose-oversized.sh
@@ -55,7 +55,7 @@ done
 MAX_LOC=200
 if [[ -f "$BSG_AUTOPILOT_FILE" ]]; then
   configured=$(grep -E '^\s*max_loc_per_issue\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \
-    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
+    | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]' || true)
   if [[ -n "$configured" ]]; then
     MAX_LOC="$configured"
   fi


### PR DESCRIPTION
Closes #682

## Problem

Five `claude-skills/scripts/*.sh` scripts read config keys from
`.bsg/AUTOPILOT.yml` with:

```bash
foo=$(grep -E '^\s*<key>\s*:' "$BSG_AUTOPILOT_FILE" 2>/dev/null \
  | head -1 | sed 's/.*:\s*//' | tr -d '[:space:]')
```

`grep` exits 1 on no-match. Combined with `set -o pipefail` inside
`set -euo pipefail`, the whole command substitution exits 1 and
the outer script aborts on the assignment — before any of the
script's actual work runs.

Several of the keys (`max_issues_per_tick`, `default_human_reviewer`,
`enabled`, `auto_merge`, `max_loc_per_issue`) aren't in the
documented `.bsg/AUTOPILOT.yml` scaffold, so most repos hit the
no-match path every tick. Reported after `@po-manager tick` on
`beyond-scale-group/prizoners`.

## Changes

Append `|| true` to the read pipe in every occurrence so a missing
key silently falls back to the script's documented default:

- `claude-skills/scripts/normalize-issue-labels.sh` — `max_issues_per_tick`
- `claude-skills/scripts/detect-stuck-issues.sh` — `default_human_reviewer`
- `claude-skills/scripts/file-issue.sh` — `enabled` + `default_human_reviewer`
- `claude-skills/scripts/auto-merge-or-flag.sh` — `enabled` + `auto_merge`
- `claude-skills/scripts/po-decompose-oversized.sh` — `max_loc_per_issue`

`claude-skills/skills/po/scripts/reconcile-milestones.sh` was also
cited in the report but was already fixed by #546 — the sentinel-key
trick around `declare -A slug_to_nums` handles the empty-epics case.
Left untouched.

## Test

Repro on main:

```bash
$ bash -c '
set -euo pipefail
tmp=$(mktemp); echo "unrelated: yes" > "$tmp"
x=$(grep -E "^\s*missing_key\s*:" "$tmp" 2>/dev/null \
    | head -1 | sed "s/.*:\s*//" | tr -d "[:space:]")
echo "still here"
'
$ echo $?
1     # aborted before `still here`
```

With the fix (`|| true` appended):

```
still here
0     # falls back to script default
```

`bash -n` clean on all five modified files.