### PR TITLE
feat(deploy): one-command gbrain deployment on Clever Cloud

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -626,6 +626,34 @@ Inside a skill, deterministic bash + jq scripts do the aggregation and
 computation (counts, risk flags, tree walks). The LLM only narrates the
 results. Agents should never re-derive numbers the scripts already emit.
 
+## Secrets policy — this repo is PUBLIC
+
+Nothing that authenticates ever lands in git. Hard rules for every session
+and every agent working in this repo:
+
+1. **Never commit credentials.** API keys, bearer/admin tokens, OAuth
+   client secrets, connection strings with passwords — none of it, in any
+   file, ever. This includes "test" keys.
+2. **Committed config references secrets by env expansion only** —
+   `${VAR}` placeholders (e.g. `.mcp.json` uses `${GBRAIN_MCP_TOKEN}`) or
+   runtime environment (Clever Cloud app env vars). Never literals.
+3. **Local-only files that hold real values** (all verified git-ignored —
+   never `git add -f` them):
+   - `deploy/gbrain/gbrain.env` — installer input keys
+     (`deploy/gbrain/.gitignore`)
+   - `.claude/settings.local.json` — session env like MCP tokens
+     (`.gitignore` ignores `.claude/`)
+   - `.mcp.json` — kept out via `.git/info/exclude` (personal endpoints
+     don't belong in a public repo)
+4. **Scan before you ship.** Before any commit/PR that adds or edits
+   config, scripts, or docs, run a secret-pattern scan over every
+   new/modified file (`git status --porcelain -uall` + grep for key
+   shapes: `sk-`, `ze_`, `sk-ant-`, 64-hex tokens, `Bearer …`) — or run
+   the `security` agent. A match blocks the commit until resolved.
+5. **If a credential ever reaches a commit**, treat it as burned: rotate
+   it at the provider first, then rewrite/drop the commit — deleting the
+   file in a follow-up commit is not remediation.
+
 ## Contributing to the shared catalog
 
 Files in `~/.claude/` on a developer's machine are cached copies — they get

--- a/deploy/gbrain/.gitignore
+++ b/deploy/gbrain/.gitignore
@@ -1,0 +1,1 @@
+gbrain.env

--- a/deploy/gbrain/README.md
+++ b/deploy/gbrain/README.md
@@ -1,0 +1,123 @@
+# Deploy gbrain on Clever Cloud
+
+Automated deployment of [gbrain](https://github.com/garrytan/gbrain) — Garry
+Tan's Postgres-native personal knowledge brain — onto Clever Cloud, using:
+
+| gbrain need | Clever Cloud piece |
+|---|---|
+| Bun + TypeScript runtime | Node app with `CC_NODE_BUILD_TOOL=bun` (native Bun support) |
+| Postgres + pgvector | `postgresql-addon` (pgvector is activated automatically; the boot preflight runs `CREATE EXTENSION IF NOT EXISTS vector`) |
+| S3 storage for big files / attachments | `cellar-addon` — gbrain's S3 backend supports custom endpoints with path-style addressing, which is exactly Cellar's shape |
+| Persistent disk for the brain repo | `fs-bucket` mounted at `/data` via `CC_FS_BUCKET` |
+| Job queue (Minions) | Postgres-native — no Redis add-on needed |
+
+```
+┌─────────────────────────── Clever Cloud ───────────────────────────┐
+│  Node app (Bun runtime, pinned to 1 instance)                      │
+│  └─ gbrain serve --http --port 8080 --bind 0.0.0.0                 │
+│       --public-url https://<app>.cleverapps.io                     │
+│     ├── Postgres add-on ── pgvector, pages, embeddings, job queue  │
+│     ├── Cellar add-on ──── S3 bucket for attachments / media       │
+│     └── FS Bucket add-on ─ /data: persistent brain git repo        │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## Layout
+
+```
+deploy/gbrain/
+├── README.md            # this file
+├── install.sh           # provisions app + add-ons, sets env, deploys, verifies
+├── gbrain.env.example   # operator-supplied secrets (copy to gbrain.env, gitignored)
+└── app/                 # the wrapper app that gets pushed to Clever Cloud
+    ├── package.json     # depends on github:garrytan/gbrain
+    ├── boot.sh          # boot sequence: config → preflight → migrations → serve
+    └── preflight.ts     # writes ~/.gbrain/config.json, ensures pgvector + Cellar bucket
+```
+
+The wrapper app is copied to a standalone git repo outside this repository
+(`~/gbrain-clever-deploy` by default) because `clever deploy` pushes a git
+repo — bsg-stack itself is never pushed to Clever Cloud.
+
+## Prerequisites
+
+- `clever` CLI ≥ 4.11 installed and logged in (`clever profile`)
+- An embedding provider API key: ZeroEntropy (gbrain's default) or OpenAI.
+  Without one, only keyword search works — no vector search.
+
+## Usage
+
+```bash
+cd deploy/gbrain
+cp gbrain.env.example gbrain.env   # fill in your API keys
+./install.sh                       # idempotent — re-run safely after any failure
+```
+
+Options (env vars or flags):
+
+```bash
+./install.sh --org my-org --name gbrain --region par
+# or: APP_NAME=gbrain REGION=par ORG=orga_xxx PG_PLAN=xs_sml ./install.sh
+```
+
+`install.sh` runs these phases, each idempotent:
+
+1. **Workdir** — copies `app/` to `$GBRAIN_DEPLOY_DIR` (default
+   `~/gbrain-clever-deploy`), commits it as its own git repo
+2. **App** — `clever create --type node` (skipped when already linked)
+3. **Add-ons** — creates + links `postgresql-addon`, `cellar-addon`,
+   `fs-bucket` (skipped when already linked)
+4. **Env** — wires `CC_NODE_BUILD_TOOL=bun`, `CC_FS_BUCKET=/data:<host>`,
+   `GBRAIN_PUBLIC_URL`, trust-proxy/CORS, a generated admin bootstrap
+   token, and your keys from `gbrain.env`
+5. **Scale** — pins the scaler to exactly 1 instance (gbrain's server
+   assumes a single writer; FS Bucket is NFS-backed so this also avoids
+   write contention)
+6. **Deploy** — `clever deploy`, then polls `/health` until green
+
+## What happens at boot (`app/boot.sh`)
+
+1. `DATABASE_URL` is exported from `POSTGRESQL_ADDON_URI` — gbrain infers
+   `engine: postgres` from it
+2. `preflight.ts` writes `~/.gbrain/config.json` (the `storage` block has no
+   env-var mapping, and `$HOME` is ephemeral, so it is rebuilt every boot from
+   the Cellar add-on's env vars), runs `CREATE EXTENSION IF NOT EXISTS vector`,
+   and creates the Cellar bucket if missing
+3. The brain repo is initialised at `$APP_HOME/data/brain` (the FS Bucket
+   mount — `CC_FS_BUCKET` paths are relative to the app folder — survives
+   redeploys) and registered as the `default` source
+4. `gbrain apply-migrations --yes` — Bun blocks gbrain's postinstall hook on
+   install ([gbrain #218](https://github.com/garrytan/gbrain/issues/218)), so
+   migrations run explicitly here
+5. `gbrain export --restore-only` repopulates any `db_only` files missing
+   from disk (the documented container-restart recovery path)
+6. `gbrain serve --http --port 8080 --bind 0.0.0.0 --public-url $GBRAIN_PUBLIC_URL`
+
+## After the install
+
+Register your first OAuth client and connect Claude Code:
+
+```bash
+clever ssh --alias gbrain
+# inside the instance:
+cd /home/bas/app_* && ./node_modules/.bin/gbrain auth register-client me \
+  --grant-types client_credentials --scopes read,write,admin
+exit
+
+# locally:
+gbrain connect https://<app>.cleverapps.io/mcp --token <token>
+```
+
+Admin dashboard: `https://<app>.cleverapps.io/admin` — log in with the
+`GBRAIN_ADMIN_BOOTSTRAP_TOKEN` printed by `install.sh`.
+
+## Costs & caveats
+
+- **~€25–35/month**: Postgres XS is the dominant cost; app XS, Cellar and
+  FS Bucket are per-GB cents at this scale.
+- **Search mode**: gbrain's cost spread between `conservative` and `tokenmax`
+  is ~25× per query. The installer defaults to `balanced`
+  (`GBRAIN_SEARCH_MODE` in `gbrain.env` to override).
+- **Single instance only** — do not scale horizontally.
+- Secrets live in Clever Cloud env vars and `gbrain.env` (gitignored) —
+  nothing sensitive is committed here or pushed in the wrapper repo.

--- a/deploy/gbrain/app/.gitignore
+++ b/deploy/gbrain/app/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.clever.json

--- a/deploy/gbrain/app/boot.sh
+++ b/deploy/gbrain/app/boot.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# gbrain boot sequence on Clever Cloud. Run by `bun run start`.
+# Everything before `exec` must be idempotent — Clever restarts rerun it.
+set -euo pipefail
+
+log() { echo "[boot] $*" >&2; }
+
+# gbrain infers engine=postgres from DATABASE_URL (src/core/config.ts).
+export DATABASE_URL="${DATABASE_URL:-${POSTGRESQL_ADDON_URI:?POSTGRESQL_ADDON_URI missing — is the Postgres add-on linked?}}"
+
+# File-plane config (Cellar storage block), pgvector extension, Cellar bucket.
+log "preflight: config.json + pgvector + Cellar bucket"
+bun run preflight.ts
+
+GBRAIN="./node_modules/.bin/gbrain"
+
+# Managed Postgres has no BYPASSRLS role; neuter gbrain's Supabase-specific
+# RLS gates (see patch-rls.ts header for why this is safe here).
+bun run patch-rls.ts
+
+# Bun blocks gbrain's postinstall hook (gbrain #218) — run migrations here.
+log "applying migrations"
+"$GBRAIN" apply-migrations --yes
+
+# Brain repo on the FS Bucket mount — persists across redeploys.
+# CC_FS_BUCKET=/data:<host> mounts at $APP_HOME/data (mount points are
+# relative to the application folder, never the filesystem root).
+BRAIN_DIR="${GBRAIN_BRAIN_DIR:-${APP_HOME:-$PWD}/data/brain}"
+if [ ! -d "$BRAIN_DIR/.git" ]; then
+  log "initialising brain repo at $BRAIN_DIR"
+  mkdir -p "$BRAIN_DIR"
+  git -C "$BRAIN_DIR" init -q
+fi
+"$GBRAIN" sources add default --path "$BRAIN_DIR" --name "Brain" 2>/dev/null \
+  || log "source 'default' already registered"
+
+# Repopulate db_only files missing from disk (container-restart recovery).
+"$GBRAIN" export --restore-only --repo "$BRAIN_DIR" \
+  || log "restore-only skipped (empty brain is fine on first boot)"
+
+# One-time-ish retrieval cost/quality setting; idempotent to re-set.
+"$GBRAIN" config set search.mode "${GBRAIN_SEARCH_MODE:-balanced}" \
+  || log "could not set search.mode (non-fatal)"
+
+# Admin SPA: serve-http resolves admin/dist relative to cwd; gbrain ships
+# the built assets inside the package — expose them where it looks.
+ln -sfn node_modules/gbrain/admin admin
+
+log "starting HTTP MCP server on :${PORT:-8080}"
+exec "$GBRAIN" serve --http \
+  --port "${PORT:-8080}" \
+  --bind 0.0.0.0 \
+  ${GBRAIN_PUBLIC_URL:+--public-url "$GBRAIN_PUBLIC_URL"}

--- a/deploy/gbrain/app/package.json
+++ b/deploy/gbrain/app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gbrain-clever",
+  "private": true,
+  "description": "Clever Cloud wrapper app for gbrain (Bun runtime)",
+  "scripts": {
+    "start": "bash boot.sh"
+  },
+  "dependencies": {
+    "gbrain": "github:garrytan/gbrain",
+    "postgres": "^3.4.0",
+    "@aws-sdk/client-s3": "^3.1028.0"
+  }
+}

--- a/deploy/gbrain/app/patch-rls.ts
+++ b/deploy/gbrain/app/patch-rls.ts
@@ -1,0 +1,87 @@
+/**
+ * Patch gbrain's Supabase-specific RLS privilege gates for managed Postgres
+ * (Clever Cloud). Runs at boot, before `gbrain apply-migrations`.
+ *
+ * Why this is safe here:
+ * - gbrain's RLS posture exists because Supabase exposes `public` via
+ *   PostgREST to a client-side anon key. Clever Cloud Postgres has no
+ *   PostgREST and no anon key — there is nothing for RLS to protect.
+ * - Our single role OWNS every table it creates, and Postgres table owners
+ *   bypass RLS policies (absent FORCE ROW LEVEL SECURITY). Forcing the
+ *   check to true lets the migrations enable RLS everywhere without locking
+ *   gbrain out — the same effective posture as Supabase's BYPASSRLS
+ *   service role.
+ * - CREATE EVENT TRIGGER requires real superuser and cannot work on managed
+ *   Postgres; it is wrapped in an insufficient_privilege catch instead.
+ * - The v35 all-public-tables RLS backfill must skip tables the role does
+ *   not own: Clever Cloud ships PostGIS, whose `spatial_ref_sys` lives in
+ *   `public` but is owned by the admin role ("must be owner of table").
+ *
+ * Each replacement is independently idempotent, so a build-cached, partially
+ * patched node_modules self-heals on the next boot. Fails loudly if gbrain's
+ * source drifts from the patterns.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const file = process.argv[2] ?? './node_modules/gbrain/src/core/migrate.ts';
+const MARKER = 'patched-for-managed-postgres';
+
+let src = readFileSync(file, 'utf8');
+let applied = 0;
+let skipped = 0;
+
+// patch(name, pattern, replacement, alreadyPatchedProbe)
+function patch(name: string, pattern: string, replacement: string, probe: string) {
+  if (src.includes(probe)) {
+    console.error(`[patch-rls] ${name}: already patched`);
+    skipped++;
+    return;
+  }
+  const count = src.split(pattern).length - 1;
+  if (count === 0) {
+    throw new Error(`[patch-rls] ${name}: pattern not found — gbrain source drifted, review the patch`);
+  }
+  src = src.replaceAll(pattern, replacement);
+  console.error(`[patch-rls] ${name}: ${count} occurrence(s) patched`);
+  applied += count;
+}
+
+// 1. Force the BYPASSRLS privilege check to true (10 occurrences upstream).
+patch(
+  'privilege-check',
+  "SELECT EXISTS (SELECT 1 FROM pg_roles pr WHERE pg_has_role(current_user, pr.oid, 'USAGE') AND (pr.rolbypassrls OR pr.rolsuper)) INTO has_bypass;",
+  `has_bypass := true; -- ${MARKER}: owner bypasses RLS; no PostgREST/anon key on this platform`,
+  `has_bypass := true; -- ${MARKER}`,
+);
+
+// 2. Guard the superuser-only event trigger (v35).
+patch(
+  'event-trigger',
+  `DROP EVENT TRIGGER IF EXISTS auto_rls_on_create_table;
+        CREATE EVENT TRIGGER auto_rls_on_create_table
+          ON ddl_command_end
+          WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+          EXECUTE FUNCTION auto_enable_rls();`,
+  `DO $managed_pg$ BEGIN
+          DROP EVENT TRIGGER IF EXISTS auto_rls_on_create_table;
+          CREATE EVENT TRIGGER auto_rls_on_create_table
+            ON ddl_command_end
+            WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+            EXECUTE FUNCTION auto_enable_rls();
+        EXCEPTION WHEN insufficient_privilege THEN
+          RAISE NOTICE 'skipping auto_rls event trigger (requires superuser; managed Postgres)';
+        END $managed_pg$;`,
+  'DO $managed_pg$ BEGIN',
+);
+
+// 3. v35 backfill: only touch tables the current role owns (PostGIS etc.).
+patch(
+  'backfill-ownership',
+  'AND c.relrowsecurity = false',
+  `AND c.relrowsecurity = false
+              AND pg_catalog.pg_has_role(current_user, c.relowner, 'USAGE') -- ${MARKER}: skip tables we don't own (PostGIS spatial_ref_sys)`,
+  "pg_has_role(current_user, c.relowner, 'USAGE')",
+);
+
+writeFileSync(file, src);
+console.error(`[patch-rls] done (${applied} replacements applied, ${skipped} already in place)`);

--- a/deploy/gbrain/app/preflight.ts
+++ b/deploy/gbrain/app/preflight.ts
@@ -1,0 +1,66 @@
+/**
+ * Boot preflight for gbrain on Clever Cloud. Idempotent; runs on every boot.
+ *
+ * 1. Writes ~/.gbrain/config.json — the `storage` block has no env-var
+ *    mapping in gbrain, and $HOME is ephemeral on Clever Cloud, so the file
+ *    is rebuilt from the Cellar add-on's env vars each time.
+ * 2. Ensures the pgvector extension exists (activated automatically on
+ *    Clever Cloud Postgres; CREATE EXTENSION is still required once).
+ * 3. Ensures the Cellar bucket for attachments exists.
+ */
+import postgres from 'postgres';
+import { S3Client, CreateBucketCommand, HeadBucketCommand } from '@aws-sdk/client-s3';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function need(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`[preflight] missing env var ${name}`);
+  return v;
+}
+
+const bucket = process.env.GBRAIN_CELLAR_BUCKET || 'gbrain-media';
+const endpoint = `https://${need('CELLAR_ADDON_HOST')}`;
+const accessKeyId = need('CELLAR_ADDON_KEY_ID');
+const secretAccessKey = need('CELLAR_ADDON_KEY_SECRET');
+
+// 1. file-plane config
+const cfgDir = join(homedir(), '.gbrain');
+mkdirSync(cfgDir, { recursive: true });
+writeFileSync(
+  join(cfgDir, 'config.json'),
+  JSON.stringify(
+    {
+      engine: 'postgres',
+      storage: { backend: 's3', bucket, endpoint, accessKeyId, secretAccessKey },
+    },
+    null,
+    2,
+  ),
+);
+console.error('[preflight] wrote ~/.gbrain/config.json');
+
+// 2. pgvector
+const sql = postgres(need('DATABASE_URL'), { max: 1 });
+try {
+  await sql`CREATE EXTENSION IF NOT EXISTS vector`;
+  console.error('[preflight] pgvector extension present');
+} finally {
+  await sql.end();
+}
+
+// 3. Cellar bucket
+const s3 = new S3Client({
+  region: 'us-east-1',
+  endpoint,
+  forcePathStyle: true,
+  credentials: { accessKeyId, secretAccessKey },
+});
+try {
+  await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+  console.error(`[preflight] Cellar bucket '${bucket}' exists`);
+} catch {
+  await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+  console.error(`[preflight] created Cellar bucket '${bucket}'`);
+}

--- a/deploy/gbrain/gbrain.env.example
+++ b/deploy/gbrain/gbrain.env.example
@@ -1,0 +1,20 @@
+# Operator-supplied secrets for the gbrain Clever Cloud deployment.
+# Copy to gbrain.env (gitignored) and fill in. install.sh forwards every
+# non-comment line to `clever env set`.
+
+# --- Embedding provider (at least one required for vector search) -----------
+# gbrain defaults to ZeroEntropy (embedding + reranker). OpenAI works as
+# fallback. Without either, keyword search still works.
+ZEROENTROPY_API_KEY=
+#OPENAI_API_KEY=
+
+# --- Optional ----------------------------------------------------------------
+# Improves search quality via query expansion.
+#ANTHROPIC_API_KEY=
+
+# Retrieval cost/quality trade-off: conservative | balanced | tokenmax.
+# ~25x per-query cost spread between the extremes. Default: balanced.
+#GBRAIN_SEARCH_MODE=balanced
+
+# Cellar bucket name for attachments/media (created at boot if missing).
+#GBRAIN_CELLAR_BUCKET=gbrain-media

--- a/deploy/gbrain/install.sh
+++ b/deploy/gbrain/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Provision and deploy gbrain on Clever Cloud.
+# Idempotent — safe to re-run after any failure; each phase skips what exists.
+#
+# Usage:
+#   cp gbrain.env.example gbrain.env   # fill in API keys first
+#   ./install.sh [--org ORG] [--name APP_NAME] [--region REGION]
+#
+# Requires: clever CLI >= 4.11 (logged in), jq, git, curl.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+APP_NAME="${APP_NAME:-gbrain}"
+REGION="${REGION:-par}"
+ORG="${ORG:-}"
+PG_PLAN="${PG_PLAN:-xs_sml}"       # NOT dev: too small for a real brain
+FLAVOR="${FLAVOR:-XS}"
+DEPLOY_DIR="${GBRAIN_DEPLOY_DIR:-$HOME/gbrain-clever-deploy}"
+ENV_FILE="$SCRIPT_DIR/gbrain.env"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --org)    ORG="$2"; shift 2 ;;
+    --name)   APP_NAME="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+ORG_FLAG=()
+[ -n "$ORG" ] && ORG_FLAG=(--org "$ORG")
+
+log()  { echo "==> $*" >&2; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Phase 0: preflight -------------------------------------------------------
+command -v clever >/dev/null || fail "clever CLI not found (brew install clevercloud/tap/clever-tools)"
+command -v jq >/dev/null || fail "jq not found"
+clever profile >/dev/null 2>&1 || fail "not logged in — run: clever login"
+[ -f "$ENV_FILE" ] || fail "$ENV_FILE missing — cp gbrain.env.example gbrain.env and fill in your keys"
+grep -qE '^(ZEROENTROPY|OPENAI)_API_KEY=.+' "$ENV_FILE" \
+  || log "WARNING: no embedding key in gbrain.env — vector search will be disabled"
+
+# --- Phase 1: deploy workdir (wrapper repo lives outside bsg-stack) -----------
+log "syncing wrapper app to $DEPLOY_DIR"
+mkdir -p "$DEPLOY_DIR"
+cp "$SCRIPT_DIR/app/package.json" "$SCRIPT_DIR/app/boot.sh" \
+   "$SCRIPT_DIR/app/preflight.ts" "$SCRIPT_DIR/app/patch-rls.ts" \
+   "$SCRIPT_DIR/app/.gitignore" "$DEPLOY_DIR/"
+chmod +x "$DEPLOY_DIR/boot.sh"
+cd "$DEPLOY_DIR"
+[ -d .git ] || git init -q
+git add -A
+git diff --cached --quiet || git commit -qm "gbrain wrapper app (synced from bsg-stack deploy/gbrain)"
+
+# --- Phase 2: application -----------------------------------------------------
+if [ ! -f .clever.json ]; then
+  log "creating app '$APP_NAME' (node/bun, $REGION)"
+  clever create --type node "$APP_NAME" --region "$REGION" "${ORG_FLAG[@]}"
+else
+  log "app already linked ($(jq -r '.apps[0].name' .clever.json 2>/dev/null || echo '?')) — skipping create"
+fi
+
+# --- Phase 3: add-ons ---------------------------------------------------------
+addon_id() { # addon_id <name> -> id or empty
+  clever addon list --format json "${ORG_FLAG[@]}" 2>/dev/null \
+    | jq -r --arg n "$1" '.[] | select(.name == $n) | .addonId' | head -1
+}
+
+ensure_addon() { # ensure_addon <provider> <name> [extra flags…]
+  local provider="$1" name="$2"; shift 2
+  if [ -n "$(addon_id "$name")" ]; then
+    log "add-on '$name' exists — ensuring link"
+    clever service link-addon "$name" 2>/dev/null || true
+  else
+    log "creating add-on '$name' ($provider)"
+    clever addon create "$provider" "$name" --region "$REGION" "${ORG_FLAG[@]}" --yes "$@"
+    clever service link-addon "$name" 2>/dev/null || true
+  fi
+}
+
+ensure_addon postgresql-addon "${APP_NAME}-db" --plan "$PG_PLAN"
+ensure_addon cellar-addon     "${APP_NAME}-cellar"
+ensure_addon fs-bucket        "${APP_NAME}-fsdata"
+
+# --- Phase 4: environment -----------------------------------------------------
+FS_ID="$(addon_id "${APP_NAME}-fsdata")"
+[ -n "$FS_ID" ] || fail "could not resolve fs-bucket add-on id"
+BUCKET_HOST="$(clever addon env "$FS_ID" --format shell | sed -n 's/^export BUCKET_HOST="\{0,1\}\([^"]*\)"\{0,1\};*$/\1/p' | head -1)"
+[ -n "$BUCKET_HOST" ] || fail "could not read BUCKET_HOST from fs-bucket add-on"
+
+DOMAIN="$(clever domain | grep -m1 cleverapps.io | tr -d ' *' | sed -E 's#^https?://##; s#/+$##')"
+[ -n "$DOMAIN" ] || fail "could not resolve cleverapps.io domain"
+PUBLIC_URL="https://${DOMAIN}"
+
+log "setting environment (public URL: $PUBLIC_URL)"
+clever env set CC_NODE_BUILD_TOOL bun >/dev/null
+clever env set CC_FS_BUCKET "/data:${BUCKET_HOST}" >/dev/null
+clever env set GBRAIN_PUBLIC_URL "$PUBLIC_URL" >/dev/null
+clever env set GBRAIN_HTTP_TRUST_PROXY 1 >/dev/null
+clever env set GBRAIN_HTTP_CORS_ORIGIN "$PUBLIC_URL" >/dev/null
+
+if ! clever env --format shell | grep -q '^export GBRAIN_ADMIN_BOOTSTRAP_TOKEN='; then
+  ADMIN_TOKEN="$(openssl rand -hex 32)"
+  clever env set GBRAIN_ADMIN_BOOTSTRAP_TOKEN "$ADMIN_TOKEN" >/dev/null
+  log "generated admin bootstrap token: $ADMIN_TOKEN  (save it — shown once)"
+fi
+
+log "forwarding secrets from gbrain.env"
+while IFS='=' read -r key value; do
+  case "$key" in ''|\#*) continue ;; esac
+  [ -n "$value" ] && clever env set "$key" "$value" >/dev/null && log "  set $key"
+done < "$ENV_FILE"
+
+# --- Phase 5: scale (single writer — never scale horizontally) ----------------
+log "pinning scaler to 1x $FLAVOR"
+clever scale --flavor "$FLAVOR" --min-instances 1 --max-instances 1 >/dev/null
+
+# --- Phase 6: deploy + verify --------------------------------------------------
+log "deploying"
+clever deploy --force
+
+log "waiting for $PUBLIC_URL/health"
+for i in $(seq 1 36); do
+  if curl -fsS --max-time 5 "$PUBLIC_URL/health" >/dev/null 2>&1; then
+    log "health check green ✓"
+    echo
+    echo "gbrain is live: $PUBLIC_URL"
+    echo "  admin dashboard: $PUBLIC_URL/admin (GBRAIN_ADMIN_BOOTSTRAP_TOKEN)"
+    echo "  next: clever ssh  →  gbrain auth register-client <name> --grant-types client_credentials --scopes read,write,admin"
+    echo "        gbrain connect $PUBLIC_URL/mcp --token <token>"
+    exit 0
+  fi
+  sleep 5
+done
+
+fail "health check did not turn green in 3 min — inspect with: clever logs"


### PR DESCRIPTION
## Summary
- **`deploy/gbrain/`** — automated, idempotent deployment of [gbrain](https://github.com/garrytan/gbrain) (Postgres-native personal knowledge brain) onto Clever Cloud: `install.sh` provisions the Bun app + `postgresql-addon` (pgvector) + `cellar-addon` (S3 for attachments) + `fs-bucket` (persistent brain repo), wires all env vars, pins the scaler to 1 instance, deploys, and polls `/health`
- **Wrapper app** (`deploy/gbrain/app/`): `boot.sh` rebuilds `~/.gbrain/config.json` every boot (ephemeral `$HOME`), runs migrations explicitly (Bun blocks gbrain's postinstall — gbrain#218), and keeps the brain git repo on the FS Bucket mount; `preflight.ts` ensures pgvector + the Cellar bucket
- **`patch-rls.ts`** — boot-time, idempotent patch of gbrain's Supabase-specific `BYPASSRLS` migration gates, required on managed Postgres. Safe because the single role owns every table (Postgres owners bypass RLS) and Clever Cloud has no PostgREST/anon key to protect against; also filters admin-owned PostGIS tables (`spatial_ref_sys`) out of the RLS backfill
- **CLAUDE.md** — new "Secrets policy — this repo is PUBLIC" section: env-expansion-only committed config, named local-only credential files, mandatory pre-ship secret scan, burned-credential protocol
- No credentials ship: `gbrain.env` is gitignored; operators copy `gbrain.env.example`

## Test plan
- [x] Full live install on a personal Clever Cloud account (`gbrain-test`): health green (`{"status":"ok","engine":"postgres"}` v0.42.57.0), admin dashboard 200, MCP 401-without-token
- [x] Idempotency: re-running `install.sh` skips existing app/add-ons and redeploys cleanly
- [x] Persistence: brain repo + registered source survive redeploys (FS Bucket + Postgres)
- [x] `patch-rls.ts` verified on fresh, half-patched, and fully-patched `migrate.ts` (self-heals cached `node_modules`)
- [x] Secret-pattern scan over every shipped file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)