### PR TITLE
fix(pilot): skip ineligible queue-head candidates instead of stalling

### DIFF
--- a/claude-skills/agents/docs-keeper.md
+++ b/claude-skills/agents/docs-keeper.md
@@ -214,8 +214,21 @@ When the tick's phase (B) runs, the procedure is:
    one `milestone:*`, only when `.bsg-autopilot.yml` authorizes
    docs-keeper). Empty output → stop.
 
-2. **Pick exactly one candidate** — oldest-first, tie-break by lowest
-   issue number. Never attempt a second issue in the same sweep.
+2. **Pick the first ELIGIBLE candidate** — walk the candidate list
+   oldest-first (tie-break by lowest issue number), applying the scope
+   contract from step 3 to each. An ineligible candidate is passed
+   over, not consumed: log one line (`pilot: skipping #NN — <reason>`),
+   release its lock (`bus_unlock NN docs-keeper`), and evaluate the next.
+   Implement at most ONE issue per sweep — the one-per-tick cap counts
+   implementations, not evaluations. A dead ticket at the head of the
+   queue must never stall the pipeline (2026-07-03: #616 then #617
+   each starved every bsg-stack sweep until a human intervened).
+   When the same issue is skipped as ineligible on a second
+   consecutive tick, remove its `needs:docs-keeper` label and post ONE
+   comment naming the matched clause (marker
+   `<!-- bsg-pilot-ineligible:docs-keeper -->`, never duplicated) — that
+   hands disposition back to the PO/human instead of re-picking it
+   forever.
 
 3. **Check the scope contract.** Read the issue body. If it matches
    any `never-auto-implements` clause, skip it silently (log one line:

--- a/claude-skills/agents/qa.md
+++ b/claude-skills/agents/qa.md
@@ -194,8 +194,21 @@ When the tick's phase (B) runs, the procedure is:
    `milestone:*`, only when `.bsg-autopilot.yml` authorizes qa).
    Empty output → stop.
 
-2. **Pick exactly one candidate** — oldest-first, tie-break by lowest
-   issue number. Never attempt a second issue in the same sweep.
+2. **Pick the first ELIGIBLE candidate** — walk the candidate list
+   oldest-first (tie-break by lowest issue number), applying the scope
+   contract from step 3 to each. An ineligible candidate is passed
+   over, not consumed: log one line (`pilot: skipping #NN — <reason>`),
+   release its lock (`bus_unlock NN qa`), and evaluate the next.
+   Implement at most ONE issue per sweep — the one-per-tick cap counts
+   implementations, not evaluations. A dead ticket at the head of the
+   queue must never stall the pipeline (2026-07-03: #616 then #617
+   each starved every bsg-stack sweep until a human intervened).
+   When the same issue is skipped as ineligible on a second
+   consecutive tick, remove its `needs:qa` label and post ONE
+   comment naming the matched clause (marker
+   `<!-- bsg-pilot-ineligible:qa -->`, never duplicated) — that
+   hands disposition back to the PO/human instead of re-picking it
+   forever.
 
 3. **Check the scope contract.** Read the issue body. If it matches
    any `never-auto-implements` clause, skip it silently (log one line:

--- a/claude-skills/agents/seo.md
+++ b/claude-skills/agents/seo.md
@@ -188,8 +188,21 @@ When the tick's phase (B) runs, the procedure is:
    `milestone:*`, only when `.bsg-autopilot.yml` authorizes seo).
    Empty output → stop.
 
-2. **Pick exactly one candidate** — oldest-first, tie-break by lowest
-   issue number. Never attempt a second issue in the same sweep.
+2. **Pick the first ELIGIBLE candidate** — walk the candidate list
+   oldest-first (tie-break by lowest issue number), applying the scope
+   contract from step 3 to each. An ineligible candidate is passed
+   over, not consumed: log one line (`pilot: skipping #NN — <reason>`),
+   release its lock (`bus_unlock NN seo`), and evaluate the next.
+   Implement at most ONE issue per sweep — the one-per-tick cap counts
+   implementations, not evaluations. A dead ticket at the head of the
+   queue must never stall the pipeline (2026-07-03: #616 then #617
+   each starved every bsg-stack sweep until a human intervened).
+   When the same issue is skipped as ineligible on a second
+   consecutive tick, remove its `needs:seo` label and post ONE
+   comment naming the matched clause (marker
+   `<!-- bsg-pilot-ineligible:seo -->`, never duplicated) — that
+   hands disposition back to the PO/human instead of re-picking it
+   forever.
 
 3. **Check the scope contract.** Read the issue body. If it matches
    any `never-auto-implements` clause, skip it silently (log one line:

--- a/claude-skills/agents/tech-lead.md
+++ b/claude-skills/agents/tech-lead.md
@@ -185,8 +185,21 @@ When the tick's phase (B) runs, the procedure is:
    plus `label:tech` plus a GitHub milestone, only when the
    repo opts into autopilot via `.bsg-autopilot.yml`. Empty output → stop.
 
-2. **Pick exactly one candidate** — oldest-first, tie-break by lowest
-   issue number. Never attempt a second issue in the same sweep.
+2. **Pick the first ELIGIBLE candidate** — walk the candidate list
+   oldest-first (tie-break by lowest issue number), applying the scope
+   contract from step 3 to each. An ineligible candidate is passed
+   over, not consumed: log one line (`pilot: skipping #NN — <reason>`),
+   release its lock (`bus_unlock NN tech`), and evaluate the next.
+   Implement at most ONE issue per sweep — the one-per-tick cap counts
+   implementations, not evaluations. A dead ticket at the head of the
+   queue must never stall the pipeline (2026-07-03: #616 then #617
+   each starved every bsg-stack sweep until a human intervened).
+   When the same issue is skipped as ineligible on a second
+   consecutive tick, remove its `needs:tech` label and post ONE
+   comment naming the matched clause (marker
+   `<!-- bsg-pilot-ineligible:tech -->`, never duplicated) — that
+   hands disposition back to the PO/human instead of re-picking it
+   forever.
 
 3. **Check the scope contract.** Read the issue body. If it matches
    any `never-auto-implements` clause, skip it silently (log one line:


### PR DESCRIPTION
'Pick exactly one candidate — never attempt a second' + 'skip
silently on never-auto-implements' meant an ineligible issue at the
head of the oldest-first queue starved phase (B) on every sweep:
observed twice in one night on bsg-stack (#616 already-implemented,
then #617 pure-refactor), each requiring human intervention while
7 eligible candidates waited behind it.

The one-per-tick cap now counts implementations, not evaluations:
agents walk the list to the first eligible candidate (unlocking the
ones they pass over), and an issue skipped as ineligible twice in a
row loses its needs:<agent> label with a single marker comment —
handing disposition back to the PO/human instead of being re-picked
forever.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
