### PR TITLE
feat(capture): opt-in SessionEnd hook uploads transcripts to gbrain

### DIFF
--- a/claude-skills/INSTALL.md
+++ b/claude-skills/INSTALL.md
@@ -108,6 +108,42 @@ The merge is **idempotent** and **narrow**:
 To add or remove a managed key, edit `claude-skills/settings.json` **and**
 update the `BSG_MANAGED_*` lists in the installer in the same PR.
 
+## Session capture to a personal gbrain (opt-in)
+
+The updater registers a `SessionEnd` hook
+(`scripts/upload-session-to-gbrain.py`) for every developer. The hook is a
+**silent no-op** unless you opt in by exporting two environment variables:
+
+```bash
+GBRAIN_INGEST_URL=https://your-brain.example.com   # gbrain HTTP server
+GBRAIN_MCP_TOKEN=gbrain_xxx                        # bearer token, write scope
+```
+
+Put them in your shell profile, or in the `env` block of
+`~/.claude/settings.json` so they only apply to Claude Code sessions.
+
+When opted in, every session end uploads the **full transcript** (user
+turns, assistant turns, tool calls, truncated tool results) to
+`POST $GBRAIN_INGEST_URL/ingest` as a markdown page under
+`sources/claude-sessions/`. gbrain dedups on content hash, so re-uploads
+are idempotent. Tuning knobs:
+
+| Env var | Default | Effect |
+|---|---|---|
+| `GBRAIN_CAPTURE_TOOL_RESULT_MAX` | `2000` | Per-block tool-result truncation (chars); `0` = unlimited |
+| `GBRAIN_CAPTURE_MAX_BYTES` | `900000` | Payload split threshold (gbrain's `/ingest` caps at 1 MB by default) |
+
+**Secrets:** the uploader runs a blocking redaction pass (API-key
+prefixes, bearer tokens, 64-hex secrets, connection-string passwords)
+before anything leaves the machine. Redaction is pattern-based, not
+perfect — treat the target brain as a private store, and point the hook
+only at a brain you own. Failures never block the session; they log to
+`~/.claude/logs/gbrain-capture.log`.
+
+Recommended gbrain-side setup: route `sources/claude-sessions/` to the
+`db_only` storage tier in the brain's `gbrain.yml` so bulk transcripts
+stay out of the brain's git history.
+
 ## GitHub labels used by BSG agents
 
 BSG agents expect the following labels to exist on any repo where they file

--- a/claude-skills/scripts/bsg_updater/config.py
+++ b/claude-skills/scripts/bsg_updater/config.py
@@ -13,6 +13,10 @@ from pathlib import Path
 REPO = "beyond-scale-group/bsg-stack"
 BRANCH = "main"
 SCRIPT_NAME = "update-bsg-skills.py"
+# Opt-in SessionEnd hook that uploads the session transcript to a personal
+# gbrain. Registered for everyone (it no-ops without GBRAIN_INGEST_URL +
+# GBRAIN_MCP_TOKEN in the environment).
+CAPTURE_SCRIPT_NAME = "upload-session-to-gbrain.py"
 
 # Top-level settings keys the BSG updater merges from
 # claude-skills/settings.json into ~/.claude/settings.json on every run.

--- a/claude-skills/scripts/bsg_updater/core.py
+++ b/claude-skills/scripts/bsg_updater/core.py
@@ -7,7 +7,11 @@ from bsg_updater.http_client import apply_token
 from bsg_updater.log_setup import log, setup_dirs, setup_logging
 from bsg_updater.manifest import load_manifest, save_manifest
 from bsg_updater.reconcile import reconcile
-from bsg_updater.settings import merge_bsg_settings, register_session_hook
+from bsg_updater.settings import (
+    merge_bsg_settings,
+    register_session_end_hook,
+    register_session_hook,
+)
 
 
 def run() -> int:
@@ -15,6 +19,7 @@ def run() -> int:
     setup_logging()
     apply_token()
     register_session_hook()
+    register_session_end_hook()
     merge_bsg_settings()
     manifest = load_manifest()
     manifest = reconcile(manifest)

--- a/claude-skills/scripts/bsg_updater/settings.py
+++ b/claude-skills/scripts/bsg_updater/settings.py
@@ -16,6 +16,7 @@ from bsg_updater.config import (
     BSG_MANAGED_MCP_SERVERS,
     BSG_MANAGED_SETTINGS_KEYS,
     BSG_RETIRED_MCP_SERVERS,
+    CAPTURE_SCRIPT_NAME,
     SCRIPTS_DIR,
     SCRIPT_NAME,
     SETTINGS_FILE,
@@ -67,6 +68,55 @@ def register_session_hook() -> None:
     tmp.write_text(json.dumps(settings, indent=2) + "\n")
     tmp.replace(SETTINGS_FILE)
     log(f"  registered SessionStart hook in {SETTINGS_FILE}")
+
+
+def register_session_end_hook() -> None:
+    """Register the opt-in gbrain session-capture hook (SessionEnd).
+
+    Same idempotence contract as :func:`register_session_hook` — detected
+    by script name, appended once, refuses to touch malformed settings.
+    The hook itself is a no-op unless the developer exports
+    ``GBRAIN_INGEST_URL`` + ``GBRAIN_MCP_TOKEN`` (see INSTALL.md).
+    """
+    script_path = SCRIPTS_DIR / CAPTURE_SCRIPT_NAME
+    command = f"python3 {script_path}"
+
+    if SETTINGS_FILE.exists():
+        try:
+            settings = json.loads(SETTINGS_FILE.read_text())
+        except json.JSONDecodeError:
+            log(f"  {SETTINGS_FILE} is not valid JSON, refusing to modify")
+            return
+    else:
+        settings = {}
+
+    if not isinstance(settings, dict):
+        log(f"  {SETTINGS_FILE} is not a JSON object, refusing to modify")
+        return
+
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        log("  settings.hooks is not an object, refusing to modify")
+        return
+    session_end = hooks.setdefault("SessionEnd", [])
+    if not isinstance(session_end, list):
+        log("  settings.hooks.SessionEnd is not a list, refusing to modify")
+        return
+
+    for entry in session_end:
+        if not isinstance(entry, dict):
+            continue
+        for h in entry.get("hooks", []) or []:
+            if isinstance(h, dict) and CAPTURE_SCRIPT_NAME in str(h.get("command", "")):
+                return  # already registered, nothing to do
+
+    session_end.append(
+        {"hooks": [{"type": "command", "command": command, "timeout": 60}]}
+    )
+    tmp = SETTINGS_FILE.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(settings, indent=2) + "\n")
+    tmp.replace(SETTINGS_FILE)
+    log(f"  registered SessionEnd gbrain-capture hook in {SETTINGS_FILE}")
 
 
 def _fetch_template_settings() -> dict | None:

--- a/claude-skills/scripts/upload-session-to-gbrain.py
+++ b/claude-skills/scripts/upload-session-to-gbrain.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Upload a finished Claude Code session transcript to a personal gbrain.
+
+Registered as a Claude Code ``SessionEnd`` hook by the BSG updater
+(``bsg_updater.settings.register_session_end_hook``). Claude Code invokes it
+with a JSON payload on stdin::
+
+    {"session_id": "...", "transcript_path": "...", "cwd": "...", ...}
+
+Strictly opt-in: the hook exits silently unless BOTH env vars are set —
+
+    GBRAIN_INGEST_URL   e.g. https://my-brain.cleverapps.io
+    GBRAIN_MCP_TOKEN    a gbrain bearer token with write scope
+
+Behavior:
+  1. Renders the FULL transcript (user turns, assistant turns, tool calls,
+     tool results) to markdown. Tool results are truncated per-block at
+     GBRAIN_CAPTURE_TOOL_RESULT_MAX chars (default 2000; 0 = unlimited).
+  2. Redacts credential-shaped strings (API keys, bearer tokens, 64-hex
+     secrets, connection-string passwords). Redaction is blocking by
+     design — transcripts are secret-dense.
+  3. Splits into parts if the payload exceeds GBRAIN_CAPTURE_MAX_BYTES
+     (default 900000, under gbrain's 1 MB /ingest cap).
+  4. POSTs each part to ``$GBRAIN_INGEST_URL/ingest`` as text/markdown with
+     a deterministic slug (gbrain dedups on content hash within 24h, so
+     re-runs are idempotent).
+
+Never fails the session: every error path logs to
+``~/.claude/logs/gbrain-capture.log`` and exits 0. Pure stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+CLAUDE_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+LOG_FILE = CLAUDE_DIR / "logs" / "gbrain-capture.log"
+
+TOOL_RESULT_MAX = int(os.environ.get("GBRAIN_CAPTURE_TOOL_RESULT_MAX", "2000"))
+MAX_BYTES = int(os.environ.get("GBRAIN_CAPTURE_MAX_BYTES", "900000"))
+HTTP_TIMEOUT = 20
+
+# Credential-shaped patterns, applied to the rendered markdown. Ordered:
+# specific prefixes first, then structural shapes, then generic assignments.
+REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Connection-string passwords: keep scheme+user, mask the password.
+    (re.compile(r"(\w+://[^:/@\s]+:)[^@\s]+(@)"), r"\1[REDACTED]\2"),
+    # Known key prefixes.
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_-]{8,}"), "[REDACTED]"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}"), "[REDACTED]"),
+    (re.compile(r"\bze_[A-Za-z0-9]{8,}"), "[REDACTED]"),
+    (re.compile(r"\bgbrain_[A-Za-z0-9_-]{8,}"), "[REDACTED]"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"), "[REDACTED]"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"), "[REDACTED]"),
+    (re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}"), "[REDACTED]"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED]"),
+    # Bearer headers and 64-hex secrets (bootstrap/admin tokens, sha-shaped
+    # keys — git SHAs are 40-hex and stay untouched).
+    (re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]{16,}"), r"\1[REDACTED]"),
+    (re.compile(r"\b[0-9a-f]{64}\b"), "[REDACTED]"),
+    # Generic KEY=value / "token": "value" assignments: keep the name.
+    (
+        re.compile(
+            r"(?i)([\"']?[\w.-]*(?:api[_-]?key|apikey|token|secret|passwd|password)[\"']?"
+            r"\s*[:=]\s*[\"']?)(?!\[REDACTED\])[^\s\"',;]{8,}"
+        ),
+        r"\1[REDACTED]",
+    ),
+]
+
+
+def log(msg: str) -> None:
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with LOG_FILE.open("a") as fh:
+            fh.write(f"{stamp} {msg}\n")
+    except OSError:
+        pass
+
+
+def redact(text: str) -> tuple[str, int]:
+    """Mask credential-shaped strings. Returns (clean_text, hit_count)."""
+    hits = 0
+    for pattern, repl in REDACT_PATTERNS:
+        text, n = pattern.subn(repl, text)
+        hits += n
+    return text, hits
+
+
+def _truncate(text: str, limit: int) -> str:
+    if limit <= 0 or len(text) <= limit:
+        return text
+    return text[:limit] + f"\n… [truncated, {len(text) - limit} chars omitted]"
+
+
+def _content_blocks(message: dict) -> list[dict]:
+    content = message.get("content")
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        return [b for b in content if isinstance(b, dict)]
+    return []
+
+
+def render_markdown(transcript_path: Path, session_id: str, project: str) -> str:
+    """Render a Claude Code JSONL transcript to a full-conversation page."""
+    lines: list[str] = []
+    turn_count = 0
+
+    with transcript_path.open() as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            rec_type = rec.get("type")
+            message = rec.get("message")
+            if rec_type not in ("user", "assistant") or not isinstance(message, dict):
+                continue
+
+            for block in _content_blocks(message):
+                btype = block.get("type")
+                if btype == "text":
+                    text = (block.get("text") or "").strip()
+                    if not text:
+                        continue
+                    turn_count += 1
+                    role = "User" if rec_type == "user" else "Assistant"
+                    lines.append(f"## {role}\n\n{text}\n")
+                elif btype == "tool_use":
+                    name = block.get("name", "?")
+                    params = json.dumps(block.get("input", {}), ensure_ascii=False)
+                    lines.append(f"> 🔧 **{name}** `{_truncate(params, 300)}`\n")
+                elif btype == "tool_result":
+                    content = block.get("content")
+                    if isinstance(content, list):
+                        content = "\n".join(
+                            b.get("text", "") for b in content if isinstance(b, dict)
+                        )
+                    text = str(content or "").strip()
+                    if text:
+                        lines.append(
+                            "<details><summary>tool result</summary>\n\n"
+                            f"```\n{_truncate(text, TOOL_RESULT_MAX)}\n```\n\n</details>\n"
+                        )
+
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    header = (
+        "---\n"
+        "type: source\n"
+        f"tags: [claude-code, session, {project}]\n"
+        f"project: {project}\n"
+        f"session_id: {session_id}\n"
+        f"date: {day}\n"
+        "---\n\n"
+        f"# Claude Code session — {project} — {day}\n\n"
+        f"Full transcript ({turn_count} conversation turns), captured "
+        "automatically at session end.\n\n"
+    )
+    return header + "\n".join(lines)
+
+
+def split_parts(markdown: str, max_bytes: int) -> list[str]:
+    """Split on paragraph boundaries so each part stays under max_bytes."""
+    if len(markdown.encode("utf-8")) <= max_bytes:
+        return [markdown]
+    parts: list[str] = []
+    current: list[str] = []
+    size = 0
+    for para in markdown.split("\n\n"):
+        chunk = para + "\n\n"
+        chunk_len = len(chunk.encode("utf-8"))
+        if size + chunk_len > max_bytes and current:
+            parts.append("".join(current))
+            current, size = [], 0
+        current.append(chunk)
+        size += chunk_len
+    if current:
+        parts.append("".join(current))
+    return parts
+
+
+def post_part(
+    base_url: str, token: str, body: str, slug: str, source_uri: str
+) -> tuple[int, str]:
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/ingest",
+        data=body.encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "text/markdown",
+            "X-Gbrain-Source-Id": "claude-code-sessions",
+            "X-Gbrain-Source-Uri": source_uri,
+            "X-Gbrain-Slug": slug,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            return resp.status, resp.read(500).decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(500).decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError) as e:
+        return 0, str(e)
+
+
+def main() -> int:
+    base_url = os.environ.get("GBRAIN_INGEST_URL", "").strip()
+    token = os.environ.get("GBRAIN_MCP_TOKEN", "").strip()
+    if not base_url or not token:
+        return 0  # not opted in — stay silent
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        log("skip: no valid hook payload on stdin")
+        return 0
+
+    transcript_path = Path(payload.get("transcript_path", ""))
+    session_id = str(payload.get("session_id", "unknown"))
+    cwd = payload.get("cwd") or os.getcwd()
+    project = Path(cwd).name or "unknown-project"
+
+    if not transcript_path.is_file():
+        log(f"skip: transcript not found: {transcript_path}")
+        return 0
+
+    try:
+        markdown = render_markdown(transcript_path, session_id, project)
+    except OSError as e:
+        log(f"error rendering transcript: {e}")
+        return 0
+
+    markdown, redactions = redact(markdown)
+
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    slug_base = f"sources/claude-sessions/{day}-{project}-{session_id[:8]}"
+    source_uri = f"claude-code:{project}:{session_id}"
+
+    parts = split_parts(markdown, MAX_BYTES)
+    ok = 0
+    for i, part in enumerate(parts, start=1):
+        slug = slug_base if len(parts) == 1 else f"{slug_base}--part-{i}"
+        status, detail = post_part(base_url, token, part, slug, source_uri)
+        if 200 <= status < 300:
+            ok += 1
+        else:
+            log(f"upload failed ({slug}): HTTP {status} {detail}")
+
+    log(
+        f"session {session_id[:8]} ({project}): {ok}/{len(parts)} part(s) uploaded, "
+        f"{redactions} redaction(s), {len(markdown)} chars"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-skills/tests/test_session_capture.py
+++ b/claude-skills/tests/test_session_capture.py
@@ -1,0 +1,194 @@
+"""
+Tests for upload-session-to-gbrain.py — the opt-in SessionEnd hook that
+uploads a full session transcript to a personal gbrain.
+
+Covers:
+1. Redaction masks credential-shaped strings (API keys, bearer tokens,
+   64-hex secrets, connection-string passwords) while leaving ordinary
+   text and 40-hex git SHAs alone.
+2. Transcript rendering includes user turns, assistant turns, tool calls,
+   and truncated tool results.
+3. Payload splitting stays under the byte limit on paragraph boundaries.
+4. The opt-in gate: without GBRAIN_INGEST_URL + GBRAIN_MCP_TOKEN the hook
+   exits 0 without reading the transcript or touching the network.
+5. The updater registers the SessionEnd hook idempotently.
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load_uploader() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "upload_session_to_gbrain", SCRIPTS_DIR / "upload-session-to-gbrain.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_settings() -> types.ModuleType:
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    from bsg_updater import settings  # noqa: WPS433 (deferred import)
+    return settings
+
+
+class TestRedaction(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_uploader()
+
+    def test_masks_known_key_prefixes(self):
+        for secret in [
+            "sk-ant-api03-abcdefghij1234",
+            "sk-proj-abcdefghijklmnopqrstuv",
+            "ze_FAKEtestKey0000",
+            "gbrain_abcdef123456789",
+            "ghp_abcdefghijklmnopqrstuv123456",
+            "github_pat_11ABCDEFGHIJKLMNOPQRST",
+            "xoxb-1234567890-abcdefghijk",
+            "AKIAIOSFODNN7EXAMPLE",
+        ]:
+            clean, hits = self.mod.redact(f"the key is {secret} ok")
+            self.assertNotIn(secret, clean, secret)
+            self.assertGreaterEqual(hits, 1, secret)
+
+    def test_masks_64_hex_but_not_git_sha(self):
+        token64 = "a" * 64
+        sha40 = "b" * 40
+        clean, _ = self.mod.redact(f"token {token64} commit {sha40}")
+        self.assertNotIn(token64, clean)
+        self.assertIn(sha40, clean)
+
+    def test_masks_connection_string_password(self):
+        clean, _ = self.mod.redact("postgresql://user:s3cretpw@host:5432/db")
+        self.assertNotIn("s3cretpw", clean)
+        self.assertIn("postgresql://user:[REDACTED]@host:5432/db", clean)
+
+    def test_masks_generic_assignment_keeps_name(self):
+        clean, _ = self.mod.redact("OPENAI_API_KEY=abcd1234efgh5678")
+        self.assertIn("OPENAI_API_KEY=", clean)
+        self.assertNotIn("abcd1234efgh5678", clean)
+
+    def test_leaves_plain_text_alone(self):
+        text = "nothing secret here, just a sentence with numbers 12345."
+        clean, hits = self.mod.redact(text)
+        self.assertEqual(text, clean)
+        self.assertEqual(hits, 0)
+
+
+class TestRendering(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_uploader()
+
+    def _write_transcript(self, records) -> Path:
+        tmp = tempfile.NamedTemporaryFile(
+            "w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
+        )
+        for rec in records:
+            tmp.write(json.dumps(rec) + "\n")
+        tmp.close()
+        return Path(tmp.name)
+
+    def test_renders_full_conversation(self):
+        path = self._write_transcript(
+            [
+                {"type": "user", "message": {"role": "user", "content": "hello brain"}},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "hi there"},
+                            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "content": "file-a\nfile-b"}
+                        ],
+                    },
+                },
+            ]
+        )
+        md = self.mod.render_markdown(path, "sess1234", "my-project")
+        self.assertIn("## User\n\nhello brain", md)
+        self.assertIn("## Assistant\n\nhi there", md)
+        self.assertIn("**Bash**", md)
+        self.assertIn("file-a", md)
+        self.assertIn("type: source", md)
+        self.assertIn("session_id: sess1234", md)
+
+    def test_tool_results_truncated(self):
+        long_output = "x" * 10000
+        path = self._write_transcript(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "tool_result", "content": long_output}],
+                    },
+                }
+            ]
+        )
+        with patch.object(self.mod, "TOOL_RESULT_MAX", 100):
+            md = self.mod.render_markdown(path, "s", "p")
+        self.assertIn("[truncated", md)
+        self.assertNotIn(long_output, md)
+
+
+class TestSplitting(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_uploader()
+
+    def test_small_payload_single_part(self):
+        self.assertEqual(len(self.mod.split_parts("short doc", 1000)), 1)
+
+    def test_large_payload_splits_under_limit(self):
+        doc = "\n\n".join(f"paragraph {i} " + "words " * 50 for i in range(100))
+        parts = self.mod.split_parts(doc, 5000)
+        self.assertGreater(len(parts), 1)
+        for part in parts:
+            self.assertLessEqual(len(part.encode("utf-8")), 5000 + 400)
+
+
+class TestOptInGate(unittest.TestCase):
+    def test_exits_zero_without_env(self):
+        mod = _load_uploader()
+        with patch.dict("os.environ", {}, clear=True):
+            with patch.object(mod, "post_part") as mock_post:
+                self.assertEqual(mod.main(), 0)
+        mock_post.assert_not_called()
+
+
+class TestHookRegistration(unittest.TestCase):
+    def test_registers_once_and_is_idempotent(self):
+        settings_mod = _load_settings()
+        with tempfile.TemporaryDirectory() as td:
+            settings_file = Path(td) / "settings.json"
+            with patch.object(settings_mod, "SETTINGS_FILE", settings_file):
+                settings_mod.register_session_end_hook()
+                settings_mod.register_session_end_hook()  # second run: no-op
+            data = json.loads(settings_file.read_text())
+            entries = data["hooks"]["SessionEnd"]
+            self.assertEqual(len(entries), 1)
+            self.assertIn(
+                "upload-session-to-gbrain.py", entries[0]["hooks"][0]["command"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `claude-skills/scripts/upload-session-to-gbrain.py`: a Claude Code `SessionEnd` hook that uploads the **full session transcript** (user/assistant turns, tool calls, truncated tool results) to a personal [gbrain](https://github.com/garrytan/gbrain) via `POST /ingest`
- **Strictly opt-in**: the BSG updater registers the hook for everyone (`register_session_end_hook`, same idempotent pattern as the existing SessionStart hook), but it exits silently unless the developer exports `GBRAIN_INGEST_URL` + `GBRAIN_MCP_TOKEN` — org-wide rollout affects nobody by default
- **Blocking redaction pass** before anything leaves the machine: API-key prefixes (`sk-`, `sk-ant-`, `ze_`, `ghp_`, `xox*`, `AKIA…`), bearer tokens, 64-hex secrets, connection-string passwords, generic `KEY=value` assignments
- Payloads split under gbrain's 1 MB `/ingest` cap; deterministic slugs + gbrain content-hash dedup make re-uploads idempotent; failures never block session close (logged to `~/.claude/logs/gbrain-capture.log`)
- Documented in `INSTALL.md` (opt-in setup, tuning knobs, secrets caveats, `db_only` storage-tier recommendation)

## Test plan
- [x] 11 unit tests (`tests/test_session_capture.py`): redaction patterns (incl. 64-hex vs 40-hex git SHA discrimination), full-conversation rendering, payload splitting, opt-in gate, idempotent hook registration
- [x] Live end-to-end: a real 1.5 MB session transcript rendered (106 turns), redacted (16 hits), uploaded, and verified searchable in the brain at `sources/claude-sessions/…`
- [x] Secret-pattern scan of all committed files: clean (test fixtures use synthetic keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)