### PR TITLE
feat(tick): per-agent fingerprint scoping via --inputs selector

### DIFF
--- a/claude-skills/agents/marketing.md
+++ b/claude-skills/agents/marketing.md
@@ -15,10 +15,10 @@ color: pink
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim marketing` to fetch any inbox items — today this returns empty because no `needs:marketing` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
-  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh marketing marketing)"`.
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh marketing marketing --inputs releases,path:marketing,path:.bsg/CALENDAR.md,path:README.md)"` — scoped inputs so PO routing-label churn on unrelated issues doesn't re-trigger the marketing audit (#714).
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
-  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh marketing marketing marketing)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to marketing/idle-ticks.log.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh marketing marketing marketing -- --inputs releases,path:marketing,path:.bsg/CALENDAR.md,path:README.md)"` — same selector as (0.5) so the idle recomputation matches the stored fingerprint (#714).  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to marketing/idle-ticks.log.
   Audit the content calendar for overdue items, check feature-marketing
   alignment against recent releases and milestones, land the report as
   marketing/reports/YYYY-MM-DD-audit.md capturing the PR URL:

--- a/claude-skills/agents/pr-comms.md
+++ b/claude-skills/agents/pr-comms.md
@@ -15,10 +15,10 @@ color: cyan
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim pr-comms` to fetch any inbox items — today this returns empty because no `needs:pr-comms` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
-  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh pr-comms comms)"`.
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh pr-comms comms --inputs releases,milestones,path:comms)"` — scoped inputs so PO routing-label churn on unrelated issues doesn't re-trigger the pr-comms audit (#714).
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
-  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh pr-comms pr-comms comms)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to comms/idle-ticks.log.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh pr-comms pr-comms comms -- --inputs releases,milestones,path:comms)"` — same selector as (0.5) so the idle recomputation matches the stored fingerprint (#714).  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to comms/idle-ticks.log.
   Scan for PR-worthy events since last tick, draft press angles for
   unannounced events, land the report as
   comms/reports/YYYY-MM-DD-events.md capturing the PR URL:

--- a/claude-skills/agents/storytelling.md
+++ b/claude-skills/agents/storytelling.md
@@ -15,10 +15,10 @@ color: violet
 output: pr
 tick: >
   (0) Source `claude-skills/scripts/github-bus.sh` and call `bus_claim storytelling` to fetch any inbox items — today this returns empty because no `needs:storytelling` labels exist yet; once routing is active the tick processes them before running the audit (see #199).
-  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh storytelling brand)"`.
+  (0.5) Run `eval "$(bash claude-skills/scripts/tick-fingerprint.sh storytelling brand --inputs path:brand,path:README.md,path:docs,path:CHANGELOG.md)"` — scoped inputs so PO routing-label churn on unrelated issues doesn't re-trigger the storytelling audit (#714).
   If TICK_SHORT_CIRCUIT=1, return "Tick: unchanged — see PR #$TICK_LAST_PR" and stop.
   Otherwise export TICK_FINGERPRINT so generate-report.sh embeds it.
-  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh storytelling storytelling brand)"`.  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to brand/idle-ticks.log.
+  (0.6) Adaptive back-off (#363): run `eval "$(bash claude-skills/scripts/tick-idle-check.sh storytelling storytelling brand -- --inputs path:brand,path:README.md,path:docs,path:CHANGELOG.md)"` — same selector as (0.5) so the idle recomputation matches the stored fingerprint (#714).  If TICK_IDLE=1, emit TICK_IDLE_RECEIPT and stop — no candidates AND audit fingerprint matched yesterday's, so phase (A) would re-derive identical output. The idle decision is logged to brand/idle-ticks.log.
   Audit public-facing repo assets against brand/NARRATIVE.md (voice
   consistency, key-message coverage, talking points for unnarrated
   releases), land the report as brand/reports/YYYY-MM-DD-audit.md

--- a/claude-skills/scripts/tick-fingerprint.sh
+++ b/claude-skills/scripts/tick-fingerprint.sh
@@ -7,7 +7,27 @@
 # can skip the full audit.
 #
 # Usage:
-#   eval "$(bash tick-fingerprint.sh <agent-name> <report-dir> [--extra-hash <string>])"
+#   eval "$(bash tick-fingerprint.sh <agent-name> <report-dir> \
+#            [--inputs <selector>] [--extra-hash <string>])"
+#
+# --inputs <selector> is a comma-separated list of input signals to hash.
+# When omitted, the default is `issues,prs,head` — the conservative shared
+# state used by the routing agents (po/tech/qa) that legitimately depend
+# on issue labels changing between ticks.
+#
+# Supported input tokens:
+#   issues            — open+closed issue numbers + labels (sorted)
+#   prs               — non-report PR numbers + state (sorted)
+#   head              — HEAD SHA excluding `report(` commits
+#   releases          — release tag list
+#   milestones        — open milestone list + state
+#   path:<pathspec>   — `git ls-tree -r HEAD -- <pathspec>` output
+#                       (deterministic hash of tracked file contents at
+#                       that path or glob). Repeatable across tokens.
+#
+# Narrow-scope agents that don't consume routing-label churn (marketing,
+# storytelling, pr-comms) pass a selector so unrelated PO relabel-sweeps
+# don't re-trigger their audits (#714).
 #
 # Exports:
 #   TICK_SHORT_CIRCUIT   1 if today's report exists and fingerprint matches; 0 otherwise
@@ -20,10 +40,12 @@ set -euo pipefail
 AGENT=""
 REPORT_DIR=""
 EXTRA_HASH=""
+INPUTS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --extra-hash) EXTRA_HASH="$2"; shift 2 ;;
+    --inputs)     INPUTS="$2"; shift 2 ;;
     -*)           echo "tick-fingerprint.sh: unknown flag: $1" >&2; exit 2 ;;
     *)
       if [[ -z "$AGENT" ]]; then
@@ -38,8 +60,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$AGENT" || -z "$REPORT_DIR" ]]; then
-  echo "usage: tick-fingerprint.sh <agent-name> <report-dir> [--extra-hash <string>]" >&2
+  echo "usage: tick-fingerprint.sh <agent-name> <report-dir> [--inputs <selector>] [--extra-hash <string>]" >&2
   exit 2
+fi
+
+# Default selector = the pre-#714 conservative fingerprint. Any agent
+# without an explicit --inputs gets the shared state, so behaviour is
+# unchanged unless the caller opts in.
+if [[ -z "$INPUTS" ]]; then
+  INPUTS="issues,prs,head"
 fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -76,35 +105,83 @@ SLUG="${TIMESTAMP}-${ROLE}"
 REPORT_FILE="${REPO_ROOT}/${REPORT_DIR}/reports/${SLUG}.md"
 
 # ------------------------------------------------ compute current fingerprint
-# Hash a stable set of repo-wide signals that any agent cares about.
-# Per-agent extensions go through --extra-hash.
+# Hash the subset of repo-wide signals declared by --inputs. The default
+# selector `issues,prs,head` reproduces the pre-#714 behaviour so any
+# agent not opting in keeps the conservative shared fingerprint.
 
 fingerprint_inputs=""
 
-# 1. Open issue numbers + labels (sorted for stability)
-issue_state=$(gh issue list --state all --limit 500 --json number,state,labels \
-  --jq '[.[] | {n: .number, s: .state, l: [.labels[].name] | sort}] | sort_by(.n)' 2>/dev/null || echo "[]")
-fingerprint_inputs+="$issue_state"
+emit_issues() {
+  # Open+closed issue numbers + labels (sorted for stability). This is
+  # the exact input that #714 wants scoped out for narrow-audit agents:
+  # routing labels (needs:*, filed-by:*) churn on every PO sweep even
+  # when nothing marketing/storytelling/pr-comms reads has changed.
+  gh issue list --state all --limit 500 --json number,state,labels \
+    --jq '[.[] | {n: .number, s: .state, l: [.labels[].name] | sort}] | sort_by(.n)' \
+    2>/dev/null || echo "[]"
+}
 
-# 2. PR numbers + state — excluding report PRs (reports/* branches).
-#    A tick's own landed report must be invisible to the next tick's
-#    fingerprint, or the loop never converges: report merges → PR state
-#    changes → fingerprint differs → new report → repeat. Observed as
-#    duplicate same-day report PRs (#538/#540, #541/#542).
-pr_state=$(gh pr list --state all --limit 200 --json number,state,headRefName \
-  --jq '[.[] | select(.headRefName | startswith("reports/") | not) | {n: .number, s: .state}] | sort_by(.n)' 2>/dev/null || echo "[]")
-fingerprint_inputs+="$pr_state"
+emit_prs() {
+  # PR numbers + state — excluding report PRs (reports/* branches).
+  # A tick's own landed report must be invisible to the next tick's
+  # fingerprint, or the loop never converges: report merges → PR state
+  # changes → fingerprint differs → new report → repeat. Observed as
+  # duplicate same-day report PRs (#538/#540, #541/#542).
+  gh pr list --state all --limit 200 --json number,state,headRefName \
+    --jq '[.[] | select(.headRefName | startswith("reports/") | not) | {n: .number, s: .state}] | sort_by(.n)' \
+    2>/dev/null || echo "[]"
+}
 
-# 3. Last non-report commit SHA (code changes). Report merges bump HEAD
-#    without changing anything an audit reads — skip them for the same
-#    convergence reason as (2).
-head_sha=$(git log -1 --invert-grep --grep='^report(' --format=%H 2>/dev/null || echo "unknown")
-[[ -n "$head_sha" ]] || head_sha="unknown"
-fingerprint_inputs+="$head_sha"
+emit_head() {
+  # Last non-report commit SHA (code changes). Report merges bump HEAD
+  # without changing anything an audit reads — skip them for the same
+  # convergence reason as prs.
+  local sha
+  sha=$(git log -1 --invert-grep --grep='^report(' --format=%H 2>/dev/null || echo "unknown")
+  [[ -n "$sha" ]] || sha="unknown"
+  printf '%s' "$sha"
+}
 
-# 4. Per-agent extra hash (e.g. lockfile content hash for security)
+emit_releases() {
+  gh release list --limit 100 --json tagName,publishedAt \
+    --jq '[.[] | {t: .tagName, p: .publishedAt}] | sort_by(.t)' \
+    2>/dev/null || echo "[]"
+}
+
+emit_milestones() {
+  gh api 'repos/{owner}/{repo}/milestones?state=all&per_page=100' \
+    --jq '[.[] | {n: .number, t: .title, s: .state, c: .closed_at}] | sort_by(.n)' \
+    2>/dev/null || echo "[]"
+}
+
+emit_path() {
+  # Deterministic hash of tracked file contents at the given pathspec.
+  # `git ls-tree -r HEAD -- <pathspec>` prints `<mode> <type> <sha1>\t<path>`
+  # for every tracked entry, which changes iff any of those files change.
+  # Missing paths yield an empty listing (safe: their absence is stable).
+  local pathspec="$1"
+  git ls-tree -r HEAD -- "$pathspec" 2>/dev/null || true
+}
+
+IFS=',' read -r -a input_tokens <<< "$INPUTS"
+for token in "${input_tokens[@]}"; do
+  token="${token#"${token%%[![:space:]]*}"}"   # ltrim
+  token="${token%"${token##*[![:space:]]}"}"   # rtrim
+  [[ -z "$token" ]] && continue
+  case "$token" in
+    issues)     fingerprint_inputs+="|issues=$(emit_issues)" ;;
+    prs)        fingerprint_inputs+="|prs=$(emit_prs)" ;;
+    head)       fingerprint_inputs+="|head=$(emit_head)" ;;
+    releases)   fingerprint_inputs+="|releases=$(emit_releases)" ;;
+    milestones) fingerprint_inputs+="|milestones=$(emit_milestones)" ;;
+    path:*)     fingerprint_inputs+="|path:${token#path:}=$(emit_path "${token#path:}")" ;;
+    *)          echo "tick-fingerprint.sh: unknown input token: $token" >&2; exit 2 ;;
+  esac
+done
+
+# Per-agent extra hash (e.g. lockfile content hash for security).
 if [[ -n "$EXTRA_HASH" ]]; then
-  fingerprint_inputs+="$EXTRA_HASH"
+  fingerprint_inputs+="|extra=$EXTRA_HASH"
 fi
 
 TICK_FINGERPRINT=$(printf '%s' "$fingerprint_inputs" | shasum -a 256 | cut -c1-16)

--- a/claude-skills/scripts/tick-idle-check.sh
+++ b/claude-skills/scripts/tick-idle-check.sh
@@ -22,7 +22,7 @@
 # in repos that want to track agent cadence.
 #
 # Usage (sourced via eval, like tick-fingerprint.sh):
-#   eval "$(bash claude-skills/scripts/tick-idle-check.sh <agent-cli-name> <bus-label> <report-dir>)"
+#   eval "$(bash claude-skills/scripts/tick-idle-check.sh <agent-cli-name> <bus-label> <report-dir> [-- <tick-fingerprint-args>...])"
 #
 # Arguments:
 #   <agent-cli-name>  the name passed to tick-fingerprint.sh
@@ -31,6 +31,12 @@
 #                     (e.g. tech, qa, seo) — this differs from the CLI
 #                     name for tech-lead vs tech.
 #   <report-dir>      e.g. tech, qa, seo (used for idle-ticks.log path)
+#   [-- <args>...]    optional extra args forwarded verbatim to
+#                     tick-fingerprint.sh. Required for narrow-scope
+#                     agents (marketing / storytelling / pr-comms) whose
+#                     stored fingerprint used --inputs — otherwise the
+#                     idle check recomputes a default fingerprint that
+#                     will never match (#714).
 #
 # Exports:
 #   TICK_IDLE             1 if the agent should short-circuit, 0 otherwise
@@ -44,13 +50,28 @@
 set -euo pipefail
 
 if [[ $# -lt 3 ]]; then
-  echo "usage: tick-idle-check.sh <agent-cli-name> <bus-label> <report-dir>" >&2
+  echo "usage: tick-idle-check.sh <agent-cli-name> <bus-label> <report-dir> [-- <tick-fingerprint-args>...]" >&2
   exit 2
 fi
 
 AGENT_CLI="$1"
 BUS_LABEL="$2"
 REPORT_DIR="$3"
+shift 3
+
+# Optional `--` separator introduces extra args forwarded to
+# tick-fingerprint.sh (e.g. `--inputs releases,path:comms`). Callers
+# that don't need it just omit the separator.
+FP_EXTRA_ARGS=()
+if [[ $# -gt 0 ]]; then
+  if [[ "$1" == "--" ]]; then
+    shift
+    FP_EXTRA_ARGS=("$@")
+  else
+    echo "tick-idle-check.sh: expected -- before extra tick-fingerprint args, got: $1" >&2
+    exit 2
+  fi
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -62,7 +83,9 @@ candidate_count=$(printf '%s\n' "$candidates" | grep -c '^{' || true)
 # Step 2: is today's audit fingerprint already on file?
 # Run tick-fingerprint.sh in a subshell to capture its exports without
 # polluting the caller — we only need to know if SHORT_CIRCUIT was set.
-fp_exports=$(bash "$SCRIPT_DIR/tick-fingerprint.sh" "$AGENT_CLI" "$REPORT_DIR" 2>/dev/null || true)
+# Forward any extra args (typically --inputs) so the recomputed
+# fingerprint matches the one stored in today's report.
+fp_exports=$(bash "$SCRIPT_DIR/tick-fingerprint.sh" "$AGENT_CLI" "$REPORT_DIR" "${FP_EXTRA_ARGS[@]}" 2>/dev/null || true)
 short_circuit=$(printf '%s\n' "$fp_exports" | sed -n 's/^export TICK_SHORT_CIRCUIT=//p' | head -1)
 
 TICK_IDLE=0

--- a/claude-skills/tests/test_tick_convergence.sh
+++ b/claude-skills/tests/test_tick_convergence.sh
@@ -148,6 +148,44 @@ cat > "$GH_FIXTURE_ISSUES" <<'EOF'
 EOF
 assert_ne "fp changes when needs:tech is applied" "$fp_before_label" "$(fingerprint)"
 
+# --- Test 6: --inputs scope excludes issue label churn (#714) ------------
+# The marketing agent hashes releases + marketing/ path + README, not
+# issues. Under the same-day observation that motivated #714, routing
+# labels churn every PO sweep and the audit shouldn't re-fire.
+echo "Test 6: --inputs scope skips issue label churn"
+fingerprint_scoped() {
+  bash "$TICK_FP" marketing marketing \
+    --inputs "releases,path:marketing,path:README.md" 2>/dev/null \
+    | sed -n 's/^export TICK_FINGERPRINT=//p'
+}
+# Bring the issue state back to something with routing labels to prove
+# the scoped fingerprint ignores them.
+cat > "$GH_FIXTURE_ISSUES" <<'EOF'
+[
+  {"number": 10, "state": "OPEN", "labels": [{"name": "bug"}, {"name": "tech"}]}
+]
+EOF
+fp_scoped_before=$(fingerprint_scoped)
+# Now churn only labels — the exact PO relabel-sweep pattern from #714.
+cat > "$GH_FIXTURE_ISSUES" <<'EOF'
+[
+  {"number": 10, "state": "OPEN", "labels": [{"name": "bug"}, {"name": "tech"}, {"name": "needs:tech"}, {"name": "filed-by:po"}]}
+]
+EOF
+assert_eq "scoped fp ignores routing-label churn" "$fp_scoped_before" "$(fingerprint_scoped)"
+
+# --- Test 7: --inputs scope still trips on in-scope path changes ---------
+echo "Test 7: scoped fp trips when marketing/ actually changes"
+mkdir -p marketing
+printf 'seed\n' > marketing/CALENDAR.md
+git add marketing/CALENDAR.md
+git commit -q -m "feat: seed marketing"
+fp_scoped_seed=$(fingerprint_scoped)
+printf 'seed\nupdate\n' > marketing/CALENDAR.md
+git add marketing/CALENDAR.md
+git commit -q -m "feat: update marketing"
+assert_ne "scoped fp changes when marketing/ content changes" "$fp_scoped_seed" "$(fingerprint_scoped)"
+
 echo ""
 echo "=== $((PASS + FAIL)) tests: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #714

## Problem
The tick short-circuit uses a shared fingerprint (issues + PRs + HEAD) for every reporting agent. That's a conservative default but it over-triggers audits whose inputs are narrower. On the 2026-07-03 sweeps, marketing produced 3 same-day reports (#696, #702, #712) restating identical findings, because the PO's routing phases legitimately relabel issues every sweep, and marketing doesn't read labels at all.

## Changes

**`claude-skills/scripts/tick-fingerprint.sh`**
- New `--inputs <selector>` flag, comma-separated. Supported tokens: `issues`, `prs`, `head`, `releases`, `milestones`, `path:<pathspec>`.
- Default when omitted: `issues,prs,head` — reproduces pre-change behaviour, so agents without explicit `--inputs` are unaffected.

**`claude-skills/scripts/tick-idle-check.sh`**
- Forwards args after `--` verbatim to `tick-fingerprint.sh`, so the recomputed fingerprint matches the one stored in the day's report. Without this, narrow-scope agents' idle back-off would never trigger.

**Agent frontmatter (narrow-scope only)**
- `marketing.md`: `--inputs releases,path:marketing,path:.bsg/CALENDAR.md,path:README.md`
- `storytelling.md`: `--inputs path:brand,path:README.md,path:docs,path:CHANGELOG.md`
- `pr-comms.md`: `--inputs releases,milestones,path:comms`

**Unchanged** (they legitimately depend on issue/PR state): `po-manager`, `tech-lead`, `qa`, `security`, `seo`, `docs-keeper`, `cleaner`.

**Regression tests** — `test_tick_convergence.sh` adds two cases:
- Routing-label churn no longer changes the scoped fingerprint.
- In-scope path changes still change it.

## Test
- \`bash claude-skills/tests/test_tick_convergence.sh\` — 8/8 pass (5 legacy + 2 new + baseline).
- \`bash claude-skills/tests/test_tick_fingerprint.sh\` — 7/7 pass (existing).
- \`python3 claude-skills/tests/test_agent_frontmatter.py\` — 12/12 pass.
- \`bash -n\` on both scripts — clean.