### PR TITLE
fix(pilot): reconcile-milestones.sh silently assigns 0 milestones (#657)

### DIFF
--- a/claude-skills/skills/po/scripts/reconcile-milestones.sh
+++ b/claude-skills/skills/po/scripts/reconcile-milestones.sh
@@ -90,6 +90,17 @@ ensure_label "$SCOPE_CREEP_LABEL" "$SCOPE_CREEP_COLOR" \
 
 # Build a map: milestone-slug -> csv of bound issue numbers.
 # Supports both [milestone:Slug] bindings and inferred slug from epic title.
+# Fix #657: parse-plan.sh already strips [tag:...] brackets out of
+# `raw` and resolves the slug into `.bindings.milestones[]` — re-deriving
+# it via a regex capture() against `.raw` never matches anymore, so the
+# explicit-tag path is read straight from `.bindings.milestones[0]`.
+#
+# Independently: never bind a possibly-zero-output generator (like a
+# non-matching capture()) via `EXPR as $var | BODY` — in jq, BODY runs
+# once per *output* of EXPR, so a non-match means BODY (and any fallback
+# it contains) never runs at all. Wrapping in `[EXPR][0]` collapses the
+# generator to exactly one output (null on no match) before the `as`
+# binding, so the fallback chain below always executes.
 mapfile -t epic_lines < <(
   jq -r '
     .items[]
@@ -97,9 +108,9 @@ mapfile -t epic_lines < <(
     | .bindings.epics as $nums
     | ($nums | map(tostring) | join(",")) as $nums_csv
     | .raw as $raw
-    | ($raw | capture("\\[milestone:(?<ms>[A-Za-z0-9_-]+)\\]") // empty | .ms) as $explicit_ms
-    | ($raw | capture("^\\*\\*(?<ep>E[0-9]+) (?<name>[a-z0-9-]+)\\*\\*") // empty
-       | if . then "\(.ep)-\(.name)" else empty end) as $inferred_ms
+    | (.bindings.milestones[0]) as $explicit_ms
+    | ([$raw | capture("^\\*\\*(?<ep>E[0-9]+) (?<name>[a-z0-9-]+)\\*\\*")][0]) as $cap
+    | ($cap | if . then "\(.ep)-\(.name)" else null end) as $inferred_ms
     | ($explicit_ms // $inferred_ms) as $slug
     | if $slug then "\($slug)\t\($nums_csv)" else empty end
   ' <<<"$plan_envelope"

--- a/claude-skills/tests/test_reconcile_milestones_explicit_ms.py
+++ b/claude-skills/tests/test_reconcile_milestones_explicit_ms.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Regression test for issue #657 — reconcile-milestones.sh silently
+assigns 0 milestones because the `as $var` jq binding used to
+re-derive the milestone slug short-circuits to zero output whenever
+`capture(...)` fails to match.
+
+Root cause (see issue #657 for the full writeup):
+
+  1. parse-plan.sh strips inline `[tag:...]` brackets out of the
+     `raw` field — the parsed slug lives in `.bindings.milestones[]`,
+     not in `.raw` anymore. So `capture("\\[milestone:...\\]")` against
+     `.raw` never matches.
+  2. In jq, `EXPR as $var | BODY` evaluates `BODY` once per *output*
+     of EXPR. A non-matching `capture(...)` (without `?` recovering
+     an error, and without the `[...][0]` single-output idiom)
+     produces zero outputs — so `BODY` never runs at all, not even
+     to try the inferred-from-title fallback. The whole per-epic
+     pipeline silently emits zero lines regardless of whether the
+     inferred pattern would have matched.
+
+This test invokes reconcile-milestones.sh against a stubbed
+parse-plan.sh that emits a fixture envelope shaped like the real
+parser's output — one "Epics" item with `bindings.milestones:
+["E1-tick-hygiene"]` and a `raw` field with the bracket tag already
+stripped (matching real parse-plan.sh behaviour) — and asserts the
+script reports a non-zero "epics parsed from plan" count instead of
+the silent "0 epics parsed from plan" regression.
+
+Stdlib only — no third-party dependencies, no network (gh is stubbed).
+
+Run locally:
+    python3 claude-skills/tests/test_reconcile_milestones_explicit_ms.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO_ROOT / "claude-skills" / "skills" / "po" / "scripts" / "reconcile-milestones.sh"
+)
+
+# Mirrors the shape parse-plan.sh --typed actually emits: bracket tags
+# are stripped from `raw` and resolved into `bindings.milestones[]` /
+# `bindings.epics[]`. This is the exact shape that broke the old
+# capture-against-raw re-derivation.
+FIXTURE_ENVELOPE = {
+    "status": "ok",
+    "items": [
+        {
+            "section": "Epics",
+            "raw": "tick-hygiene work",
+            "bindings": {
+                "milestones": ["E1-tick-hygiene"],
+                "epics": [123],
+                "labels": [],
+            },
+        }
+    ],
+}
+
+
+class TestReconcileMilestonesExplicitMs(unittest.TestCase):
+
+    def setUp(self):
+        self.assertTrue(SCRIPT.exists(), f"reconcile-milestones.sh not found at {SCRIPT}")
+
+    def _run_with_fixture(self) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts_dir = Path(tmpdir) / "claude-skills" / "skills" / "po" / "scripts"
+            scripts_dir.mkdir(parents=True)
+
+            # Stub parse-plan.sh: emit the fixture envelope regardless of args.
+            parse_plan_stub = scripts_dir / "parse-plan.sh"
+            parse_plan_stub.write_text(
+                "#!/usr/bin/env bash\ncat <<'JSON'\n"
+                + json.dumps(FIXTURE_ENVELOPE)
+                + "\nJSON\n"
+            )
+            parse_plan_stub.chmod(0o755)
+
+            # Stub gh: no-op success with empty output for every call so
+            # the script never touches the network and never crashes past
+            # the "epics parsed from plan" line we're asserting on.
+            bin_dir = Path(tmpdir) / "bin"
+            bin_dir.mkdir()
+            gh_stub = bin_dir / "gh"
+            gh_stub.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    exit 0
+                    """
+                )
+            )
+            gh_stub.chmod(0o755)
+
+            sut = scripts_dir / "reconcile-milestones.sh"
+            sut.symlink_to(SCRIPT)
+
+            env = {
+                **os.environ,
+                "PATH": str(bin_dir) + ":" + str(scripts_dir) + ":" + os.environ.get("PATH", ""),
+            }
+
+            return subprocess.run(
+                ["bash", str(sut)],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+
+    def test_explicit_milestone_binding_is_parsed(self):
+        """A plan item with an already-resolved [milestone:] binding must
+        be counted — not silently dropped to zero.
+
+        Before the #657 fix: stdout contains "0 epics parsed from plan"
+        even though the fixture carries one epic with an explicit
+        milestone binding.
+        After the fix: stdout contains "1 epics parsed from plan".
+        """
+        result = self._run_with_fixture()
+        self.assertIn(
+            "1 epics parsed from plan",
+            result.stdout,
+            "Regression #657: reconcile-milestones.sh must count the explicit "
+            f"[milestone:] binding, not silently drop to zero.\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}",
+        )
+        self.assertNotIn(
+            "0 epics parsed from plan",
+            result.stdout,
+            f"Regression #657 reproduced: 0 epics parsed.\nstdout={result.stdout}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `reconcile-milestones.sh` re-derived the milestone slug via a jq `capture()` against `.raw`, but `parse-plan.sh` already strips `[tag:...]` brackets out of `raw` and resolves the slug into `.bindings.milestones[]` — so the explicit-tag capture never matched.
- Worse, binding that non-matching `capture()` via `EXPR as $var | BODY` meant `BODY` (including the inferred-from-title fallback) never ran at all — jq's `as` runs `BODY` once per *output* of `EXPR`, and a non-match produces zero outputs.
- Net effect: `reconcile-milestones.sh` has printed `0 epics parsed from plan` on every po-manager tick since #288 landed, silently no-op'ing milestone assignment and scope-creep reconciliation.

Fix reads the explicit slug straight from `.bindings.milestones[0]` and collapses the inferred-from-title `capture()` into a single-output `[EXPR][0]` before binding, so the fallback chain always executes.

## Test plan
- [x] Added `claude-skills/tests/test_reconcile_milestones_explicit_ms.py` — reproduces the exact regression (fixture plan item with an already-resolved `[milestone:]` binding), confirmed it **fails** against the pre-fix script (`0 epics parsed from plan`)
- [x] Confirmed it **passes** after the fix (`1 epics parsed from plan`)
- [x] Re-ran `test_reconcile_milestones_unbound.py` (#546 regression) — still passes
- [x] Re-ran `test_po_milestone_reconcile.py` (#288 wiring) — still passes
- [x] `bash -n` syntax check on the patched script
- [x] Manually verified the inferred-from-title fallback path (`**E1 tick-hygiene**`) still resolves correctly

Closes #657.

🤖 Generated by `@tech-lead` autopilot (#181/#221) during a scoped implementation pilot.