### PR TITLE
report(docs-keeper): 2026-07-03-audit

### DIFF
--- a/docs-keeper/reports/2026-07-03-audit.md
+++ b/docs-keeper/reports/2026-07-03-audit.md
@@ -1,0 +1,58 @@
+<!-- fingerprint: none -->
+# Docs Health — 2026-07-03
+
+**Repository:** `bsg-stack`
+**Generated:** 2026-07-02T23:10:15Z
+**Tracked markdown files:** 342
+
+---
+
+## Broken links
+
+**Summary:** 6 broken link(s) in tracked markdown.
+
+| Source | Target |
+|--------|--------|
+| claude-skills/skills/md-to-office/SKILL.md | path |
+| claude-skills/skills/md-to-office/references/markdown-conventions.md | url |
+| claude-skills/skills/md-to-office/references/markdown-conventions.md | path/to/img.png |
+| claude-skills/skills/md-to-office/references/markdown-conventions.md | path |
+| claude-skills/skills/nextjs-seo/references/geo-llms.md | URL absolue |
+| claude-skills/skills/nextjs-seo/references/geo-llms.md | url |
+
+---
+
+## Stale README commands
+
+**Summary:** 0 command(s) referenced in READMEs but not present in package.json / Makefile.
+
+_No stale commands._
+
+---
+
+## CHANGELOG gaps
+
+**Summary:** 0 version(s) logged, 9 tag(s) missing from CHANGELOG.md.
+
+### Tags missing from CHANGELOG
+
+- pre-e10-agentic-run
+- v1
+- v1.0.0
+- v1.0.1
+- v1.0.2
+- v1.0.3
+- v2
+- v2.0.0
+- v2.1.0
+
+---
+
+## .bsg/ doc freshness
+
+**Summary:** 0 dead reference(s), 0 doc(s) unedited since latest tag.
+
+_No dead references in .bsg/ flat docs._
+
+
+


### PR DESCRIPTION
Automated report generated by @docs-keeper.

File: `docs-keeper/reports/2026-07-03-audit.md`

This PR is opened by `open-report-pr.sh` and auto-merges when the repo allows it.