### PR TITLE
fix(tech-report): repair quality.sh bugs, missing .bsg/adr detection, worktree repo-name

### DIFF
--- a/claude-skills/skills/tech-report/scripts/collect.sh
+++ b/claude-skills/skills/tech-report/scripts/collect.sh
@@ -77,7 +77,11 @@ TODOS_JSON=$({ git grep -n -E '(TODO|FIXME|HACK)[:(]' -- '*.ts' '*.tsx' '*.js' '
 # -------------------------------------------------------------- ADRs
 
 ADR_DIR=""
-for candidate in "adr" "docs/adr" "architecture" "docs/architecture"; do
+# .bsg/adr is the canonical location per ADR-001 (the .bsg/ directory
+# convention); checked first so repos that migrated off the legacy
+# adr/ / docs/adr/ folders still get indexed instead of reporting a
+# false "no ADR directory found."
+for candidate in ".bsg/adr" "adr" "docs/adr" "architecture" "docs/architecture"; do
   if [[ -d "$candidate" ]]; then
     ADR_DIR="$candidate"; break
   fi

--- a/claude-skills/skills/tech-report/scripts/collect.sh
+++ b/claude-skills/skills/tech-report/scripts/collect.sh
@@ -55,7 +55,13 @@ SOURCE_FILES_JSON=$(git ls-files 2>/dev/null \
 # Emit { file, line, kind, text, age_days } entries.
 TODAY_EPOCH=$(date +%s)
 
-TODOS_JSON=$({ git grep -n -E '(TODO|FIXME|HACK)[:(]' -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.py' '*.go' '*.rs' '*.scala' '*.java' '*.kt' '*.rb' '*.md' 2>/dev/null || true; } \
+# Exclude this skill's own dated report output (legacy tech/reports/ and
+# the .bsg/ convention target .bsg/reports/tech/): every report prints a
+# "**Summary:** N markers — TODO: N, FIXME: 0, HACK: 0" line, and without
+# this exclusion each day's report seeds a false-positive match for every
+# following day's scan — a self-inflating debt count that never reflects
+# real code comments (#677).
+TODOS_JSON=$({ git grep -n -E '(TODO|FIXME|HACK)[:(]' -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.py' '*.go' '*.rs' '*.scala' '*.java' '*.kt' '*.rb' '*.md' ':!tech/reports/*' ':!.bsg/reports/tech/*' 2>/dev/null || true; } \
   | while IFS=: read -r file line rest; do
       [[ -z "$file" || -z "$line" ]] && continue
       kind=$(echo "$rest" | grep -oE '(TODO|FIXME|HACK)' | head -1)

--- a/claude-skills/skills/tech-report/scripts/generate-report.sh
+++ b/claude-skills/skills/tech-report/scripts/generate-report.sh
@@ -16,7 +16,23 @@ DEBT=$(bash "$SCRIPT_DIR/debt.sh"    --snapshot "$SNAPSHOT")
 ADR=$(bash "$SCRIPT_DIR/adr.sh"      --snapshot "$SNAPSHOT")
 
 DATE=$(date +%F)
-REPO=$(jq -r '.repoRoot' "$SNAPSHOT" | xargs -I{} basename {})
+REPO_ROOT_PATH=$(jq -r '.repoRoot' "$SNAPSHOT")
+# Prefer the origin remote's repo name over `basename $REPO_ROOT_PATH`:
+# under worktree-isolated ticks (CLAUDE.md "Worktree-isolated in
+# parallel sweeps") the working tree lives at
+# .claude/worktrees/agent-<hash>, so basename alone reports the
+# worktree hash as the repo name instead of the real repo. Parameter
+# expansion (not sed -E) for portability — BSD sed on macOS rejects
+# the non-greedy `+?` regex GNU sed accepts.
+ORIGIN_URL=$(git -C "$REPO_ROOT_PATH" remote get-url origin 2>/dev/null || true)
+REPO=""
+if [[ -n "$ORIGIN_URL" ]]; then
+  REPO="${ORIGIN_URL%.git}"
+  REPO="${REPO##*/}"
+fi
+if [[ -z "$REPO" ]]; then
+  REPO=$(basename "$REPO_ROOT_PATH")
+fi
 
 cat <<EOF
 <!-- fingerprint: ${TICK_FINGERPRINT:-none} -->

--- a/claude-skills/skills/tech-report/scripts/quality.sh
+++ b/claude-skills/skills/tech-report/scripts/quality.sh
@@ -26,20 +26,24 @@ MAX_FUNCTIONS=20
 
 # Function-detection patterns per extension.
 count_functions() {
-  local f=$1
+  local f=$1 n=0
   case "$f" in
     *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs)
-      grep -cE '^\s*(export\s+)?(async\s+)?function\s+\w+|^\s*(export\s+)?const\s+\w+\s*=\s*(async\s+)?\(' "$f" 2>/dev/null || echo 0 ;;
+      n=$(grep -cE '^\s*(export\s+)?(async\s+)?function\s+\w+|^\s*(export\s+)?const\s+\w+\s*=\s*(async\s+)?\(' "$f" 2>/dev/null) || true ;;
     *.py)
-      grep -cE '^\s*(async\s+)?def\s+\w+' "$f" 2>/dev/null || echo 0 ;;
+      n=$(grep -cE '^\s*(async\s+)?def\s+\w+' "$f" 2>/dev/null) || true ;;
     *.go)
-      grep -cE '^func\s+(\([^)]+\)\s+)?\w+' "$f" 2>/dev/null || echo 0 ;;
+      n=$(grep -cE '^func\s+(\([^)]+\)\s+)?\w+' "$f" 2>/dev/null) || true ;;
     *.rs)
-      grep -cE '^\s*(pub(\([^)]+\))?\s+)?(async\s+)?fn\s+\w+' "$f" 2>/dev/null || echo 0 ;;
+      n=$(grep -cE '^\s*(pub(\([^)]+\))?\s+)?(async\s+)?fn\s+\w+' "$f" 2>/dev/null) || true ;;
     *.scala)
-      grep -cE '^\s*(private\s+|protected\s+)?def\s+\w+' "$f" 2>/dev/null || echo 0 ;;
-    *) echo 0 ;;
+      n=$(grep -cE '^\s*(private\s+|protected\s+)?def\s+\w+' "$f" 2>/dev/null) || true ;;
+    *) n=0 ;;
   esac
+  # grep -c prints the count even on no-match (exit 1); the `|| true`
+  # above only neutralizes set -e, so `n` is still a single clean
+  # digit line here. Guard against an empty/unset value regardless.
+  echo "${n:-0}"
 }
 
 # Compute per-file function counts and build oversized[] / dense[] lists.
@@ -90,16 +94,26 @@ if jq -e '[.sourceFiles[] | select(.path | test("\\.(ts|tsx|js|jsx|mjs|cjs)$"))]
         done
   done < <(jq -r '.sourceFiles[] | select(.path | test("\\.(ts|tsx|js|jsx|mjs|cjs)$")) | .path' "$SNAPSHOT") > "$GRAPH_TMP" || true
 
-  # Detect trivial 2-cycles (A imports B, B imports A).
+  # Detect trivial 2-cycles (A imports B, B imports A). Keyed on a
+  # concatenated "from\tto" string rather than a nested fwd[$1][$2]
+  # array: nested/multi-dimensional arrays are a gawk extension that
+  # BSD/macOS awk (the default `/usr/bin/awk` on developer laptops)
+  # rejects with a syntax error, silently corrupting CIRCULAR_JSON.
   CIRCULAR_JSON=$(awk -F'\t' '
-    NR==FNR { fwd[$1][$2]=1; next }
-    { if ($2 in fwd && $1 in fwd[$2]) {
+    NR==FNR { fwd[$1 "\t" $2]=1; next }
+    { if (($2 "\t" $1) in fwd) {
         a=$1; b=$2;
         key = (a < b) ? (a "\t" b) : (b "\t" a);
         seen[key]=1
       } }
     END { for (k in seen) { split(k, p, "\t"); printf "{\"a\":\"%s\",\"b\":\"%s\"}\n", p[1], p[2] } }
-  ' "$GRAPH_TMP" "$GRAPH_TMP" | jq -sc '.' 2>/dev/null || echo '[]')
+  ' "$GRAPH_TMP" "$GRAPH_TMP" 2>/dev/null | jq -sc '.' 2>/dev/null)
+  # Validate rather than `|| echo '[]'` after the pipe: under `set -o
+  # pipefail` a failing awk stage still lets a successful jq emit valid
+  # JSON, but the pipe's overall exit status is still non-zero — the
+  # old `|| echo '[]'` fallback fired anyway and appended a second
+  # "[]" line onto the already-valid output, breaking --argjson below.
+  jq -e . >/dev/null 2>&1 <<<"$CIRCULAR_JSON" || CIRCULAR_JSON='[]'
 
   rm -f "$GRAPH_TMP"
 fi


### PR DESCRIPTION
## Summary
Found and fixed while running today's `@tech-lead tick`: `generate-report.sh` was exiting non-zero on macOS, and the ADR section of every tech-health report has been silently reporting "no ADR directory found" even in repos (like this one) that have migrated to `.bsg/adr/`.

- `quality.sh`: `grep -cE ... || echo 0` double-emits `"0\n0"` whenever grep finds zero matches (`grep -c` already prints `0` on no-match but exits 1), breaking `(( … ))` arithmetic and the `--argjson` call. Same double-echo pattern in the circular-import branch, triggered by `pipefail` treating a failing awk stage as a pipe failure even though the trailing `jq` succeeded.
- `quality.sh`: circular-import detection used a nested `fwd[$1][$2]` awk array — a gawk-only extension that macOS's default BSD `awk` rejects with a syntax error, silently disabling the detector on every macOS run. Rewritten with a portable concatenated key.
- `collect.sh`: ADR directory detection never checked `.bsg/adr` (this repo's own ADR-001 convention), only the legacy `adr/` / `docs/adr/` paths.
- `generate-report.sh`: the report header's repo name used `basename $REPO_ROOT`, which reports the worktree directory name (e.g. `agent-<hash>`) instead of the real repo name under worktree-isolated ticks. Now derived from the origin remote.

## Test plan
- [x] `bash -n` syntax check on all three edited scripts
- [x] `quality.sh` runs clean (exit 0) standalone and via `generate-report.sh`, both before/after confirmed to reproduce the original failure
- [x] `generate-report.sh` produces a complete report with correct `**Repository:** \`bsg-stack\`` header and populated ADR section (3 entries from `.bsg/adr`)
- [ ] Human review of the awk rewrite / sed→parameter-expansion swap for portability across shells

Filed by @tech-lead during today's tick — see `tech/reports/2026-07-03-health.md`.