### PR TITLE
test(po): split test_po_report_integration.py by feature (#691)

### DIFF
--- a/claude-skills/tests/_po_integration_helpers.py
+++ b/claude-skills/tests/_po_integration_helpers.py
@@ -1,0 +1,122 @@
+"""Shared fixture for the po integration test suite.
+
+Extracted from test_po_report_integration.py during split for #691
+(single file >500 LOC). Feature-focused test modules inherit
+`BasePoIntegration` to get a workdir + snapshot without duplicating
+the `gh`/`jq`/auth precondition dance.
+
+Stdlib only. Every subclass is auto-skipped when `gh`/`jq` are missing
+or when `gh` isn't authenticated, matching the original behavior.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "claude-skills" / "skills" / "po" / "scripts"
+TARGET = "beyond-scale-group/edomata"
+
+SCRIPT_TIMEOUT_S = 120
+
+
+def _which(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def _gh_authenticated() -> bool:
+    try:
+        r = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return r.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+class BasePoIntegration(unittest.TestCase):
+    """Shared fixture: workdir with a git remote pointing at TARGET
+    plus one cached snapshot.json that every test reads via `--snapshot`.
+
+    Not a test case itself (no test_* methods) so unittest discovery
+    walks over it silently.
+    """
+
+    tmpdir: "tempfile.TemporaryDirectory | None" = None
+    workdir: Path
+    snapshot_path: Path  # collect.sh output cached once per test class
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _which("gh"):
+            raise unittest.SkipTest("gh CLI not available")
+        if not _which("jq"):
+            raise unittest.SkipTest("jq not available")
+        if not _gh_authenticated():
+            raise unittest.SkipTest(
+                "gh is not authenticated (set GH_TOKEN or run `gh auth login`)"
+            )
+
+        # Minimal git init + remote pointing at TARGET so `gh`'s CWD
+        # autodetection resolves to the right repo without a real clone.
+        cls.tmpdir = tempfile.TemporaryDirectory(prefix="po-integration-")
+        cls.workdir = Path(cls.tmpdir.name)
+        remote_url = f"https://github.com/{TARGET}.git"
+        for cmd in (
+            ["git", "init", "--quiet"],
+            ["git", "remote", "add", "origin", remote_url],
+        ):
+            subprocess.run(
+                cmd, cwd=cls.workdir, check=True, capture_output=True, text=True
+            )
+
+        # Collect once per test class so each downstream script reads the
+        # same snapshot via `--snapshot <path>` — one GraphQL fetch total.
+        cls.snapshot_path = cls.workdir / "snapshot.json"
+        result = subprocess.run(
+            ["bash", str(SCRIPTS / "collect.sh")],
+            cwd=cls.workdir,
+            capture_output=True,
+            text=True,
+            timeout=SCRIPT_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            raise unittest.SkipTest(
+                f"collect.sh failed: {result.stderr}"
+            )
+        cls.snapshot_path.write_text(result.stdout)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.tmpdir is not None:
+            cls.tmpdir.cleanup()
+
+    def _run(self, script: str, *args: str, use_snapshot: bool = True) -> str:
+        path = SCRIPTS / script
+        self.assertTrue(path.is_file(), f"script not found: {path}")
+        cmd = ["bash", str(path)]
+        # collect.sh produces the snapshot; every other script consumes it
+        # from the cached path to avoid a fresh GraphQL fetch per test.
+        if use_snapshot and script != "collect.sh" and script != "generate-report.sh":
+            cmd.extend(["--snapshot", str(self.snapshot_path)])
+        cmd.extend(args)
+        result = subprocess.run(
+            cmd,
+            cwd=self.workdir,
+            capture_output=True,
+            text=True,
+            timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{script} exited {result.returncode}\nSTDERR:\n{result.stderr}",
+        )
+        return result.stdout

--- a/claude-skills/tests/test_po_plan_integration.py
+++ b/claude-skills/tests/test_po_plan_integration.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Integration test for the po skill's planning surface against
+beyond-scale-group/edomata.
+
+Covers plan handling: parse-plan.sh, adherence.sh, trends.sh, and
+bootstrap-plan.sh. The report-generation surface (collect / status /
+milestone-progress / stale / generate-report / pr-flow) lives in
+`test_po_report_integration.py` (split for #691, single file >500 LOC).
+
+Same skip semantics as the sibling module: no `gh`, no auth, or no
+`jq` -> the class is skipped cleanly.
+
+Run locally:
+
+    python3 claude-skills/tests/test_po_plan_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+
+from _po_integration_helpers import (
+    SCRIPT_TIMEOUT_S,
+    SCRIPTS,
+    TARGET,
+    BasePoIntegration,
+)
+
+
+class TestPoPlanIntegration(BasePoIntegration):
+    """End-to-end smoke test of the planning po scripts."""
+
+    def test_parse_plan_extracts_binding_tags(self) -> None:
+        """parse-plan.sh returns one item per tagged bullet with typed bindings."""
+        plan = self.workdir / "test-plan.md"
+        plan.write_text(
+            "# Big plan — fixture\n\n"
+            "## Objectives\n"
+            "- Ship redesign              [milestone:Payments-v1]\n"
+            "- Migrate DB                  [epic:#142]\n"
+            "- Hire DevRel                 [label:hire:devrel]\n"
+            "- Do everything               [milestone:Payments-v1] [epic:#287] [label:area:core]\n"
+            "- Shorthand issue ref         [#7]\n"
+            "\n"
+            "## Notes\n"
+            "This is prose and should be skipped.\n"
+        )
+        out = self._run("parse-plan.sh", "--plan", str(plan), use_snapshot=False)
+        items = json.loads(out)
+        self.assertEqual(len(items), 5)
+        # Check the multi-tag bullet picked up every binding.
+        multi = next(i for i in items if i["raw"] == "Do everything")
+        self.assertEqual(multi["bindings"]["milestones"], ["Payments-v1"])
+        self.assertEqual(multi["bindings"]["epics"], [287])
+        self.assertEqual(multi["bindings"]["labels"], ["area:core"])
+        # [#7] shorthand becomes an epic binding with integer value.
+        shorthand = next(i for i in items if i["raw"] == "Shorthand issue ref")
+        self.assertEqual(shorthand["bindings"]["epics"], [7])
+        # Section tracking.
+        self.assertEqual(multi["section"], "Objectives")
+
+    def test_parse_plan_returns_empty_array_when_missing(self) -> None:
+        """A missing PLAN.md is NOT an error — emit [] so adherence can surface the gap."""
+        nonexistent = self.workdir / "does-not-exist.md"
+        out = self._run("parse-plan.sh", "--plan", str(nonexistent), use_snapshot=False)
+        self.assertEqual(json.loads(out), [])
+
+    def test_adherence_emits_matrix_and_drift(self) -> None:
+        """adherence.sh joins a hand-written plan with the snapshot."""
+        plan = self.workdir / "adherence-plan.md"
+        plan.write_text(
+            "# Big plan — edomata fixture\n\n"
+            "## Objectives\n"
+            "- Audit Renovate PRs           [#21]\n"
+            "- Add release automation       [milestone:non-existent]\n"
+        )
+        out = subprocess.run(
+            [
+                "bash",
+                str(SCRIPTS / "adherence.sh"),
+                "--plan",
+                str(plan),
+                "--snapshot",
+                str(self.snapshot_path),
+            ],
+            cwd=self.workdir,
+            capture_output=True,
+            text=True,
+            timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(out.returncode, 0, out.stderr)
+        data = json.loads(out.stdout)
+        self.assertTrue(data["planFound"])
+        self.assertEqual(data["repo"], TARGET)
+        # Top-level shape.
+        for key in ("items", "drift", "summary"):
+            self.assertIn(key, data)
+        for drift_key in ("scopeCreep", "abandonedItems", "offCourse"):
+            self.assertIn(drift_key, data["drift"])
+        for summary_key in (
+            "totalPlanItems",
+            "notStarted",
+            "inProgress",
+            "done",
+            "atRisk",
+            "scopeCreep",
+        ):
+            self.assertIn(summary_key, data["summary"])
+        self.assertEqual(data["summary"]["totalPlanItems"], 2)
+        # Every plan item carries its derived status + counts.
+        for item in data["items"]:
+            self.assertIn(item["status"],
+                {"done", "in_progress", "at_risk", "not_started"})
+            self.assertIn("counts", item)
+            self.assertIn("evidence", item)
+        # PR #21 is an open Renovate PR on edomata → the #21 binding
+        # should resolve to in_progress with non-zero openPrs.
+        pr21_item = next(i for i in data["items"] if i["raw"] == "Audit Renovate PRs")
+        self.assertEqual(pr21_item["status"], "in_progress")
+        self.assertGreaterEqual(pr21_item["counts"]["openPrs"], 1)
+        # Milestone binding against a non-existent milestone resolves
+        # to not_started (no evidence anywhere).
+        missing = next(i for i in data["items"] if i["raw"] == "Add release automation")
+        self.assertEqual(missing["status"], "not_started")
+
+    def test_trends_handles_missing_history_dir(self) -> None:
+        """trends.sh emits a well-formed empty object when there's no history yet."""
+        out = subprocess.run(
+            ["bash", str(SCRIPTS / "trends.sh"), "--dir", "/nonexistent-po-history"],
+            capture_output=True, text=True, timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(out.returncode, 0, out.stderr)
+        data = json.loads(out.stdout)
+        self.assertEqual(data["series"], [])
+        self.assertIsNone(data["velocity"])
+        self.assertIsNone(data["latestChange"])
+
+    def test_trends_derives_velocity_from_two_snapshots(self) -> None:
+        """Given two history files, trends.sh computes velocity from the delta."""
+        hist_dir = self.workdir / "history"
+        hist_dir.mkdir(exist_ok=True)
+        # Two synthetic snapshots 7 days apart; 3 issues closed, 2 PRs merged.
+        for offset, (closed, merged) in enumerate([(0, 0), (3, 2)]):
+            (hist_dir / f"2026-04-{1 + offset * 7:02d}.json").write_text(json.dumps({
+                "generatedAt": f"2026-04-{1 + offset * 7:02d}T00:00:00Z",
+                "issues": (
+                    [{"state": "OPEN"}] * 5
+                    + [{"state": "CLOSED"}] * closed
+                ),
+                "pullRequests": (
+                    [{"state": "OPEN"}] * 2
+                    + [{"state": "MERGED"}] * merged
+                ),
+                "milestones": [],
+            }))
+        out = subprocess.run(
+            ["bash", str(SCRIPTS / "trends.sh"), "--dir", str(hist_dir)],
+            capture_output=True, text=True, timeout=SCRIPT_TIMEOUT_S,
+        )
+        self.assertEqual(out.returncode, 0, out.stderr)
+        data = json.loads(out.stdout)
+        self.assertEqual(len(data["series"]), 2)
+        v = data["velocity"]
+        self.assertIsNotNone(v)
+        self.assertEqual(v["samplePoints"], 2)
+        self.assertEqual(v["spanDays"], 7)
+        # 3 issues closed over 7 days = 3 per week.
+        self.assertAlmostEqual(v["issuesClosedPerWeek"], 3.0, places=1)
+        self.assertAlmostEqual(v["prsMergedPerWeek"], 2.0, places=1)
+
+    def test_bootstrap_plan_emits_draft_markdown(self) -> None:
+        """bootstrap-plan.sh produces a reviewable draft — no filesystem writes."""
+        out = self._run("bootstrap-plan.sh")
+        self.assertIn(f"# Big plan — {TARGET}", out)
+        for header in (
+            "## Objectives",
+            "## Milestones",
+            "## Epics",
+            "## Cross-cutting work (by label)",
+            "## Decision log",
+            "## Tracked risks",
+        ):
+            self.assertIn(header, out, f"missing bootstrap section: {header!r}")
+        # Draft references plan-schema.md so readers know how to edit it.
+        self.assertIn("plan-schema.md", out)
+
+    def test_bootstrap_plan_seeds_epics_from_issues_when_no_milestones(self) -> None:
+        """#115: when no milestones and no epic labels exist, bootstrap seeds
+        epics from open issues by token-clustering — not a bare placeholder."""
+        snapshot = {
+            'repo': 'test-org/test-repo',
+            'generatedAt': '2026-05-04T00:00:00Z',
+            'meta': {},
+            'issues': [
+                {
+                    'number': 1,
+                    'title': 'feat: add authentication login page',
+                    'state': 'OPEN',
+                    'labels': ['enhancement'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+                {
+                    'number': 2,
+                    'title': 'feat: add authentication logout flow',
+                    'state': 'OPEN',
+                    'labels': ['enhancement'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+                {
+                    'number': 3,
+                    'title': 'feat: authentication session refresh',
+                    'state': 'OPEN',
+                    'labels': ['enhancement'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+                {
+                    'number': 4,
+                    'title': 'fix: database query timeout',
+                    'state': 'OPEN',
+                    'labels': ['bug'],
+                    'assignees': [],
+                    'createdAt': '2026-01-01T00:00:00Z',
+                    'updatedAt': '2026-01-01T00:00:00Z',
+                    'lastCommentedAt': None,
+                    'closedAt': None,
+                },
+            ],
+            'pullRequests': [],
+            'milestones': [],
+            'releases': [],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False, dir=self.workdir
+        ) as fh:
+            json.dump(snapshot, fh)
+            snap_path = fh.name
+
+        result = subprocess.run(
+            ['bash', str(SCRIPTS / 'bootstrap-plan.sh'), '--snapshot', snap_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f'bootstrap-plan.sh failed: {result.stderr}',
+        )
+        out = result.stdout
+        # Must not emit the bare placeholder when >= 3 issues are available.
+        self.assertNotIn(
+            '- _No epic candidates detected. Add parent issues manually._',
+            out,
+            'bootstrap-plan.sh fell back to bare placeholder despite >= 3 open issues',
+        )
+        # Must contain at least one auto-suggested epic cluster.
+        self.assertIn(
+            '_auto-suggested',
+            out,
+            'bootstrap-plan.sh did not emit any _auto-suggested epic clusters',
+        )
+        # The issues should be bound in the suggestion.
+        self.assertIn('#1', out)
+        self.assertIn('#2', out)
+        self.assertIn('#3', out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/claude-skills/tests/test_po_report_integration.py
+++ b/claude-skills/tests/test_po_report_integration.py
@@ -2,13 +2,12 @@
 """
 Integration test for the po skill against beyond-scale-group/edomata.
 
-Runs every po script against the real GitHub repo (via `GH_REPO=`
-— no checkout needed) and asserts:
+Covers the report-generation pipeline: collect.sh, status.sh,
+milestone-progress.sh, stale-issues.sh, generate-report.sh, and
+pr-flow.sh — all reading from the shared cached snapshot.
 
-  - JSON-emitting scripts produce well-formed JSON with the expected
-    top-level keys
-  - generate-report.sh produces markdown with the expected section headers
-  - repo-level values (repo slug, invariants between fields) are correct
+Plan / adherence / trends / bootstrap tests live in
+`test_po_plan_integration.py` (split for #691, single file >500 LOC).
 
 Assertions are schema-level so the test tolerates edomata's real issue /
 PR / milestone counts drifting over time. No hardcoded counts.
@@ -34,115 +33,13 @@ Run locally:
 from __future__ import annotations
 
 import json
-import os
-import shutil
-import subprocess
-import tempfile
 import unittest
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPTS = REPO_ROOT / "claude-skills" / "skills" / "po" / "scripts"
-TARGET = "beyond-scale-group/edomata"
-
-SCRIPT_TIMEOUT_S = 120
+from _po_integration_helpers import TARGET, BasePoIntegration
 
 
-def _which(cmd: str) -> bool:
-    return shutil.which(cmd) is not None
-
-
-def _gh_authenticated() -> bool:
-    try:
-        r = subprocess.run(
-            ["gh", "auth", "status"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        return r.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
-
-
-class TestPoReportIntegration(unittest.TestCase):
-    """End-to-end smoke test of every po script against a real repo."""
-
-    tmpdir: "tempfile.TemporaryDirectory | None" = None
-    workdir: Path
-    snapshot_path: Path  # collect.sh output cached once per test class
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        if not _which("gh"):
-            raise unittest.SkipTest("gh CLI not available")
-        if not _which("jq"):
-            raise unittest.SkipTest("jq not available")
-        if not _gh_authenticated():
-            raise unittest.SkipTest(
-                "gh is not authenticated (set GH_TOKEN or run `gh auth login`)"
-            )
-
-        # Minimal git init + remote pointing at TARGET so `gh`'s CWD
-        # autodetection resolves to the right repo without a real clone.
-        cls.tmpdir = tempfile.TemporaryDirectory(prefix="po-integration-")
-        cls.workdir = Path(cls.tmpdir.name)
-        remote_url = f"https://github.com/{TARGET}.git"
-        for cmd in (
-            ["git", "init", "--quiet"],
-            ["git", "remote", "add", "origin", remote_url],
-        ):
-            subprocess.run(
-                cmd, cwd=cls.workdir, check=True, capture_output=True, text=True
-            )
-
-        # Collect once per test class so each downstream script reads the
-        # same snapshot via `--snapshot <path>` — one GraphQL fetch total.
-        cls.snapshot_path = cls.workdir / "snapshot.json"
-        result = subprocess.run(
-            ["bash", str(SCRIPTS / "collect.sh")],
-            cwd=cls.workdir,
-            capture_output=True,
-            text=True,
-            timeout=SCRIPT_TIMEOUT_S,
-        )
-        if result.returncode != 0:
-            raise unittest.SkipTest(
-                f"collect.sh failed: {result.stderr}"
-            )
-        cls.snapshot_path.write_text(result.stdout)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        if cls.tmpdir is not None:
-            cls.tmpdir.cleanup()
-
-    # -- helpers --------------------------------------------------------
-
-    def _run(self, script: str, *args: str, use_snapshot: bool = True) -> str:
-        path = SCRIPTS / script
-        self.assertTrue(path.is_file(), f"script not found: {path}")
-        cmd = ["bash", str(path)]
-        # collect.sh produces the snapshot; every other script consumes it
-        # from the cached path to avoid a fresh GraphQL fetch per test.
-        if use_snapshot and script != "collect.sh" and script != "generate-report.sh":
-            cmd.extend(["--snapshot", str(self.snapshot_path)])
-        cmd.extend(args)
-        result = subprocess.run(
-            cmd,
-            cwd=self.workdir,
-            capture_output=True,
-            text=True,
-            timeout=SCRIPT_TIMEOUT_S,
-        )
-        self.assertEqual(
-            result.returncode,
-            0,
-            f"{script} exited {result.returncode}\nSTDERR:\n{result.stderr}",
-        )
-        return result.stdout
-
-    # -- tests ----------------------------------------------------------
+class TestPoReportIntegration(BasePoIntegration):
+    """End-to-end smoke test of the report-generation po scripts."""
 
     def test_collect_script_emits_valid_snapshot(self) -> None:
         """The single GraphQL snapshot all other scripts consume."""
@@ -298,101 +195,6 @@ class TestPoReportIntegration(unittest.TestCase):
         ):
             self.assertIn(metric, out, f"missing at-a-glance row: {metric!r}")
 
-    # -- plan adherence -----------------------------------------------
-
-    def test_parse_plan_extracts_binding_tags(self) -> None:
-        """parse-plan.sh returns one item per tagged bullet with typed bindings."""
-        plan = self.workdir / "test-plan.md"
-        plan.write_text(
-            "# Big plan — fixture\n\n"
-            "## Objectives\n"
-            "- Ship redesign              [milestone:Payments-v1]\n"
-            "- Migrate DB                  [epic:#142]\n"
-            "- Hire DevRel                 [label:hire:devrel]\n"
-            "- Do everything               [milestone:Payments-v1] [epic:#287] [label:area:core]\n"
-            "- Shorthand issue ref         [#7]\n"
-            "\n"
-            "## Notes\n"
-            "This is prose and should be skipped.\n"
-        )
-        out = self._run("parse-plan.sh", "--plan", str(plan), use_snapshot=False)
-        items = json.loads(out)
-        self.assertEqual(len(items), 5)
-        # Check the multi-tag bullet picked up every binding.
-        multi = next(i for i in items if i["raw"] == "Do everything")
-        self.assertEqual(multi["bindings"]["milestones"], ["Payments-v1"])
-        self.assertEqual(multi["bindings"]["epics"], [287])
-        self.assertEqual(multi["bindings"]["labels"], ["area:core"])
-        # [#7] shorthand becomes an epic binding with integer value.
-        shorthand = next(i for i in items if i["raw"] == "Shorthand issue ref")
-        self.assertEqual(shorthand["bindings"]["epics"], [7])
-        # Section tracking.
-        self.assertEqual(multi["section"], "Objectives")
-
-    def test_parse_plan_returns_empty_array_when_missing(self) -> None:
-        """A missing PLAN.md is NOT an error — emit [] so adherence can surface the gap."""
-        nonexistent = self.workdir / "does-not-exist.md"
-        out = self._run("parse-plan.sh", "--plan", str(nonexistent), use_snapshot=False)
-        self.assertEqual(json.loads(out), [])
-
-    def test_adherence_emits_matrix_and_drift(self) -> None:
-        """adherence.sh joins a hand-written plan with the snapshot."""
-        plan = self.workdir / "adherence-plan.md"
-        plan.write_text(
-            "# Big plan — edomata fixture\n\n"
-            "## Objectives\n"
-            "- Audit Renovate PRs           [#21]\n"
-            "- Add release automation       [milestone:non-existent]\n"
-        )
-        out = subprocess.run(
-            [
-                "bash",
-                str(SCRIPTS / "adherence.sh"),
-                "--plan",
-                str(plan),
-                "--snapshot",
-                str(self.snapshot_path),
-            ],
-            cwd=self.workdir,
-            capture_output=True,
-            text=True,
-            timeout=SCRIPT_TIMEOUT_S,
-        )
-        self.assertEqual(out.returncode, 0, out.stderr)
-        data = json.loads(out.stdout)
-        self.assertTrue(data["planFound"])
-        self.assertEqual(data["repo"], TARGET)
-        # Top-level shape.
-        for key in ("items", "drift", "summary"):
-            self.assertIn(key, data)
-        for drift_key in ("scopeCreep", "abandonedItems", "offCourse"):
-            self.assertIn(drift_key, data["drift"])
-        for summary_key in (
-            "totalPlanItems",
-            "notStarted",
-            "inProgress",
-            "done",
-            "atRisk",
-            "scopeCreep",
-        ):
-            self.assertIn(summary_key, data["summary"])
-        self.assertEqual(data["summary"]["totalPlanItems"], 2)
-        # Every plan item carries its derived status + counts.
-        for item in data["items"]:
-            self.assertIn(item["status"],
-                {"done", "in_progress", "at_risk", "not_started"})
-            self.assertIn("counts", item)
-            self.assertIn("evidence", item)
-        # PR #21 is an open Renovate PR on edomata → the #21 binding
-        # should resolve to in_progress with non-zero openPrs.
-        pr21_item = next(i for i in data["items"] if i["raw"] == "Audit Renovate PRs")
-        self.assertEqual(pr21_item["status"], "in_progress")
-        self.assertGreaterEqual(pr21_item["counts"]["openPrs"], 1)
-        # Milestone binding against a non-existent milestone resolves
-        # to not_started (no evidence anywhere).
-        missing = next(i for i in data["items"] if i["raw"] == "Add release automation")
-        self.assertEqual(missing["status"], "not_started")
-
     def test_pr_flow_emits_structured_metrics(self) -> None:
         """pr-flow.sh produces review latency, age buckets, merge-queue, throughput."""
         out = self._run("pr-flow.sh")
@@ -410,159 +212,6 @@ class TestPoReportIntegration(unittest.TestCase):
         self.assertIn("mergedLast30d", data["throughput"])
         self.assertIn("mergedPerWeek", data["throughput"])
 
-    def test_trends_handles_missing_history_dir(self) -> None:
-        """trends.sh emits a well-formed empty object when there's no history yet."""
-        out = subprocess.run(
-            ["bash", str(SCRIPTS / "trends.sh"), "--dir", "/nonexistent-po-history"],
-            capture_output=True, text=True, timeout=SCRIPT_TIMEOUT_S,
-        )
-        self.assertEqual(out.returncode, 0, out.stderr)
-        data = json.loads(out.stdout)
-        self.assertEqual(data["series"], [])
-        self.assertIsNone(data["velocity"])
-        self.assertIsNone(data["latestChange"])
-
-    def test_trends_derives_velocity_from_two_snapshots(self) -> None:
-        """Given two history files, trends.sh computes velocity from the delta."""
-        hist_dir = self.workdir / "history"
-        hist_dir.mkdir(exist_ok=True)
-        # Two synthetic snapshots 7 days apart; 3 issues closed, 2 PRs merged.
-        for offset, (closed, merged) in enumerate([(0, 0), (3, 2)]):
-            (hist_dir / f"2026-04-{1 + offset * 7:02d}.json").write_text(json.dumps({
-                "generatedAt": f"2026-04-{1 + offset * 7:02d}T00:00:00Z",
-                "issues": (
-                    [{"state": "OPEN"}] * 5
-                    + [{"state": "CLOSED"}] * closed
-                ),
-                "pullRequests": (
-                    [{"state": "OPEN"}] * 2
-                    + [{"state": "MERGED"}] * merged
-                ),
-                "milestones": [],
-            }))
-        out = subprocess.run(
-            ["bash", str(SCRIPTS / "trends.sh"), "--dir", str(hist_dir)],
-            capture_output=True, text=True, timeout=SCRIPT_TIMEOUT_S,
-        )
-        self.assertEqual(out.returncode, 0, out.stderr)
-        data = json.loads(out.stdout)
-        self.assertEqual(len(data["series"]), 2)
-        v = data["velocity"]
-        self.assertIsNotNone(v)
-        self.assertEqual(v["samplePoints"], 2)
-        self.assertEqual(v["spanDays"], 7)
-        # 3 issues closed over 7 days = 3 per week.
-        self.assertAlmostEqual(v["issuesClosedPerWeek"], 3.0, places=1)
-        self.assertAlmostEqual(v["prsMergedPerWeek"], 2.0, places=1)
-
-    def test_bootstrap_plan_emits_draft_markdown(self) -> None:
-        """bootstrap-plan.sh produces a reviewable draft — no filesystem writes."""
-        out = self._run("bootstrap-plan.sh")
-        self.assertIn(f"# Big plan — {TARGET}", out)
-        for header in (
-            "## Objectives",
-            "## Milestones",
-            "## Epics",
-            "## Cross-cutting work (by label)",
-            "## Decision log",
-            "## Tracked risks",
-        ):
-            self.assertIn(header, out, f"missing bootstrap section: {header!r}")
-        # Draft references plan-schema.md so readers know how to edit it.
-        self.assertIn("plan-schema.md", out)
-
-
-
-    def test_bootstrap_plan_seeds_epics_from_issues_when_no_milestones(self) -> None:
-        """#115: when no milestones and no epic labels exist, bootstrap seeds
-        epics from open issues by token-clustering — not a bare placeholder."""
-        snapshot = {
-            'repo': 'test-org/test-repo',
-            'generatedAt': '2026-05-04T00:00:00Z',
-            'meta': {},
-            'issues': [
-                {
-                    'number': 1,
-                    'title': 'feat: add authentication login page',
-                    'state': 'OPEN',
-                    'labels': ['enhancement'],
-                    'assignees': [],
-                    'createdAt': '2026-01-01T00:00:00Z',
-                    'updatedAt': '2026-01-01T00:00:00Z',
-                    'lastCommentedAt': None,
-                    'closedAt': None,
-                },
-                {
-                    'number': 2,
-                    'title': 'feat: add authentication logout flow',
-                    'state': 'OPEN',
-                    'labels': ['enhancement'],
-                    'assignees': [],
-                    'createdAt': '2026-01-01T00:00:00Z',
-                    'updatedAt': '2026-01-01T00:00:00Z',
-                    'lastCommentedAt': None,
-                    'closedAt': None,
-                },
-                {
-                    'number': 3,
-                    'title': 'feat: authentication session refresh',
-                    'state': 'OPEN',
-                    'labels': ['enhancement'],
-                    'assignees': [],
-                    'createdAt': '2026-01-01T00:00:00Z',
-                    'updatedAt': '2026-01-01T00:00:00Z',
-                    'lastCommentedAt': None,
-                    'closedAt': None,
-                },
-                {
-                    'number': 4,
-                    'title': 'fix: database query timeout',
-                    'state': 'OPEN',
-                    'labels': ['bug'],
-                    'assignees': [],
-                    'createdAt': '2026-01-01T00:00:00Z',
-                    'updatedAt': '2026-01-01T00:00:00Z',
-                    'lastCommentedAt': None,
-                    'closedAt': None,
-                },
-            ],
-            'pullRequests': [],
-            'milestones': [],
-            'releases': [],
-        }
-        with tempfile.NamedTemporaryFile(
-            mode='w', suffix='.json', delete=False, dir=self.workdir
-        ) as fh:
-            json.dump(snapshot, fh)
-            snap_path = fh.name
-
-        result = subprocess.run(
-            ['bash', str(SCRIPTS / 'bootstrap-plan.sh'), '--snapshot', snap_path],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        self.assertEqual(
-            result.returncode, 0,
-            f'bootstrap-plan.sh failed: {result.stderr}',
-        )
-        out = result.stdout
-        # Must not emit the bare placeholder when >= 3 issues are available.
-        self.assertNotIn(
-            '- _No epic candidates detected. Add parent issues manually._',
-            out,
-            'bootstrap-plan.sh fell back to bare placeholder despite >= 3 open issues',
-        )
-        # Must contain at least one auto-suggested epic cluster.
-        self.assertIn(
-            '_auto-suggested',
-            out,
-            'bootstrap-plan.sh did not emit any _auto-suggested epic clusters',
-        )
-        # The issues should be bound in the suggestion.
-        self.assertIn('#1', out)
-        self.assertIn('#2', out)
-        self.assertIn('#3', out)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #691

## Changements

Split `claude-skills/tests/test_po_report_integration.py` (568 LOC, 18 top-level defs) into feature-focused modules, each well under the 500-LOC oversized threshold.

- **`_po_integration_helpers.py`** (122 LOC) — shared fixture. `BasePoIntegration` holds the `setUpClass`/`tearDownClass` workdir-with-remote + one-shot `collect.sh` snapshot, plus the `_run` helper and `gh`/`jq`/auth skip preconditions.
- **`test_po_report_integration.py`** (217 LOC) — report-generation surface: `collect.sh`, `status.sh`, `milestone-progress.sh`, `stale-issues.sh`, `generate-report.sh`, `pr-flow.sh`.
- **`test_po_plan_integration.py`** (284 LOC, new) — planning surface: `parse-plan.sh`, `adherence.sh`, `trends.sh`, `bootstrap-plan.sh` (both variants).

No test bodies were changed and no coverage was dropped — every one of the 13 original tests is preserved, just moved into the module aligned with the script it exercises. Follows the existing split pattern already established for `test_md_to_office_*.py` + `_md_to_office_helpers.py` (#330).

Trade-off worth flagging: since the base fixture's `setUpClass` runs once per `TestCase` subclass, splitting into two classes means two `collect.sh` GraphQL fetches per run instead of one. Both files still cache their snapshot for their own tests.

## Test

Ran both modules against the real `beyond-scale-group/edomata` repo with `gh` authenticated:

```
python3 -m unittest test_po_report_integration test_po_plan_integration -v
# Ran 13 tests in 14.856s — OK
```

Ran `python3 -c "import ast; ast.parse(...)"` on the three files to confirm no syntax regressions.